### PR TITLE
[SysAdmin] add CNAME for conp.dev

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+conp.dev


### PR DESCRIPTION
This PR:
* Adds a CNAME record to point the flask prototype to the conp.dev url