### PR TITLE
Issue and PR templates, code of conduct, contribution guide

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at conp-tsc@googlegroups.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contribution			
+
+Changes and improvements are more than welcome! ❤️ Feel free to fork and open a pull request.		
+
+
+Please consider the following :
+
+
+1. Fork it!
+2. Create your feature branch, under `develop`
+3. Add your function/methods to proper files
+4. Add documentation (standard `docstring`) to your functions/methods
+5. Add tests for your functions/methods (when testing framework is ready :))
+6. Pass all CI tests
+7. Submit a pull request into `develop` (please complete the pull request template)

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'Description of the bug'
+labels: bug
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the title above -->
+
+## Expected Behavior
+<!--- Tell us what should happen. Add an example with all 
+ the information needed to reproduce the bug (descriptors, inputs, etc) -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior. Add an example with all 
+ the information needed to reproduce the bug (descriptors, inputs, etc) -->
+
+## Environment (optional)
+<!--- Information about the execution environment, in particular: Python version, Docker/Singularity version
+ if relevant -->
+
+## Context (optional)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Possible fix (optional)
+<!--- Not obligatory, but suggest an idea to fix the prroblem -->
+
+## Related issues (optional)
+<!--- Link any related issue -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'Description of the feature'
+labels: enhancement
+assignees: ''
+
+---
+
+## Purpose
+<!--- A clear and concise description of the proposed new feature. -->
+
+## Context
+<!-- Why the new feature would be useful -->
+
+## Possible Implementation (optional)
+<!--- Not obligatory, but suggest an idea for implementing the new feature-->
+
+## Related issues (optional)
+<!-- Link any related issue-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+---
+name: Feature or bug fix name
+about: Propose modifications in the code
+title: 'Feature implementation | Bug fix for issue #<000>'
+labels: enhancement
+assignees: ''
+
+---
+
+## Related issues
+<!-- List the issue(s) that are addressed by this PR -->
+
+## Checklist
+<!--- Make sure to check the following items -->
+- [ ] **DO** Unit tests pass.
+- [ ] **DO** If new feature, created unit test.
+
+## Purpose
+<!--- A clear and concise description of what the PR does. -->
+
+## Current behaviour
+<!--- Tell us what currently happens -->
+
+## New behaviour
+<!--- Tell us what will happen when the PR is merged -->
+ 
+#### Does this introduce a major change?
+- [ ] Yes
+- [ ] No
+
+## Implementation Detail
+<!--- Provide a detailed description of the change or addition you are proposing -->
+


### PR DESCRIPTION
This adds:
* Issue and pull-request templates, to help describe development tasks more consistently. 
* A code of conduct
* Contribution guide: @paiva, I assumed that we would create a `develop` branch where all PRs will be pointing to.