### PR TITLE
[Bug Fix] Fix neurolibre icon positioning

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -347,7 +347,7 @@ li.active-nav:hover > a {
 
 .image-swap {
    display: block;
-   width: 95px;
+   /*width: 95px;*/
 }
 
 .image-swap:hover {

--- a/app/templates/public.html
+++ b/app/templates/public.html
@@ -58,7 +58,7 @@
             <a href="/search" class="a-link"><button class="btn btn-success btn-block btn-lg">Browse Datasets <i class="fa fa-search"></i></button></a>
         </div>
         <div class="col-xs-6">
-            <a href="/login" class="a-link"><button class="btn btn-default btn-block btn-lg">Share a Dataset <i class="fa fa-arrow-circle-up"></i></button></a>
+            <a href="/login" class="a-link"><button class="btn btn-default btn-block btn-lg">Share a Dataset <i class="fa fa-upload"></i></button></a>
         </div>
         </div>
     </div>


### PR DESCRIPTION
This PR fixes the neurolibre positioning

BEFORE
![Screen Shot 2019-05-02 at 2 07 46 PM](https://user-images.githubusercontent.com/1534575/57096635-c6313380-6ce3-11e9-8a5c-9cdced11029c.png)


AFTER
<img width="123" alt="Screen Shot 2019-05-02 at 2 07 53 PM" src="https://user-images.githubusercontent.com/1534575/57096637-c92c2400-6ce3-11e9-964f-15670cb892b6.png">
