### PR TITLE
Update temporary path for zenodo pipelines

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -409,7 +409,10 @@ def pipeline_search():
         # initialize variables
         search_query = request.args.get("search").lower()
         sort_key = request.args.get("sortKey") or "downloads-desc"
-        cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
+
+        #cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
+        cache_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static/pipelines')
+
         all_desc_path = os.path.join(cache_dir, "all_descriptors.json")
         all_detailed_desc_path = os.path.join(cache_dir, "detailed_all_descriptors.json")
 

--- a/app/static/pipelines/all_descriptors.json
+++ b/app/static/pipelines/all_descriptors.json
@@ -1,0 +1,272 @@
+[
+    {
+        "ID": "zenodo.2644621",
+        "TITLE": "Example Boutiques Tool",
+        "DESCRIPTION": "This property describes the tool or application",
+        "DOWNLOADS": 14158.0
+    },
+    {
+        "ID": "zenodo.2587160",
+        "TITLE": "makeblastdb",
+        "DESCRIPTION": "Application to create BLAST databases, version 2.7.1+",
+        "DOWNLOADS": 2477.0
+    },
+    {
+        "ID": "zenodo.2602109",
+        "TITLE": "MCFLIRT",
+        "DESCRIPTION": "MCFLIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: MCFLIRT).",
+        "DOWNLOADS": 69.0
+    },
+    {
+        "ID": "zenodo.1451003",
+        "TITLE": "qeeg",
+        "DESCRIPTION": "qeeg application",
+        "DOWNLOADS": 47.0
+    },
+    {
+        "ID": "zenodo.1482743",
+        "TITLE": "fsl_bet",
+        "DESCRIPTION": "Automated brain extraction tool for FSL",
+        "DOWNLOADS": 47.0
+    },
+    {
+        "ID": "zenodo.1451001",
+        "TITLE": "BIDS app example",
+        "DESCRIPTION": "See https://github.com/BIDS-Apps/example",
+        "DOWNLOADS": 44.0
+    },
+    {
+        "ID": "zenodo.1895219",
+        "TITLE": "BIDS App - fmriprep",
+        "DESCRIPTION": "fMRIprep is a functional magneticresonance image pre-processing pipeline that is designed to provide an easily accessible, state-of-the-art interface that is robust to differences in scan acquisition protocols and that requires minimal user input, while providing easily interpretable and comprehensive error and output reporting. https://fmriprep.readthedocs.io",
+        "DOWNLOADS": 39.0
+    },
+    {
+        "ID": "zenodo.2587157",
+        "TITLE": "blast_formatter",
+        "DESCRIPTION": "Stand-alone BLAST formatter client, version 2.7.1+",
+        "DOWNLOADS": 37.0
+    },
+    {
+        "ID": "zenodo.2587156",
+        "TITLE": "blastdbcheck",
+        "DESCRIPTION": "BLAST database integrity and validity checking application",
+        "DOWNLOADS": 35.0
+    },
+    {
+        "ID": "zenodo.1484547",
+        "TITLE": "BIDS App - FreeSurfer 6.0",
+        "DESCRIPTION": "BIDS App version of freesurfer 6.0, from https://github.com/BIDS-Apps/freesurfer, see the readme there for more details, note it needs a license file to run",
+        "DOWNLOADS": 33.0
+    },
+    {
+        "ID": "zenodo.1445789",
+        "TITLE": "ICA_AROMA",
+        "DESCRIPTION": "ICA-AROMA (i.e. Independent Component Analyis-based Automatic Removal Of Motion Artifacts) is a data-driven method to identify and remove motion-related independent components from fMRI data.",
+        "DOWNLOADS": 33.0
+    },
+    {
+        "ID": "zenodo.1450991",
+        "TITLE": "fsl_probtrackx2",
+        "DESCRIPTION": "probabilistic tracking with crossing fibres",
+        "DOWNLOADS": 33.0
+    },
+    {
+        "ID": "zenodo.2601876",
+        "TITLE": "DTIFit",
+        "DESCRIPTION": "DTIFit, as implemented in Nipype (module: nipype.interfaces.fsl, interface: DTIFit).",
+        "DOWNLOADS": 30.0
+    },
+    {
+        "ID": "zenodo.1450997",
+        "TITLE": "FreeSurferPipelineBatch-CentOS7",
+        "DESCRIPTION": "FreeSurferPipelineBatch HCP pipeline",
+        "DOWNLOADS": 30.0
+    },
+    {
+        "ID": "zenodo.3242714",
+        "TITLE": "MRIQC",
+        "DESCRIPTION": "tool description",
+        "DOWNLOADS": 29.0
+    },
+    {
+        "ID": "zenodo.1450993",
+        "TITLE": "PostFreeSurferPipelineBatch-CentOS7",
+        "DESCRIPTION": "PostFreeSurferPipelineBatch HCP pipeline",
+        "DOWNLOADS": 29.0
+    },
+    {
+        "ID": "zenodo.1450999",
+        "TITLE": "ndmg",
+        "DESCRIPTION": "dwi connectome estimation pipeline",
+        "DOWNLOADS": 29.0
+    },
+    {
+        "ID": "zenodo.1494312",
+        "TITLE": "fsl_first",
+        "DESCRIPTION": "FIRST is a model-based segmentation and registration tool, based on a Bayesian model of shape and appearance for subcortical structures.",
+        "DOWNLOADS": 28.0
+    },
+    {
+        "ID": "zenodo.2566443",
+        "TITLE": "mask2boundary",
+        "DESCRIPTION": "Transforms a binary mask of a niftii image (such as a brain or white matter mask) into a boundary mask. This tool was originally developed to transform a white matter mask into a mask of seed locations for performing tractography in diffusion images.",
+        "DOWNLOADS": 28.0
+    },
+    {
+        "ID": "zenodo.2573071",
+        "TITLE": "GateCLforOpenDose",
+        "DESCRIPTION": "Descriptor for the GATE command with input parameters, used for import in VIP via Boutiques",
+        "DOWNLOADS": 27.0
+    },
+    {
+        "ID": "zenodo.1450995",
+        "TITLE": "PreFreeSurferPipelineBatch",
+        "DESCRIPTION": "PreFreeSurferPipelineBatch HCP pipeline",
+        "DOWNLOADS": 27.0
+    },
+    {
+        "ID": "zenodo.1494308",
+        "TITLE": "fsl_fast",
+        "DESCRIPTION": "FAST (FMRIB's Automated Segmentation Tool) segments a 3D image of the brain into different tissue types (Grey Matter, White Matter, CSF, etc.), whilst also correcting for spatial intensity variations (also known as bias field or RF inhomogeneities), via a hidden Markov random field model and an associated EM algorithm. Note that the alternative priors option is not supported at this time.",
+        "DOWNLOADS": 27.0
+    },
+    {
+        "ID": "zenodo.2639849",
+        "TITLE": "FNIRT",
+        "DESCRIPTION": "FNIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FNIRT).",
+        "DOWNLOADS": 27.0
+    },
+    {
+        "ID": "zenodo.2566455",
+        "TITLE": "BIDS App - FSL Diffusion Preprocessing",
+        "DESCRIPTION": "Preprocessing pipeline for diffusion MRI data using the FSL software suite.",
+        "DOWNLOADS": 25.0
+    },
+    {
+        "ID": "zenodo.2563057",
+        "TITLE": "BIDS App - fmriprep",
+        "DESCRIPTION": "fMRIprep is a functional magneticresonance image pre-processing pipeline that is designed to provide an easily accessible, state-of-the-art interface that is robust to differences in scan acquisition protocols and that requires minimal user input, while providing easily interpretable and comprehensive error and output reporting. https://fmriprep.readthedocs.io",
+        "DOWNLOADS": 25.0
+    },
+    {
+        "ID": "zenodo.2541125",
+        "TITLE": "BEst",
+        "DESCRIPTION": "<p>EEG/MEG source localisation techniques based upon the Maximum Entropy on the Mean framework</p>",
+        "DOWNLOADS": 24.0
+    },
+    {
+        "ID": "zenodo.2573287",
+        "TITLE": "oneVoxel",
+        "DESCRIPTION": "Adds 1-voxel noise to a Nifti image at either a provided or random location within a mask.",
+        "DOWNLOADS": 24.0
+    },
+    {
+        "ID": "zenodo.2566450",
+        "TITLE": "BIDS App - ndmg",
+        "DESCRIPTION": "ndmg connectome estimation pipeline",
+        "DOWNLOADS": 23.0
+    },
+    {
+        "ID": "zenodo.2597643",
+        "TITLE": "FLIRT",
+        "DESCRIPTION": "FLIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FLIRT).",
+        "DOWNLOADS": 22.0
+    },
+    {
+        "ID": "zenodo.2602072",
+        "TITLE": "BEDPOSTX5",
+        "DESCRIPTION": "BEDPOSTX5, as implemented in Nipype (module: nipype.interfaces.fsl, interface: BEDPOSTX5).",
+        "DOWNLOADS": 21.0
+    },
+    {
+        "ID": "zenodo.2634608",
+        "TITLE": "CorticalThickness",
+        "DESCRIPTION": "CorticalThickness, as implemented in Nipype (module: nipype.interfaces.ants, interface: CorticalThickness).",
+        "DOWNLOADS": 21.0
+    },
+    {
+        "ID": "zenodo.2646555",
+        "TITLE": "LaplacianThickness",
+        "DESCRIPTION": "LaplacianThickness, as implemented in Nipype (module: nipype.interfaces.ants, interface: LaplacianThickness).",
+        "DOWNLOADS": 21.0
+    },
+    {
+        "ID": "zenodo.2636973",
+        "TITLE": "BrainExtraction",
+        "DESCRIPTION": "BrainExtraction, as implemented in Nipype (module: nipype.interfaces.ants, interface: BrainExtraction).",
+        "DOWNLOADS": 20.0
+    },
+    {
+        "ID": "zenodo.2640953",
+        "TITLE": "ConcatTransfo",
+        "DESCRIPTION": "Concatenate multiple ANTs warping fields using ComposeMultiTransform.\n\nFor instance if you have\n- Warping field: anatomical to MNI template\n- Affine matrix: Diffusion to anatomical\nYou can obtain the transform diffusion to MNI template\n\n\nComposeMultiTransform ImageDimension output_field [-R reference_image] {[deformation_field | [-i] affine_transform_txt ]}\n  Usage has the same form as WarpImageMultiTransform\n For Example:\n\nComposeMultiTransform Dimension  outwarp.nii   -R template.nii   ExistingWarp.nii  ExistingAffine.nii\n or for an inverse mapping :\nComposeMultiTransform Dimension  outwarp.nii   -R template.nii   -i ExistingAffine.nii ExistingInverseWarp.nii\n recalling that the -i option takes the inverse of the affine mapping\n\nOr: to compose multiple affine text file into one:\nComposeMultiTransform ImageDimension output_affine_txt [-R reference_affine_txt] {[-i] affine_transform_txt}\nThis will be evoked if a text file is given as the second parameter. In this case reference_affine_txt is used to define the center of the output affine.  The default reference is the first given affine text file. This ignores all non-txt files among the following parameters.",
+        "DOWNLOADS": 20.0
+    },
+    {
+        "ID": "zenodo.2621482",
+        "TITLE": "TOPUP",
+        "DESCRIPTION": "TOPUP, as implemented in Nipype (module: nipype.interfaces.fsl, interface: TOPUP).",
+        "DOWNLOADS": 20.0
+    },
+    {
+        "ID": "zenodo.2621487",
+        "TITLE": "ApplyTOPUP",
+        "DESCRIPTION": "ApplyTOPUP, as implemented in Nipype (module: nipype.interfaces.fsl, interface: ApplyTOPUP).",
+        "DOWNLOADS": 20.0
+    },
+    {
+        "ID": "zenodo.2648761",
+        "TITLE": "CompositeTransformUtil",
+        "DESCRIPTION": "CompositeTransformUtil, as implemented in Nipype (module: nipype.interfaces.ants, interface: CompositeTransformUtil).",
+        "DOWNLOADS": 19.0
+    },
+    {
+        "ID": "zenodo.3235835",
+        "TITLE": "workflow generated from dataset:5c0c06e6f6f108004b490e2a",
+        "DESCRIPTION": "from acpc_aligned t1 and singleshell b2000 dwi, generate afq output",
+        "DOWNLOADS": 19.0
+    },
+    {
+        "ID": "zenodo.2650465",
+        "TITLE": "DistanceMap",
+        "DESCRIPTION": "DistanceMap, as implemented in Nipype (module: nipype.interfaces.fsl, interface: DistanceMap).",
+        "DOWNLOADS": 18.0
+    },
+    {
+        "ID": "zenodo.2650440",
+        "TITLE": "ApplyWarp",
+        "DESCRIPTION": "ApplyWarp, as implemented in Nipype (module: nipype.interfaces.fsl, interface: ApplyWarp).",
+        "DOWNLOADS": 18.0
+    },
+    {
+        "ID": "zenodo.3240521",
+        "TITLE": "fslstats",
+        "DESCRIPTION": "Descriptor of fslstats from the FSL toolbox. Computes various statistics on nifti images.",
+        "DOWNLOADS": 16.0
+    },
+    {
+        "ID": "zenodo.3239451",
+        "TITLE": "blastp",
+        "DESCRIPTION": "Protein-Protein BLAST 2.7.1+",
+        "DOWNLOADS": 9.0
+    },
+    {
+        "ID": "zenodo.3240577",
+        "TITLE": "blastn",
+        "DESCRIPTION": "Nucleotide-Nucleotide BLAST 2.7.1+",
+        "DOWNLOADS": 9.0
+    },
+    {
+        "ID": "zenodo.3245387",
+        "TITLE": "AQUA",
+        "DESCRIPTION": "automatic quality improvment for multiple sequence alignment.",
+        "DOWNLOADS": 5.0
+    },
+    {
+        "ID": "zenodo.3257614",
+        "TITLE": "spark",
+        "DESCRIPTION": "SParsity-based Analysis of Reliable K-hubness (SPARK) for brain fMRI functional connectivity",
+        "DOWNLOADS": 4.0
+    }
+]

--- a/app/static/pipelines/detailed_all_descriptors.json
+++ b/app/static/pipelines/detailed_all_descriptors.json
@@ -1,0 +1,11871 @@
+[
+    {
+        "author": "Test author",
+        "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FILE_LIST_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [LOG] [INT_LIST_INPUT]",
+        "container-image": {
+            "container-opts": [
+                "-e",
+                "HOME=$PWD"
+            ],
+            "image": "boutiques/example1:test",
+            "type": "docker"
+        },
+        "deprecated": true,
+        "description": "This property describes the tool or application",
+        "descriptor-url": "https://github.com/boutiques/boutiques/blob/master/tools/python/boutiques/schema/examples/example1/example1_docker.json",
+        "environment-variables": [
+            {
+                "name": "ENVAR",
+                "value": "theValue"
+            }
+        ],
+        "error-codes": [
+            {
+                "code": 2,
+                "description": "File does not exist!"
+            }
+        ],
+        "groups": [
+            {
+                "description": "This group forces us to choose exactly one of the file or the enum input to use.",
+                "id": "an_example_group",
+                "members": [
+                    "num_input",
+                    "enum_input"
+                ],
+                "mutually-exclusive": true,
+                "name": "Example group 1",
+                "one-is-required": true
+            }
+        ],
+        "inputs": [
+            {
+                "command-line-flag": "-i",
+                "default-value": [
+                    "aStringValue"
+                ],
+                "description": "Describe the use and meaning of the parameter",
+                "id": "str_input_list",
+                "list": true,
+                "max-list-entries": 3,
+                "min-list-entries": 1,
+                "name": "A list of string inputs",
+                "type": "String",
+                "value-key": "[STRING_INPUT_LIST]"
+            },
+            {
+                "command-line-flag": "-s",
+                "default-value": "aStringValue",
+                "description": "Describe the use and meaning of the parameter",
+                "id": "str_input",
+                "name": "A string input",
+                "type": "String",
+                "value-key": "[STRING_INPUT]"
+            },
+            {
+                "command-line-flag": "-l",
+                "description": "Describe the use and meaning of the parameter",
+                "id": "list_int_input",
+                "integer": true,
+                "list": true,
+                "min-list-entries": 1,
+                "name": "A list of ints",
+                "type": "Number",
+                "value-key": "[INT_LIST_INPUT]"
+            },
+            {
+                "id": "config_num",
+                "name": "A number put in the configuration file",
+                "type": "Number",
+                "value-choices": [
+                    4
+                ],
+                "value-key": "[CONFIG_NUMBER]"
+            },
+            {
+                "command-line-flag": "-n",
+                "command-line-flag-separator": "=",
+                "exclusive-minimum": true,
+                "id": "num_input",
+                "maximum": 1,
+                "minimum": 0,
+                "name": "A number input",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[NUMBER_INPUT]"
+            },
+            {
+                "id": "file_input",
+                "name": "A file input",
+                "optional": true,
+                "type": "File",
+                "value-key": "[FILE_INPUT]"
+            },
+            {
+                "command-line-flag": "-t",
+                "id": "file_list_input",
+                "list": true,
+                "name": "A file list input",
+                "optional": true,
+                "type": "File",
+                "value-key": "[FILE_LIST_INPUT]"
+            },
+            {
+                "command-line-flag": "-e",
+                "id": "enum_input",
+                "name": "An enum input",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "val1",
+                    "val2",
+                    "val3"
+                ],
+                "value-key": "[ENUM_INPUT]"
+            },
+            {
+                "command-line-flag": "-f",
+                "disables-inputs": [
+                    "num_input"
+                ],
+                "id": "flag_input",
+                "name": "A flag input",
+                "optional": true,
+                "requires-inputs": [
+                    "file_input"
+                ],
+                "type": "Flag",
+                "value-key": "[FLAG_INPUT]"
+            }
+        ],
+        "name": "Example Boutiques Tool",
+        "online-platform-urls": [
+            "http://somewhere.org/good_tool",
+            "https://someplace.com/bad_tool"
+        ],
+        "output-files": [
+            {
+                "description": "The output log file from the example tool",
+                "id": "logfile",
+                "name": "Log file",
+                "path-template": "log-[CONFIG_NUMBER]-[STRING_INPUT].txt",
+                "path-template-stripped-extensions": [
+                    ".txt",
+                    ".csv"
+                ],
+                "value-key": "[LOG]"
+            },
+            {
+                "id": "output_files",
+                "list": true,
+                "name": "outfiles",
+                "optional": true,
+                "path-template": "output/*_exampleOutputTag.resultType"
+            },
+            {
+                "command-line-flag": "-c",
+                "file-template": [
+                    "# This is a demo configuration file",
+                    "numInput=[CONFIG_NUMBER]",
+                    "strInput=[STRING_INPUT]"
+                ],
+                "id": "config_file",
+                "name": "Configuration file",
+                "path-template": "./config.txt",
+                "value-key": "[CONFIG_FILE]"
+            }
+        ],
+        "schema-version": "0.5",
+        "tags": {
+            "domain": "testing",
+            "foo": [
+                "bar1",
+                "bar2"
+            ],
+            "programming-language": "Python"
+        },
+        "tool-doi": "00.0000/example.0000000",
+        "tool-version": "0.0.1",
+        "url": "http://example.com"
+    },
+    {
+        "tool-version": "v2.7.1",
+        "description": "Application to create BLAST databases, version 2.7.1+",
+        "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/makeblastdb [IN] [INPUT_TYPE] [DBTYPE] [TITLE] [fPARSE_SEQIDS] [fHASHINDEX] [MASK_DATA_FILES] [MASK_ALGO_IDS] [MASK_DESC] [fGI_MASK] [GI_MASK_NAME] [OUT] [MAX_FILE_SIZE] [LOG_FILE] [TAX_ID] [TAX_ID_MAP]",
+        "author": "Altschul et al.",
+        "tags": {
+            "domain": [
+                "bioinformatics",
+                "blast"
+            ]
+        },
+        "container-image": {
+            "index": "docker://",
+            "image": "c3genomics/genpipes",
+            "type": "singularity"
+        },
+        "inputs": [
+            {
+                "command-line-flag": "-parse_seqids",
+                "description": "A flag which enables parsing of sequence ids",
+                "value-key": "[fPARSE_SEQIDS]",
+                "optional": true,
+                "type": "Flag",
+                "id": "parse_seqids",
+                "name": "Parse Sequence IDs flag"
+            },
+            {
+                "command-line-flag": "-hash_index",
+                "description": "A flag which enables the creation of sequence hash values. These hash values can then be used to quickly determine if a given sequence data exists in this BLAST database.",
+                "value-key": "[fHASHINDEX]",
+                "optional": true,
+                "type": "Flag",
+                "id": "hash_index",
+                "name": "Enable Hash indexes"
+            },
+            {
+                "command-line-flag": "-gi_mask",
+                "description": "A flag which creates GI indexed masking data.",
+                "value-key": "[fGI_MASK]",
+                "optional": true,
+                "requires-inputs": [
+                    "parse_seqids"
+                ],
+                "type": "Flag",
+                "id": "gi_mask",
+                "name": "GI indexed masking data flag"
+            },
+            {
+                "command-line-flag": "-gi_mask_name",
+                "description": "Comma-separated list of masking data output files.",
+                "value-key": "[GI_MASK_NAME]",
+                "type": "File",
+                "list": true,
+                "requires-inputs": [
+                    "mask_data",
+                    "gi_mask"
+                ],
+                "list-separator": ",",
+                "optional": true,
+                "id": "gi_mask_name",
+                "min-list-entries": 1,
+                "name": "Masking data"
+            },
+            {
+                "command-line-flag": "-dbtype",
+                "description": "Molecule type of target db",
+                "value-key": "[DBTYPE]",
+                "optional": false,
+                "value-choices": [
+                    "nucl",
+                    "prot"
+                ],
+                "type": "String",
+                "id": "dbtype",
+                "name": "Database Type"
+            },
+            {
+                "command-line-flag": "-in",
+                "description": "The input source, either a file name or standard in (-, the default)",
+                "value-key": "[IN]",
+                "optional": true,
+                "type": "File",
+                "id": "in",
+                "name": "Input file/database name"
+            },
+            {
+                "command-line-flag": "-out",
+                "description": "   Name of BLAST database to be created\n   Default = input file name provided to -in argument\n   Required if multiple file(s)/database(s)\n   are provided as input",
+                "value-key": "[OUT]",
+                "optional": false,
+                "type": "File",
+                "id": "out",
+                "name": "Name of BLAST database to be created"
+            },
+            {
+                "command-line-flag": "-input_type",
+                "description": "Type of the data specified in input_file. Will default to 'fasta'",
+                "value-key": "[INPUT_TYPE]",
+                "optional": true,
+                "value-choices": [
+                    "asn1_bin",
+                    "asn1_txt",
+                    "blastdb",
+                    "fasta"
+                ],
+                "type": "String",
+                "id": "input_type",
+                "name": "Type of the data specified in input_file"
+            },
+            {
+                "command-line-flag": "-title",
+                "description": "Title for BLAST database. Defaults to input file name.",
+                "value-key": "[TITLE]",
+                "optional": true,
+                "type": "String",
+                "id": "title",
+                "name": "Title for BLAST database"
+            },
+            {
+                "command-line-flag": "-mask_data",
+                "description": "Title for BLAST database. Defaults to input file name.",
+                "value-key": "[MASK_DATA_FILES]",
+                "type": "File",
+                "list": true,
+                "list-separator": ",",
+                "optional": true,
+                "id": "mask_data",
+                "min-list-entries": 1,
+                "name": "Title for BLAST database"
+            },
+            {
+                "command-line-flag": "-mask_id",
+                "description": "Comma-separated list of strings to uniquely identify the masking algorithm.",
+                "value-key": "[MASK_ALGO_IDS]",
+                "type": "String",
+                "list": true,
+                "requires-inputs": [
+                    "mask_data"
+                ],
+                "list-separator": ",",
+                "disables-inputs": [
+                    "gi_mask"
+                ],
+                "optional": true,
+                "id": "mask_id",
+                "min-list-entries": 1,
+                "name": "Masking Algorithm"
+            },
+            {
+                "command-line-flag": "-mask_desc",
+                "description": "Comma-separated list of free form strings to describe the masking algorithm details.",
+                "value-key": "[MASK_DESC]",
+                "type": "String",
+                "list": true,
+                "requires-inputs": [
+                    "mask_id"
+                ],
+                "list-separator": ",",
+                "optional": true,
+                "id": "mask_desc",
+                "min-list-entries": 1,
+                "name": "Masking Algorithm Details"
+            },
+            {
+                "command-line-flag": "-max_file_sz",
+                "description": "Maximum file size for BLAST database files.",
+                "value-key": "[MAX_FILE_SIZE]",
+                "optional": true,
+                "type": "String",
+                "id": "max_file_sz",
+                "name": "Max database file size"
+            },
+            {
+                "command-line-flag": "-logfile",
+                "description": "File to which the program log should be redirected.",
+                "value-key": "[LOG_FILE]",
+                "optional": true,
+                "type": "File",
+                "id": "logfile",
+                "name": "Log file"
+            },
+            {
+                "command-line-flag": "-taxid",
+                "description": "Taxonomy ID to assign to all sequences.",
+                "value-key": "[TAX_ID]",
+                "optional": true,
+                "disables-inputs": [
+                    "taxid_map"
+                ],
+                "minimum": 0,
+                "type": "Number",
+                "id": "taxid",
+                "name": "Taxonomy ID"
+            },
+            {
+                "command-line-flag": "-taxid_map",
+                "description": "Text file mapping sequence IDs to taxonomy IDs.",
+                "value-key": "[TAX_ID_MAP]",
+                "optional": true,
+                "requires-inputs": [
+                    "parse_seqids"
+                ],
+                "disables-inputs": [
+                    "taxid"
+                ],
+                "type": "File",
+                "id": "taxid_map",
+                "name": "Sequence to taxonomy mapping"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[OUT].phr",
+                "optional": false,
+                "id": "outputdbphr",
+                "name": "Output Database Headers"
+            },
+            {
+                "path-template": "[OUT].psq",
+                "optional": false,
+                "id": "outputdbpsq",
+                "name": "Output Database Binary Sequences"
+            },
+            {
+                "path-template": "[OUT].pin",
+                "optional": false,
+                "id": "outputdbpin",
+                "name": "Output Database Index File"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 60,
+            "ram": 1,
+            "cpu-cores": 1
+        },
+        "name": "makeblastdb"
+    },
+    {
+        "name": "MCFLIRT",
+        "command-line": "mcflirt [IN_FILE] [BINS] [COST] [DOF] [INIT] [INTERPOLATION] [MEAN_VOL] [OUT_FILE] [REF_FILE] [REF_VOL] [ROTATION] [SAVE_MATS] [SAVE_PLOTS] [SAVE_RMS] [SCALING] [SMOOTH] [STAGES] [STATS_IMGS] [USE_CONTOUR] [USE_GRADIENT]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "MCFLIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: MCFLIRT).",
+        "inputs": [
+            {
+                "id": "bins",
+                "name": "Bins",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[BINS]",
+                "command-line-flag": "-bins",
+                "description": "An integer (int or long). Number of histogram bins.",
+                "optional": true
+            },
+            {
+                "id": "cost",
+                "name": "Cost",
+                "type": "String",
+                "value-key": "[COST]",
+                "command-line-flag": "-cost",
+                "description": "'mutualinfo' or 'woods' or 'corratio' or 'normcorr' or 'normmi' or 'leastsquares'. Cost function to optimize.",
+                "optional": true,
+                "value-choices": [
+                    "mutualinfo",
+                    "woods",
+                    "corratio",
+                    "normcorr",
+                    "normmi",
+                    "leastsquares"
+                ]
+            },
+            {
+                "id": "dof",
+                "name": "Dof",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[DOF]",
+                "command-line-flag": "-dof",
+                "description": "An integer (int or long). Degrees of freedom for the transformation.",
+                "optional": true
+            },
+            {
+                "id": "in_file",
+                "name": "In file",
+                "type": "File",
+                "value-key": "[IN_FILE]",
+                "command-line-flag": "-in",
+                "description": "An existing file name. Timeseries to motion-correct.",
+                "optional": false
+            },
+            {
+                "id": "init",
+                "name": "Init",
+                "type": "File",
+                "value-key": "[INIT]",
+                "command-line-flag": "-init",
+                "description": "An existing file name. Inital transformation matrix.",
+                "optional": true
+            },
+            {
+                "id": "interpolation",
+                "name": "Interpolation",
+                "type": "String",
+                "value-key": "[INTERPOLATION]",
+                "command-line-flag": "-",
+                "command-line-flag-separator": "",
+                "description": "'spline' or 'nn' or 'sinc'. Interpolation method for transformation.",
+                "optional": true,
+                "value-choices": [
+                    "spline_final",
+                    "nn_final",
+                    "sinc_final"
+                ]
+            },
+            {
+                "id": "mean_vol",
+                "name": "Mean vol",
+                "type": "Flag",
+                "value-key": "[MEAN_VOL]",
+                "command-line-flag": "-meanvol",
+                "description": "A boolean. Register to mean volume.",
+                "optional": true
+            },
+            {
+                "id": "out_file",
+                "name": "Out file",
+                "type": "File",
+                "value-key": "[OUT_FILE]",
+                "command-line-flag": "-out",
+                "description": "A file name. File to write.",
+                "optional": true
+            },
+            {
+                "id": "ref_file",
+                "name": "Ref file",
+                "type": "File",
+                "value-key": "[REF_FILE]",
+                "command-line-flag": "-reffile",
+                "description": "An existing file name. Target image for motion correction.",
+                "optional": true
+            },
+            {
+                "id": "ref_vol",
+                "name": "Ref vol",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[REF_VOL]",
+                "command-line-flag": "-refvol",
+                "description": "An integer (int or long). Volume to align frames to.",
+                "optional": true
+            },
+            {
+                "id": "rotation",
+                "name": "Rotation",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[ROTATION]",
+                "command-line-flag": "-rotation",
+                "description": "An integer (int or long). Scaling factor for rotation tolerances.",
+                "optional": true
+            },
+            {
+                "id": "save_mats",
+                "name": "Save mats",
+                "type": "Flag",
+                "value-key": "[SAVE_MATS]",
+                "command-line-flag": "-mats",
+                "description": "A boolean. Save transformation matrices.",
+                "optional": true
+            },
+            {
+                "id": "save_plots",
+                "name": "Save plots",
+                "type": "Flag",
+                "value-key": "[SAVE_PLOTS]",
+                "command-line-flag": "-plots",
+                "description": "A boolean. Save transformation parameters.",
+                "optional": true
+            },
+            {
+                "id": "save_rms",
+                "name": "Save rms",
+                "type": "Flag",
+                "value-key": "[SAVE_RMS]",
+                "command-line-flag": "-rmsabs -rmsrel",
+                "description": "A boolean. Save rms displacement parameters.",
+                "optional": true
+            },
+            {
+                "id": "scaling",
+                "name": "Scaling",
+                "type": "Number",
+                "value-key": "[SCALING]",
+                "command-line-flag": "-scaling",
+                "description": "A float. Scaling factor to use.",
+                "optional": true
+            },
+            {
+                "id": "smooth",
+                "name": "Smooth",
+                "type": "Number",
+                "value-key": "[SMOOTH]",
+                "command-line-flag": "-smooth",
+                "description": "A float. Smoothing factor for the cost function.",
+                "optional": true
+            },
+            {
+                "id": "stages",
+                "name": "Stages",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[STAGES]",
+                "command-line-flag": "-stages",
+                "description": "An integer (int or long). Stages (if 4, perform final search with sinc interpolation.",
+                "optional": true
+            },
+            {
+                "id": "stats_imgs",
+                "name": "Stats imgs",
+                "type": "Flag",
+                "value-key": "[STATS_IMGS]",
+                "command-line-flag": "-stats",
+                "description": "A boolean. Produce variance and std. dev. images.",
+                "optional": true
+            },
+            {
+                "id": "use_contour",
+                "name": "Use contour",
+                "type": "Flag",
+                "value-key": "[USE_CONTOUR]",
+                "command-line-flag": "-edge",
+                "description": "A boolean. Run search on contour images.",
+                "optional": true
+            },
+            {
+                "id": "use_gradient",
+                "name": "Use gradient",
+                "type": "Flag",
+                "value-key": "[USE_GRADIENT]",
+                "command-line-flag": "-gdt",
+                "description": "A boolean. Run search on gradient images.",
+                "optional": true
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Mat file",
+                "id": "mat_file",
+                "path-template": "MAT_*",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Transformation matrices.",
+                "list": true
+            },
+            {
+                "name": "Mean img",
+                "id": "mean_img",
+                "path-template": "[OUT_FILE]_mean_reg.ext",
+                "optional": true,
+                "description": "An existing file name. Mean timeseries image (if mean_vol=true)."
+            },
+            {
+                "name": "Out file",
+                "id": "out_file_outfile",
+                "path-template": "[OUT_FILE]",
+                "optional": true,
+                "description": "An existing file name. Motion-corrected timeseries."
+            },
+            {
+                "name": "Par file",
+                "id": "par_file",
+                "path-template": "[OUT_FILE].par",
+                "optional": true,
+                "description": "An existing file name. Text-file with motion parameters."
+            },
+            {
+                "name": "Rms files",
+                "id": "rms_files",
+                "path-template": "[OUT_FILE]_*.rms",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Absolute and relative displacement parameters.",
+                "list": true
+            },
+            {
+                "name": "Std img",
+                "id": "std_img",
+                "path-template": "[OUT_FILE]_sigma.ext",
+                "optional": true,
+                "description": "An existing file name. Standard deviation image."
+            },
+            {
+                "name": "Variance img",
+                "id": "variance_img",
+                "path-template": "[OUT_FILE]_variance.ext",
+                "optional": true,
+                "description": "An existing file name. Variance image."
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ],
+            "source": "nipype-interface"
+        },
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/preprocess.py"
+    },
+    {
+        "tool-version": "undefined",
+        "name": "qeeg",
+        "author": "Neuroinformatics Collaboratory",
+        "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-eeg/blob/master/cbrain_task_descriptors/qeeg.json",
+        "command-line": "qeegt.sh --input [input_directory]/[basename] --state [state] --lwin [lwin] --fmin [fmin] --freqres [freqres] --fmax [fmax] --wbands [wbands] [brain] [pg_apply] [bbsm] [nbsm] [spectra] [bbsmz] [nbsmz] [ssz] [corr] [cohe] [phdiff] [fcorr] [storexyz] --output \"results\" ",
+        "inputs": [
+            {
+                "description": "Directory containing the files to process.",
+                "value-key": "[input_directory]",
+                "optional": false,
+                "list": false,
+                "type": "File",
+                "id": "input_directory",
+                "name": "Input directory"
+            },
+            {
+                "description": "Basename of the file to process in the input directory.",
+                "value-key": "[basename]",
+                "optional": false,
+                "list": false,
+                "type": "String",
+                "id": "basename",
+                "name": "Basename"
+            },
+            {
+                "description": "Example: \"A\". EEG state to be analyzed. The program will look for existing analysis windows labelled as state 'A' (Eyes Closed).",
+                "default-value": "A",
+                "value-key": "[state]",
+                "optional": false,
+                "list": false,
+                "type": "String",
+                "id": "state",
+                "name": "State"
+            },
+            {
+                "description": "Length of the analysis window in seconds.",
+                "default-value": 2.56,
+                "value-key": "[lwin]",
+                "optional": false,
+                "list": false,
+                "minimum": 0,
+                "type": "Number",
+                "id": "lwin",
+                "name": "Window length"
+            },
+            {
+                "description": "Low cut frequency for analysis. Example: \"0.390625\".",
+                "default-value": 0.390625,
+                "value-key": "[fmin]",
+                "optional": false,
+                "list": false,
+                "minimum": 0,
+                "type": "Number",
+                "id": "fmin",
+                "name": "fmin"
+            },
+            {
+                "description": "Fequency resolution for analysis. Example: \"0.390625\". The analysis will use a frequency band like this: fmin:freqres:fmax. The program will compare this interval with the interval that is obtained for the real frequency parameters of the signal and will match both of them.",
+                "default-value": 0.390625,
+                "value-key": "[freqres]",
+                "optional": false,
+                "list": false,
+                "type": "Number",
+                "id": "freqres",
+                "name": "freqres"
+            },
+            {
+                "description": "High cut frequency for analysis. Example: \"19.11\".",
+                "default-value": 19.11,
+                "value-key": "[fmax]",
+                "optional": false,
+                "list": false,
+                "type": "Number",
+                "id": "fmax",
+                "name": "fmax"
+            },
+            {
+                "description": "Broad Bands definition. A string representing a 5x2 matrix of real numbers, where rows are separated by ';' and columns by spaces. Example: \"1.56 3.51; 3.9 7.41; 7.8 12.48; 12.87 19.11; 1.56 19.11\".",
+                "default-value": "1.56 3.51; 3.9 7.41; 7.8 12.48; 12.87 19.11; 1.56 19.11",
+                "value-key": "[wbands]",
+                "optional": false,
+                "list": false,
+                "type": "String",
+                "id": "wbands",
+                "name": "wbands"
+            },
+            {
+                "command-line-flag": "--brain",
+                "description": "Restricts the inverse solution to only gray matter. Otherwise, deep structure (basal ganglia) will be included in the grid.",
+                "default-value": true,
+                "value-key": "[brain]",
+                "optional": true,
+                "type": "Flag",
+                "id": "brain",
+                "name": "Brain"
+            },
+            {
+                "command-line-flag": "--pg_apply",
+                "description": "Substracts the Global Scale Factor (Geometric Power) from the EEG signal.",
+                "default-value": true,
+                "value-key": "[pg_apply]",
+                "optional": true,
+                "type": "Flag",
+                "id": "pg_apply",
+                "name": "PG Apply"
+            },
+            {
+                "command-line-flag": "--bbsm",
+                "description": "Calculates the Broad Band Spectral Model.",
+                "default-value": true,
+                "value-key": "[bbsm]",
+                "optional": true,
+                "type": "Flag",
+                "id": "bbsm",
+                "name": "Broad Band Spectral Model"
+            },
+            {
+                "command-line-flag": "--nbsm",
+                "description": "Calculates the Narrow Band Spectral Model.",
+                "default-value": true,
+                "value-key": "[nbsm]",
+                "optional": true,
+                "type": "Flag",
+                "id": "nbsm",
+                "name": "Narrow Band Spectral Model"
+            },
+            {
+                "command-line-flag": "--spectra",
+                "description": "Calculates the Spectra at the EEG sources.",
+                "default-value": true,
+                "value-key": "[spectra]",
+                "optional": true,
+                "type": "Flag",
+                "id": "spectra",
+                "name": "Spectra"
+            },
+            {
+                "command-line-flag": "--bbsmz",
+                "description": "Calculates the Broad Band Spectral Model Z values.",
+                "default-value": true,
+                "value-key": "[bbsmz]",
+                "optional": true,
+                "type": "Flag",
+                "id": "bbsmz",
+                "name": "Broad Band Spectral Model Z values"
+            },
+            {
+                "command-line-flag": "--nbsmz",
+                "description": "Calculates the Narrow Band Spectral Model Z values.",
+                "default-value": true,
+                "value-key": "[nbsmz]",
+                "optional": true,
+                "type": "Flag",
+                "id": "nbsmz",
+                "name": "Narrow Band Spectral Model Z values"
+            },
+            {
+                "command-line-flag": "--ssz",
+                "description": "Calculates the Sources Spectra Z values.",
+                "default-value": true,
+                "value-key": "[ssz]",
+                "optional": true,
+                "type": "Flag",
+                "id": "ssz",
+                "name": "Source Spectra Z"
+            },
+            {
+                "command-line-flag": "--corr",
+                "description": "Calculates the correlations matrix bewteen all pairs of channels for each epoch.",
+                "default-value": true,
+                "value-key": "[corr]",
+                "optional": true,
+                "type": "Flag",
+                "id": "corr",
+                "name": "Correlations matrix"
+            },
+            {
+                "command-line-flag": "--cohe",
+                "description": "Calculates the coherence matrix bewteen all pairs of channels for each frequency.",
+                "default-value": true,
+                "value-key": "[cohe]",
+                "optional": true,
+                "type": "Flag",
+                "id": "cohe",
+                "name": "Coherence matrix"
+            },
+            {
+                "command-line-flag": "--phdiff",
+                "description": "Calculates the phase difference matrix bewteen all pairs of channels for each frequency.",
+                "default-value": true,
+                "value-key": "[phdiff]",
+                "optional": true,
+                "type": "Flag",
+                "id": "phdiff",
+                "name": "Phase difference matrix"
+            },
+            {
+                "command-line-flag": "--fcorr",
+                "description": "Calculates  the frequency domain correlations bewteen all pairs of channels for each frequency and each epoch.",
+                "default-value": true,
+                "value-key": "[fcorr]",
+                "optional": true,
+                "type": "Flag",
+                "id": "fcorr",
+                "name": "Frequency domain correlations"
+            },
+            {
+                "command-line-flag": "--storexyz",
+                "description": "Stores the XYZ components of the solutions at the sources.",
+                "default-value": true,
+                "value-key": "[storexyz]",
+                "optional": true,
+                "type": "Flag",
+                "id": "storexyz",
+                "name": "XYZ components"
+            }
+        ],
+        "container-image": {
+            "image": "mcin/qeeg:latest",
+            "type": "docker"
+        },
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "description": "A folder containing the output files.",
+                "list": false,
+                "id": "folder_out",
+                "optional": false,
+                "path-template": "results",
+                "name": "Output folder"
+            }
+        ],
+        "description": "qeeg application",
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "eeg"
+            ]
+        }
+    },
+    {
+        "tool-version": "1.0.0",
+        "name": "fsl_bet",
+        "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+        "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_bet.json",
+        "command-line": "bet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [CENTER_OF_GRAVITY] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [VTK_VIEW_FLAG] [HEAD_RADIUS] [THRESHOLDING_FLAG] [ROBUST_ITERS_FLAG] [RES_OPTIC_CLEANUP_FLAG] [REDUCE_BIAS_FLAG] [SLICE_PADDING_FLAG] [MASK_WHOLE_SET_FLAG] [ADD_SURFACES_FLAG] [ADD_SURFACES_T2] [VERBOSE_FLAG] [DEBUG_FLAG]",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "inputs": [
+            {
+                "description": "Input image (e.g. img.nii.gz)",
+                "value-key": "[INPUT_FILE]",
+                "type": "File",
+                "optional": false,
+                "id": "infile",
+                "name": "Input file"
+            },
+            {
+                "description": "Output brain mask (e.g. img_bet.nii.gz)",
+                "value-key": "[MASK]",
+                "type": "String",
+                "optional": false,
+                "id": "maskfile",
+                "name": "Mask file"
+            },
+            {
+                "command-line-flag": "-f",
+                "description": "Fractional intensity threshold (0->1); default=0.5; smaller values give larger brain outline estimates",
+                "value-key": "[FRACTIONAL_INTENSITY]",
+                "type": "Number",
+                "maximum": 1,
+                "minimum": 0,
+                "integer": false,
+                "optional": true,
+                "id": "fractional_intensity",
+                "name": "Fractional intensity threshold"
+            },
+            {
+                "command-line-flag": "-g",
+                "description": "Vertical gradient in fractional intensity threshold (-1->1); default=0; positive values give larger brain outline at bottom, smaller at top",
+                "value-key": "[VERTICAL_GRADIENT]",
+                "type": "Number",
+                "maximum": 1,
+                "minimum": -1,
+                "integer": false,
+                "optional": true,
+                "id": "vg_fractional_intensity",
+                "name": "Vertical gradient fractional intensity threshold"
+            },
+            {
+                "command-line-flag": "-c",
+                "description": "The xyz coordinates of the center of gravity (voxels, not mm) of initial mesh surface. Must have exactly three numerical entries in the list (3-vector).",
+                "value-key": "[CENTER_OF_GRAVITY]",
+                "type": "Number",
+                "list": true,
+                "max-list-entries": 3,
+                "optional": true,
+                "id": "center_of_gravity",
+                "min-list-entries": 3,
+                "name": "Center of gravity vector"
+            },
+            {
+                "command-line-flag": "-o",
+                "description": "Generate brain surface outline overlaid onto original image",
+                "value-key": "[OVERLAY_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "overlay_flag",
+                "name": "Overlay flag"
+            },
+            {
+                "command-line-flag": "-m",
+                "description": "Generate binary brain mask",
+                "value-key": "[BINARY_MASK_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "binary_mask_flag",
+                "name": "Binary mask flag"
+            },
+            {
+                "command-line-flag": "-s",
+                "description": "Generate rough skull image (not as clean as betsurf)",
+                "value-key": "[APPROX_SKULL_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "approx_skull_flag",
+                "name": "Approximate skull flag"
+            },
+            {
+                "command-line-flag": "-n",
+                "description": "Don't generate segmented brain image output",
+                "value-key": "[NO_SEG_OUTPUT_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "no_seg_output_flag",
+                "name": "No segmented brain image flag"
+            },
+            {
+                "command-line-flag": "-e",
+                "description": "Generate brain surface as mesh in .vtk format",
+                "value-key": "[VTK_VIEW_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "vtk_mesh",
+                "name": "VTK format brain surface mesh flag"
+            },
+            {
+                "command-line-flag": "-r",
+                "description": "head radius (mm not voxels); initial surface sphere is set to half of this",
+                "value-key": "[HEAD_RADIUS]",
+                "type": "Number",
+                "optional": true,
+                "id": "head_radius",
+                "name": "Head Radius"
+            },
+            {
+                "command-line-flag": "-t",
+                "description": "Apply thresholding to segmented brain image and mask",
+                "value-key": "[THRESHOLDING_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "thresholding_flag",
+                "name": "Threshold segmented image flag"
+            },
+            {
+                "command-line-flag": "-R",
+                "description": "More robust brain center estimation, by iterating BET with a changing center-of-gravity.",
+                "value-key": "[ROBUST_ITERS_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "robust_iters_flag",
+                "name": "Robust iterations flag"
+            },
+            {
+                "command-line-flag": "-S",
+                "description": "This attempts to cleanup residual eye and optic nerve voxels which bet2 can sometimes leave behind. This can be useful when running SIENA or SIENAX, for example. Various stages involving standard-space masking, morphpological operations and thresholdings are combined to produce a result which can often give better results than just running bet2.",
+                "value-key": "[RES_OPTIC_CLEANUP_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "residual_optic_cleanup_flag",
+                "name": "Residual optic cleanup flag"
+            },
+            {
+                "command-line-flag": "-B",
+                "description": "This attempts to reduce image bias, and residual neck voxels. This can be useful when running SIENA or SIENAX, for example. Various stages involving FAST segmentation-based bias field removal and standard-space masking are combined to produce a result which can often give better results than just running bet2.",
+                "value-key": "[REDUCE_BIAS_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "reduce_bias_flag",
+                "name": "Bias reduction flag"
+            },
+            {
+                "command-line-flag": "-Z",
+                "description": "This can improve the brain extraction if only a few slices are present in the data (i.e., a small field of view in the Z direction). This is achieved by padding the end slices in both directions, copying the end slices several times, running bet2 and then removing the added slices.",
+                "value-key": "[SLICE_PADDING_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "slice_padding_flag",
+                "name": "Slice padding flag"
+            },
+            {
+                "command-line-flag": "-F",
+                "description": "This option uses bet2 to determine a brain mask on the basis of the first volume in a 4D data set, and applies this to the whole data set. This is principally intended for use on FMRI data, for example to remove eyeballs. Because it is normally important (in this application) that masking be liberal (ie that there be little risk of cutting out valid brain voxels) the -f threshold is reduced to 0.3, and also the brain mask is \"dilated\" slightly before being used.",
+                "value-key": "[MASK_WHOLE_SET_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "whole_set_mask_flag",
+                "name": "Mask-whole-set flag"
+            },
+            {
+                "command-line-flag": "-A",
+                "description": "This runs both bet2 and betsurf programs in order to get the additional skull and scalp surfaces created by betsurf. This involves registering to standard space in order to allow betsurf to find the standard space masks it needs.",
+                "value-key": "[ADD_SURFACES_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "additional_surfaces_flag",
+                "name": "Additional surfaces flag"
+            },
+            {
+                "command-line-flag": "-A2",
+                "description": "This is the same as -A except that a T2 image is also input, to further improve the estimated skull and scalp surfaces. As well as carrying out the standard space registration this also registers the T2 to the T1 input image.",
+                "value-key": "[ADD_SURFACES_T2]",
+                "type": "File",
+                "optional": true,
+                "id": "additional_surfaces_t2",
+                "name": "Additional surfaces with T2"
+            },
+            {
+                "command-line-flag": "-v",
+                "description": "Switch on diagnostic messages",
+                "value-key": "[VERBOSE_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "verbose_flag",
+                "name": "Verbose Flag"
+            },
+            {
+                "command-line-flag": "-d",
+                "description": "Don't delete temporary intermediate images",
+                "value-key": "[DEBUG_FLAG]",
+                "type": "Flag",
+                "optional": true,
+                "id": "debug_flag",
+                "name": "Debug Flag"
+            }
+        ],
+        "schema-version": "0.5",
+        "groups": [
+            {
+                "description": "Specify parameters that alter the default BET functionality",
+                "id": "optional_params_group",
+                "members": [
+                    "fractional_intensity",
+                    "vg_fractional_intensity",
+                    "center_of_gravity",
+                    "overlay_flag",
+                    "binary_mask_flag",
+                    "approx_skull_flag",
+                    "no_seg_output_flag",
+                    "vtk_mesh",
+                    "head_radius",
+                    "thresholding_flag"
+                ],
+                "name": "Main Program Parameters"
+            },
+            {
+                "description": "Mutually exclusive options that specify variations on how BET should be run.",
+                "mutually-exclusive": true,
+                "id": "variational_params_group",
+                "members": [
+                    "robust_iters_flag",
+                    "residual_optic_cleanup_flag",
+                    "reduce_bias_flag",
+                    "slice_padding_flag",
+                    "whole_set_mask_flag",
+                    "additional_surfaces_flag",
+                    "additional_surfaces_t2"
+                ],
+                "name": "Variations on Default Functionality"
+            },
+            {
+                "description": "Optional miscellaneous parameters when running BET",
+                "id": "miscellaneous_params_group",
+                "members": [
+                    "verbose_flag",
+                    "debug_flag"
+                ],
+                "name": "Miscellaneous Parameters"
+            }
+        ],
+        "output-files": [
+            {
+                "path-template": "[MASK].nii.gz",
+                "description": "Main default mask output of BET",
+                "optional": true,
+                "id": "outfile",
+                "name": "Output mask file"
+            },
+            {
+                "path-template": "[MASK]_mask.nii.gz",
+                "description": "Binary mask file (from -m option)",
+                "optional": true,
+                "id": "binary_mask",
+                "name": "Output binary mask file"
+            },
+            {
+                "path-template": "[MASK]_overlay.nii.gz",
+                "description": "Overlaid brain surface onto original image",
+                "optional": true,
+                "id": "overlay_file",
+                "name": "Surface overlay file"
+            },
+            {
+                "path-template": "[MASK]_skull.nii.gz",
+                "description": "Approximate skull image file",
+                "optional": true,
+                "id": "approx_skull_img",
+                "name": "Approximate skull file"
+            },
+            {
+                "path-template": "[MASK]_mesh.vtk",
+                "description": "Mesh in VTK format",
+                "optional": true,
+                "id": "output_vtk_mesh",
+                "name": "VTK mesh"
+            },
+            {
+                "path-template": "[MASK]_skull_mask.nii.gz",
+                "description": "Output mask for skull image",
+                "optional": true,
+                "id": "skull_mask",
+                "name": "Skull mask image"
+            },
+            {
+                "path-template": "[MASK]_inskull_mask.nii.gz",
+                "description": "The in-skull mask file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_inskull_mask",
+                "name": "Output in-skull mask file"
+            },
+            {
+                "path-template": "[MASK]_inskull_mesh.nii.gz",
+                "description": "The in-skull mesh file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_inskull_mesh",
+                "name": "Output in-skull mesh file"
+            },
+            {
+                "path-template": "[MASK]_inskull_mesh.off",
+                "description": "The in-skull mesh .off file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_inskull_off",
+                "name": "Output in-skull mesh off file"
+            },
+            {
+                "path-template": "[MASK]_outskin_mask.nii.gz",
+                "description": "The out-skin mask file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_outskin_mask",
+                "name": "Output out-skin mask file"
+            },
+            {
+                "path-template": "[MASK]_outskin_mesh.nii.gz",
+                "description": "The out-skin mesh file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_outskin_mesh",
+                "name": "Output out-skin mesh file"
+            },
+            {
+                "path-template": "[MASK]_outskin_mesh.off",
+                "description": "The out-skin mesh .off file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_outskin_off",
+                "name": "Output out-skin mesh off file"
+            },
+            {
+                "path-template": "[MASK]_outskull_mask.nii.gz",
+                "description": "The out-skull mask file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_outskull_mask",
+                "name": "Output out-skull mask file"
+            },
+            {
+                "path-template": "[MASK]_outskull_mesh.nii.gz",
+                "description": "The out-skull mesh file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_outskull_mesh",
+                "name": "Output out-skull mesh file"
+            },
+            {
+                "path-template": "[MASK]_outskull_mesh.off",
+                "description": "The out-skull mesh .off file from betsurf (from -A or -A2)",
+                "optional": true,
+                "id": "out_outskull_off",
+                "name": "Output out-skull mesh off file"
+            }
+        ],
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ]
+        },
+        "tests": [
+            {
+                "name": "fsl_bet_test",
+                "invocation": {
+                    "infile": "sub-01_T1w.nii.gz",
+                    "maskfile": "img_bet"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "outfile",
+                            "md5-reference": "053507dd8605d62f5ba71dbecece17f8"
+                        }
+                    ]
+                }
+            }
+        ],
+        "description": "Automated brain extraction tool for FSL"
+    },
+    {
+        "author": "chrisfilo and others",
+        "command-line": "mkdir -p OUTPUT_DIR; /run.py BIDS_DIR OUTPUT_DIR ANALYSIS_LEVEL PARTICIPANT_LABEL SESSION_LABEL",
+        "container-image": {
+            "image": "bids/example",
+            "type": "docker"
+        },
+        "description": "See https://github.com/BIDS-Apps/example",
+        "descriptor-url": "https://github.com/BIDS-Apps/example/blob/master/boutiques/bids-app-example.json",
+        "groups": [
+            {
+                "description": "For a participants analysis, an output directory name must be specified. For a group analysis, a directory containing the output of participant-level analyses must be selected. ",
+                "id": "output_directory",
+                "members": [
+                    "output_dir_name",
+                    "participant_level_analysis_dir"
+                ],
+                "mutually-exclusive": true,
+                "name": "Output Directory",
+                "one-is-required": true
+            }
+        ],
+        "inputs": [
+            {
+                "description": "The directory with the input dataset formatted according to the BIDS standard.",
+                "id": "bids_dir",
+                "name": "BIDS directory",
+                "optional": false,
+                "type": "File",
+                "value-key": "BIDS_DIR"
+            },
+            {
+                "description": "The directory where the output files should be stored. If you are running a group level analysis, this folder should be prepopulated with the results of the participant level analysis.",
+                "id": "output_dir_name",
+                "name": "Output directory name",
+                "optional": true,
+                "type": "String",
+                "value-key": "OUTPUT_DIR"
+            },
+            {
+                "description": "Directory containing the output of the participants analysis.",
+                "id": "participant_level_analysis_dir",
+                "name": "Participants dir",
+                "optional": true,
+                "type": "File",
+                "value-key": "OUTPUT_DIR"
+            },
+            {
+                "description": "Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel).",
+                "id": "analysis_level",
+                "name": "Analysis level",
+                "type": "String",
+                "value-choices": [
+                    "participant",
+                    "group"
+                ],
+                "value-key": "ANALYSIS_LEVEL"
+            },
+            {
+                "command-line-flag": "--participant_label",
+                "description": "The label(s) of the participant(s) that should be analyzed. The label corresponds to sub-<participant_label> from the BIDS spec (so it does not include \"sub-\"). If this parameter is not provided all subjects will be analyzed. Multiple participants can be specified with a space separated list.",
+                "id": "participant_label",
+                "list": true,
+                "name": "Participant label",
+                "optional": true,
+                "type": "String",
+                "value-key": "PARTICIPANT_LABEL"
+            },
+            {
+                "command-line-flag": "--session_label",
+                "description": "The label(s) of the session(s) that should be analyzed. The label corresponds to ses-<session_label>, an extension of the BIDS spec (so it does not include \"ses-\"). If this parameter is not provided all sessions will be analyzed. Multiple sessions can be specified with a space separated list.",
+                "id": "session_label",
+                "list": true,
+                "name": "Session label",
+                "optional": true,
+                "type": "String",
+                "value-key": "SESSION_LABEL"
+            }
+        ],
+        "invocation-schema": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "anyOf": [
+                        {
+                            "required": [
+                                "output_dir_name"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "participant_level_analysis_dir"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "dependencies": {
+                "output_dir_name": {
+                    "properties": {
+                        "participant_level_analysis_dir": {
+                            "not": {}
+                        }
+                    }
+                },
+                "participant_level_analysis_dir": {
+                    "properties": {
+                        "output_dir_name": {
+                            "not": {}
+                        }
+                    }
+                }
+            },
+            "description": "Invocation schema for example.",
+            "properties": {
+                "analysis_level": {
+                    "enum": [
+                        "participant",
+                        "group",
+                        "session"
+                    ]
+                },
+                "bids_dir": {
+                    "type": "string"
+                },
+                "output_dir_name": {
+                    "type": "string"
+                },
+                "participant_label": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "participant_level_analysis_dir": {
+                    "type": "string"
+                },
+                "session_label": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "bids_dir",
+                "analysis_level"
+            ],
+            "title": "example.invocationSchema",
+            "type": "object"
+        },
+        "name": "BIDS app example",
+        "output-files": [
+            {
+                "description": "The directory where the output files should be stored. If you are running a group level analysis, this folder should be prepopulated with the results of the participant level analysis.",
+                "id": "output_dir",
+                "name": "Output directory",
+                "optional": false,
+                "path-template": "OUTPUT_DIR"
+            }
+        ],
+        "schema-version": "0.5",
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "testing"
+            ]
+        },
+        "tool-version": "dev"
+    },
+    {
+        "command-line": "fmriprep [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [VERSION] [PARTICIPANT_LABEL] [TASK_ID] [NTHREADS] [OMP_NTHREADS] [MEM_MB] [LOW_MEM] [USE_PLUGIN] [ANAT_ONLY] [BOILERPLATE] [IGNORE_AROMA_DENOISING_ERRORS] [VERBOSE_COUNT] [DEBUG] [IGNORE] [LONGITUDINAL] [T2S_COREG] [BOLD2T1W_DOF] [OUTPUT_SPACE] [USE_BBR] [TEMPLATE] [OUTPUT_GRID_REFERENCE] [TEMPLATE_RESAMPLING_GRID] [MEDIAL_SURFACE_NAN] [USE_AROMA] [AROMA_MELODIC_DIMENSIONALITY] [SKULL_STRIP_TEMPLATE] [SKULL_STRIP_FIXED_SEED] [FMAP_BSPLINE] [FMAP_NO_DEMEAN] [USE_SYN_SDC] [FORCE_SYN] [FS_LICENSE_FILE] [HIRES] [CIFTI_OUTPUT] [RUN_RECONALL] [WORK_DIR] [RESOURCE_MONITOR] [REPORTS_ONLY] [RUN_UUID] [WRITE_GRAPH] [STOP_ON_FIRST_CRASH] [NOTRACK] [SLOPPY]",
+        "description": "fMRIprep is a functional magneticresonance image pre-processing pipeline that is designed to provide an easily accessible, state-of-the-art interface that is robust to differences in scan acquisition protocols and that requires minimal user input, while providing easily interpretable and comprehensive error and output reporting. https://fmriprep.readthedocs.io",
+        "author": "Poldrack lab",
+        "url": "https://fmriprep.readthedocs.io",
+        "inputs": [
+            {
+                "description": "the root folder of a BIDS valid dataset (sub-XXXXX folders should be found at the top level in this folder).",
+                "id": "bids_dir",
+                "name": "bids_dir",
+                "optional": false,
+                "type": "String",
+                "value-key": "[BIDS_DIR]"
+            },
+            {
+                "description": "the output path for the outcomes of preprocessing and visual reports",
+                "id": "output_dir",
+                "name": "output_dir",
+                "optional": false,
+                "type": "String",
+                "value-key": "[OUTPUT_DIR]"
+            },
+            {
+                "description": "processing stage to be run, only \"participant\" in the case of FMRIPREP (see BIDS-Apps specification).",
+                "id": "analysis_level",
+                "name": "analysis_level",
+                "optional": false,
+                "type": "String",
+                "value-choices": [
+                    "participant"
+                ],
+                "value-key": "[ANALYSIS_LEVEL]"
+            },
+            {
+                "command-line-flag": "--version",
+                "default-value": "==SUPPRESS==",
+                "description": "show program's version number and exit",
+                "id": "version",
+                "name": "version",
+                "optional": true,
+                "type": "String",
+                "value-key": "[VERSION]"
+            },
+            {
+                "command-line-flag": "--participant_label",
+                "description": "a space delimited list of participant identifiers or a single identifier (the sub- prefix can be removed)",
+                "id": "participant_label",
+                "list": true,
+                "name": "participant_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[PARTICIPANT_LABEL]"
+            },
+            {
+                "command-line-flag": "-t",
+                "description": "select a specific task to be processed",
+                "id": "task_id",
+                "name": "task_id",
+                "optional": true,
+                "type": "String",
+                "value-key": "[TASK_ID]"
+            },
+            {
+                "command-line-flag": "--nthreads",
+                "description": "maximum number of threads across all processes",
+                "id": "nthreads",
+                "name": "nthreads",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[NTHREADS]"
+            },
+            {
+                "command-line-flag": "--omp-nthreads",
+                "description": "maximum number of threads per-process",
+                "id": "omp_nthreads",
+                "name": "omp_nthreads",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[OMP_NTHREADS]"
+            },
+            {
+                "command-line-flag": "--mem_mb",
+                "description": "upper bound memory limit for FMRIPREP processes",
+                "id": "mem_mb",
+                "name": "mem_mb",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[MEM_MB]"
+            },
+            {
+                "command-line-flag": "--low-mem",
+                "description": "attempt to reduce memory usage (will increase disk usage in working directory)",
+                "id": "low_mem",
+                "name": "low_mem",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[LOW_MEM]"
+            },
+            {
+                "command-line-flag": "--use-plugin",
+                "description": "nipype plugin configuration file",
+                "id": "use_plugin",
+                "name": "use_plugin",
+                "optional": true,
+                "type": "String",
+                "value-key": "[USE_PLUGIN]"
+            },
+            {
+                "command-line-flag": "--anat-only",
+                "description": "run anatomical workflows only",
+                "id": "anat_only",
+                "name": "anat_only",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[ANAT_ONLY]"
+            },
+            {
+                "command-line-flag": "--boilerplate",
+                "description": "generate boilerplate only",
+                "id": "boilerplate",
+                "name": "boilerplate",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[BOILERPLATE]"
+            },
+            {
+                "command-line-flag": "--ignore-aroma-denoising-errors",
+                "description": "ignores the errors ICA_AROMA returns when there are no components classified as either noise or signal",
+                "id": "ignore_aroma_denoising_errors",
+                "name": "ignore_aroma_denoising_errors",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[IGNORE_AROMA_DENOISING_ERRORS]"
+            },
+            {
+                "command-line-flag": "-v",
+                "description": "increases log verbosity for each occurence, debug level is -vvv",
+                "id": "verbose_count",
+                "name": "verbose_count",
+                "optional": true,
+                "type": "String",
+                "value-key": "[VERBOSE_COUNT]"
+            },
+            {
+                "command-line-flag": "--debug",
+                "description": "DEPRECATED - Does not do what you want.",
+                "id": "debug",
+                "name": "debug",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[DEBUG]"
+            },
+            {
+                "command-line-flag": "--ignore",
+                "description": "ignore selected aspects of the input dataset to disable corresponding parts of the workflow (a space delimited list)",
+                "id": "ignore",
+                "list": true,
+                "name": "ignore",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "fieldmaps",
+                    "slicetiming",
+                    "sbref"
+                ],
+                "value-key": "[IGNORE]"
+            },
+            {
+                "command-line-flag": "--longitudinal",
+                "description": "treat dataset as longitudinal - may increase runtime",
+                "id": "longitudinal",
+                "name": "longitudinal",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[LONGITUDINAL]"
+            },
+            {
+                "command-line-flag": "--t2s-coreg",
+                "description": "If provided with multi-echo BOLD dataset, create T2*-map and perform T2*-driven coregistration. When multi-echo data is provided and this option is not enabled, standard EPI-T1 coregistration is performed using the middle echo.",
+                "id": "t2s_coreg",
+                "name": "t2s_coreg",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[T2S_COREG]"
+            },
+            {
+                "command-line-flag": "--bold2t1w-dof",
+                "default-value": 6,
+                "description": "Degrees of freedom when registering BOLD to T1w images. 6 degrees (rotation and translation) are used by default.",
+                "id": "bold2t1w_dof",
+                "name": "bold2t1w_dof",
+                "optional": true,
+                "type": "Number",
+                "value-choices": [
+                    6,
+                    9,
+                    12
+                ],
+                "value-key": "[BOLD2T1W_DOF]"
+            },
+            {
+                "command-line-flag": "--output-space",
+                "default-value": [
+                    "template",
+                    "fsaverage5"
+                ],
+                "description": "volume and surface spaces to resample functional series into\n - T1w: subject anatomical volume\n - template: normalization target specified by --template\n - fsnative: individual subject surface\n - fsaverage*: FreeSurfer average meshes\nthis argument can be single value or a space delimited list,\nfor example: --output-space T1w fsnative",
+                "id": "output_space",
+                "list": true,
+                "name": "output_space",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "T1w",
+                    "template",
+                    "fsnative",
+                    "fsaverage",
+                    "fsaverage6",
+                    "fsaverage5"
+                ],
+                "value-key": "[OUTPUT_SPACE]"
+            },
+            {
+                "command-line-flag": "--force-bbr",
+                "description": "Always use boundary-based registration (no goodness-of-fit checks)",
+                "id": "use_bbr",
+                "name": "use_bbr",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[USE_BBR]"
+            },
+            {
+                "command-line-flag": "--template",
+                "default-value": "MNI152NLin2009cAsym",
+                "description": "volume template space (default: MNI152NLin2009cAsym)",
+                "id": "template",
+                "name": "template",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "MNI152NLin2009cAsym"
+                ],
+                "value-key": "[TEMPLATE]"
+            },
+            {
+                "command-line-flag": "--output-grid-reference",
+                "description": "Deprecated after FMRIPREP 1.0.8. Please use --template-resampling-grid instead.",
+                "id": "output_grid_reference",
+                "name": "output_grid_reference",
+                "optional": true,
+                "type": "String",
+                "value-key": "[OUTPUT_GRID_REFERENCE]"
+            },
+            {
+                "command-line-flag": "--template-resampling-grid",
+                "default-value": "native",
+                "description": "Keyword (\"native\", \"1mm\", or \"2mm\") or path to an existing file. Allows to define a reference grid for the resampling of BOLD images in template space. Keyword \"native\" will use the original BOLD grid as reference. Keywords \"1mm\" and \"2mm\" will use the corresponding isotropic template resolutions. If a path is given, the grid of that image will be used. It determines the field of view and resolution of the output images, but is not used in normalization.",
+                "id": "template_resampling_grid",
+                "name": "template_resampling_grid",
+                "optional": true,
+                "type": "String",
+                "value-key": "[TEMPLATE_RESAMPLING_GRID]"
+            },
+            {
+                "command-line-flag": "--medial-surface-nan",
+                "description": "Replace medial wall values with NaNs on functional GIFTI files. Only performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).",
+                "id": "medial_surface_nan",
+                "name": "medial_surface_nan",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[MEDIAL_SURFACE_NAN]"
+            },
+            {
+                "command-line-flag": "--use-aroma",
+                "description": "add ICA_AROMA to your preprocessing stream",
+                "id": "use_aroma",
+                "name": "use_aroma",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[USE_AROMA]"
+            },
+            {
+                "command-line-flag": "--aroma-melodic-dimensionality",
+                "default-value": -200,
+                "description": "Exact or maximum number of MELODIC components to estimate (positive = exact, negative = maximum)",
+                "id": "aroma_melodic_dimensionality",
+                "name": "aroma_melodic_dimensionality",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[AROMA_MELODIC_DIMENSIONALITY]"
+            },
+            {
+                "command-line-flag": "--skull-strip-template",
+                "default-value": "OASIS",
+                "description": "select ANTs skull-stripping template (default: OASIS))",
+                "id": "skull_strip_template",
+                "name": "skull_strip_template",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "OASIS",
+                    "NKI"
+                ],
+                "value-key": "[SKULL_STRIP_TEMPLATE]"
+            },
+            {
+                "command-line-flag": "--skull-strip-fixed-seed",
+                "description": "do not use a random seed for skull-stripping - will ensure run-to-run replicability when used with --omp-nthreads 1",
+                "id": "skull_strip_fixed_seed",
+                "name": "skull_strip_fixed_seed",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[SKULL_STRIP_FIXED_SEED]"
+            },
+            {
+                "command-line-flag": "--fmap-bspline",
+                "description": "fit a B-Spline field using least-squares (experimental)",
+                "id": "fmap_bspline",
+                "name": "fmap_bspline",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[FMAP_BSPLINE]"
+            },
+            {
+                "command-line-flag": "--fmap-no-demean",
+                "default-value": true,
+                "description": "do not remove median (within mask) from fieldmap",
+                "id": "fmap_no_demean",
+                "name": "fmap_no_demean",
+                "optional": true,
+                "type": "String",
+                "value-key": "[FMAP_NO_DEMEAN]"
+            },
+            {
+                "command-line-flag": "--use-syn-sdc",
+                "description": "EXPERIMENTAL: Use fieldmap-free distortion correction",
+                "id": "use_syn_sdc",
+                "name": "use_syn_sdc",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[USE_SYN_SDC]"
+            },
+            {
+                "command-line-flag": "--force-syn",
+                "description": "EXPERIMENTAL/TEMPORARY: Use SyN correction in addition to fieldmap correction, if available",
+                "id": "force_syn",
+                "name": "force_syn",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[FORCE_SYN]"
+            },
+            {
+                "command-line-flag": "--fs-license-file",
+                "description": "Path to FreeSurfer license key file. Get it (for free) by registering at https://surfer.nmr.mgh.harvard.edu/registration.html",
+                "id": "fs_license_file",
+                "name": "fs_license_file",
+                "optional": true,
+                "uses-absolute-path": true,
+                "type": "File",
+                "value-key": "[FS_LICENSE_FILE]"
+            },
+            {
+                "command-line-flag": "--no-submm-recon",
+                "default-value": true,
+                "description": "disable sub-millimeter (hires) reconstruction",
+                "id": "hires",
+                "name": "hires",
+                "optional": true,
+                "type": "String",
+                "value-key": "[HIRES]"
+            },
+            {
+                "command-line-flag": "--cifti-output",
+                "description": "output BOLD files as CIFTI dtseries",
+                "id": "cifti_output",
+                "name": "cifti_output",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[CIFTI_OUTPUT]"
+            },
+            {
+                "command-line-flag": "--fs-no-reconall",
+                "default-value": true,
+                "description": "disable FreeSurfer surface preprocessing. Note : `--no-freesurfer` is deprecated and will be removed in 1.2. Use `--fs-no-reconall` instead.",
+                "id": "run_reconall",
+                "name": "run_reconall",
+                "optional": true,
+                "type": "String",
+                "value-key": "[RUN_RECONALL]"
+            },
+            {
+                "command-line-flag": "-w",
+                "description": "path where intermediate results should be stored",
+                "id": "work_dir",
+                "name": "work_dir",
+                "optional": true,
+                "type": "String",
+                "value-key": "[WORK_DIR]"
+            },
+            {
+                "command-line-flag": "--resource-monitor",
+                "description": "enable Nipype's resource monitoring to keep track of memory and CPU usage",
+                "id": "resource_monitor",
+                "name": "resource_monitor",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[RESOURCE_MONITOR]"
+            },
+            {
+                "command-line-flag": "--reports-only",
+                "description": "only generate reports, don't run workflows. This will only rerun report aggregation, not reportlet generation for specific nodes.",
+                "id": "reports_only",
+                "name": "reports_only",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[REPORTS_ONLY]"
+            },
+            {
+                "command-line-flag": "--run-uuid",
+                "description": "Specify UUID of previous run, to include error logs in report. No effect without --reports-only.",
+                "id": "run_uuid",
+                "name": "run_uuid",
+                "optional": true,
+                "type": "String",
+                "value-key": "[RUN_UUID]"
+            },
+            {
+                "command-line-flag": "--write-graph",
+                "description": "Write workflow graph.",
+                "id": "write_graph",
+                "name": "write_graph",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[WRITE_GRAPH]"
+            },
+            {
+                "command-line-flag": "--stop-on-first-crash",
+                "description": "Force stopping on first crash, even if a work directory was specified.",
+                "id": "stop_on_first_crash",
+                "name": "stop_on_first_crash",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[STOP_ON_FIRST_CRASH]"
+            },
+            {
+                "command-line-flag": "--notrack",
+                "description": "Opt-out of sending tracking information of this run to the FMRIPREP developers. This information helps to improve FMRIPREP and provides an indicator of real world usage crucial for obtaining funding.",
+                "id": "notrack",
+                "name": "notrack",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[NOTRACK]"
+            },
+            {
+                "command-line-flag": "--sloppy",
+                "description": "Use low-quality tools for speed - TESTING ONLY",
+                "id": "sloppy",
+                "name": "sloppy",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[SLOPPY]"
+            }
+        ],
+        "name": "BIDS App - fmriprep",
+        "schema-version": "0.5",
+        "tags": {
+            "application-type": [
+                "bids"
+            ],
+            "domain": [
+                "neuroinformatics",
+                "fmri"
+            ]
+        },
+        "container-image": {
+            "type": "docker",
+            "image": "poldracklab/fmriprep:1.2.3"
+        },
+        "tool-version": "1.2.3"
+    },
+    {
+        "tool-version": "v2.7.1",
+        "description": "Stand-alone BLAST formatter client, version 2.7.1+",
+        "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/blast_formatter [RID] [ARCHIVE] [OUTFORMAT] [fSHOWGIS] [NUM_DESCRIPTIONS] [NUM_ALIGNMENTS] [LINE_LENGTH] [fHTML] [MAX_TARGET_SEQS] [OUT] [fPARSE_DEFLINES]",
+        "author": "Altschul et al.",
+        "tags": {
+            "domain": [
+                "bioinformatics",
+                "blast"
+            ]
+        },
+        "container-image": {
+            "index": "docker://",
+            "image": "c3genomics/genpipes",
+            "type": "singularity"
+        },
+        "inputs": [
+            {
+                "command-line-flag": "-show_gis",
+                "description": "Show NCBI GIs in deflines?",
+                "value-key": "[fSHOWGIS]",
+                "optional": true,
+                "type": "Flag",
+                "id": "show_gis",
+                "name": "Show NCBI GIs"
+            },
+            {
+                "command-line-flag": "-html",
+                "description": "Produce HTML Output",
+                "value-key": "[fHTML]",
+                "optional": true,
+                "type": "Flag",
+                "id": "html",
+                "name": "Show HTML"
+            },
+            {
+                "command-line-flag": "-parse_deflines",
+                "description": "Should the query and subject defline(s) be parsed?",
+                "value-key": "[fPARSE_DEFLINES]",
+                "optional": true,
+                "type": "Flag",
+                "id": "parse_deflines",
+                "name": "Parse Deflines"
+            },
+            {
+                "command-line-flag": "-rid",
+                "description": "BLAST Request ID (RID)",
+                "disables-inputs": [
+                    "archive"
+                ],
+                "optional": true,
+                "value-key": "[RID]",
+                "type": "String",
+                "id": "rid",
+                "name": "BLAST Request ID"
+            },
+            {
+                "command-line-flag": "-archive",
+                "description": "File containing BLAST Archive format in ASN.1 (i.e.: output format 11)",
+                "value-key": "[ARCHIVE]",
+                "optional": true,
+                "type": "File",
+                "id": "archive",
+                "name": "Blast Archive File"
+            },
+            {
+                "command-line-flag": "-outfmt",
+                "description": "   alignment view options:\n     0 = Pairwise,\n     1 = Query-anchored showing identities,\n     2 = Query-anchored no identities,\n     3 = Flat query-anchored showing identities,\n     4 = Flat query-anchored no identities,\n     5 = BLAST XML,\n     6 = Tabular,\n     7 = Tabular with comment lines,\n     8 = Seqalign (Text ASN.1),\n     9 = Seqalign (Binary ASN.1),\n    10 = Comma-separated values,\n    11 = BLAST archive (ASN.1),\n    12 = Seqalign (JSON),\n    13 = Multiple-file BLAST JSON,\n    14 = Multiple-file BLAST XML2,\n    15 = Single-file BLAST JSON,\n    16 = Single-file BLAST XML2,\n    17 = Sequence Alignment/Map (SAM),\n    18 = Organism Report\n\n   Options 6, 7, 10 and 17 can be additionally configured to produce\n   a custom format specified by space delimited format specifiers.\n   The supported format specifiers for options 6, 7 and 10 are:\n            qseqid means Query Seq-id\n               qgi means Query GI\n              qacc means Query accesion\n           qaccver means Query accesion.version\n              qlen means Query sequence length\n            sseqid means Subject Seq-id\n         sallseqid means All subject Seq-id(s), separated by a ';'\n               sgi means Subject GI\n            sallgi means All subject GIs\n              sacc means Subject accession\n           saccver means Subject accession.version\n           sallacc means All subject accessions\n              slen means Subject sequence length\n            qstart means Start of alignment in query\n              qend means End of alignment in query\n            sstart means Start of alignment in subject\n              send means End of alignment in subject\n              qseq means Aligned part of query sequence\n              sseq means Aligned part of subject sequence\n            evalue means Expect value\n          bitscore means Bit score\n             score means Raw score\n            length means Alignment length\n            pident means Percentage of identical matches\n            nident means Number of identical matches\n          mismatch means Number of mismatches\n          positive means Number of positive-scoring matches\n           gapopen means Number of gap openings\n              gaps means Total number of gaps\n              ppos means Percentage of positive-scoring matches\n            frames means Query and subject frames separated by a '/'\n            qframe means Query frame\n            sframe means Subject frame\n              btop means Blast traceback operations (BTOP)\n            staxid means Subject Taxonomy ID\n          ssciname means Subject Scientific Name\n          scomname means Subject Common Name\n        sblastname means Subject Blast Name\n         sskingdom means Subject Super Kingdom\n           staxids means unique Subject Taxonomy ID(s), separated by a ';'\n                         (in numerical order)\n         sscinames means unique Subject Scientific Name(s), separated by a ';'\n         scomnames means unique Subject Common Name(s), separated by a ';'\n        sblastnames means unique Subject Blast Name(s), separated by a ';'\n                         (in alphabetical order)\n        sskingdoms means unique Subject Super Kingdom(s), separated by a ';'\n                         (in alphabetical order)\n            stitle means Subject Title\n        salltitles means All Subject Title(s), separated by a '<>'\n           sstrand means Subject Strand\n             qcovs means Query Coverage Per Subject\n           qcovhsp means Query Coverage Per HSP\n            qcovus means Query Coverage Per Unique Subject (blastn only)\n   When not provided, the default value is:\n   'qaccver saccver pident length mismatch gapopen qstart qend sstart send\n   evalue bitscore', which is equivalent to the keyword 'std'\n   The supported format specifier for option 17 is:\n                SQ means Include Sequence Data\n                SR means Subject as Reference Seq\n  Default = `0'",
+                "value-key": "[OUTFORMAT]",
+                "optional": true,
+                "type": "String",
+                "id": "outfmt",
+                "name": "Alignment View Options"
+            },
+            {
+                "command-line-flag": "-num_descriptions",
+                "description": "   Number of database sequences to show one-line descriptions for\n   Not applicable for outfmt > 4\n   Default = `500'",
+                "value-key": "[NUM_DESCRIPTIONS]",
+                "optional": true,
+                "minimum": 0,
+                "type": "Number",
+                "id": "num_descriptions",
+                "name": "Number of Sequence Descriptions to Show"
+            },
+            {
+                "command-line-flag": "-num_alignments",
+                "description": "   Number of database sequences to show alignments for\n   Default = `250'",
+                "value-key": "[NUM_ALIGNMENTS]",
+                "optional": true,
+                "minimum": 0,
+                "type": "Number",
+                "id": "num_alignments",
+                "name": "Number of Sequence Alignments to Show"
+            },
+            {
+                "command-line-flag": "-line_length",
+                "description": "   Line length for formatting alignments\n   Not applicable for outfmt > 4\n   Default = `60'",
+                "value-key": "[LINE_LENGTH]",
+                "optional": true,
+                "minimum": 1,
+                "type": "Number",
+                "id": "line_length",
+                "name": "Line Length"
+            },
+            {
+                "command-line-flag": "-max_target_seqs",
+                "description": "   Maximum number of aligned sequences to keep\n   Not applicable for outfmt <= 4\n   Default = `500'",
+                "value-key": "[MAX_TARGET_SEQS]",
+                "optional": true,
+                "disables-inputs": [
+                    "num_descriptions",
+                    "num_alignments"
+                ],
+                "minimum": 1,
+                "type": "Number",
+                "id": "max_target_seqs",
+                "name": "Maximum Number of Aligned Sequences to Keep"
+            },
+            {
+                "command-line-flag": "-out",
+                "description": "   Output file name",
+                "value-key": "[OUT]",
+                "optional": true,
+                "type": "String",
+                "id": "out",
+                "name": "Output file name"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[OUT]",
+                "optional": false,
+                "id": "output",
+                "name": "Output File"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 60,
+            "ram": 1,
+            "cpu-cores": 1
+        },
+        "name": "blast_formatter"
+    },
+    {
+        "inputs": [
+            {
+                "command-line-flag": "-dbtype",
+                "description": "Molecule type of target db",
+                "value-key": "[DBTYPE]",
+                "optional": true,
+                "value-choices": [
+                    "nucl",
+                    "prot",
+                    "guess"
+                ],
+                "type": "String",
+                "id": "dbtype",
+                "name": "Database Type"
+            },
+            {
+                "command-line-flag": "-db",
+                "description": "Specify a database name",
+                "value-key": "[DB]",
+                "optional": true,
+                "type": "String",
+                "id": "db",
+                "name": "Database Name"
+            },
+            {
+                "command-line-flag": "-dir",
+                "description": "Specify a directory containing one or more databases.",
+                "disables-inputs": [
+                    "db"
+                ],
+                "type": "String",
+                "value-key": "[DIR]",
+                "optional": true,
+                "id": "dir",
+                "name": "Database Directory"
+            },
+            {
+                "command-line-flag": "-recursive",
+                "description": "Specify true to recurse through all dbs in directory tree.",
+                "value-key": "[RECURSIVE]",
+                "type": "Flag",
+                "requires-inputs": [
+                    "dir"
+                ],
+                "optional": true,
+                "id": "recursive",
+                "name": "Blast Archive File"
+            },
+            {
+                "command-line-flag": "-verbosity",
+                "name": "Verbosity",
+                "value-key": "[VERBOSITY]",
+                "type": "Number",
+                "maximum": 4,
+                "minimum": 0,
+                "optional": true,
+                "id": "verbosity",
+                "description": "Verbiosity of results.\n   0=Quiet, 1=Brief, 2=Summary, 3=Detailed, 4=Minutia"
+            },
+            {
+                "command-line-flag": "-full",
+                "description": "If true, test every sequence (warning: may be slow).",
+                "disables-inputs": [
+                    "stride",
+                    "random",
+                    "ends"
+                ],
+                "type": "Flag",
+                "value-key": "[FULL]",
+                "optional": true,
+                "id": "full",
+                "name": "Full Test"
+            },
+            {
+                "command-line-flag": "-stride",
+                "description": "Check integrity of every Nth sequence.",
+                "value-key": "[STRIDE]",
+                "type": "Number",
+                "minimum": 1,
+                "optional": true,
+                "id": "stride",
+                "name": "Stride Sequence Integrity Test"
+            },
+            {
+                "command-line-flag": "-random",
+                "description": "Check this many randomly selected sequences.",
+                "value-key": "[RANDOM]",
+                "type": "Number",
+                "minimum": 1,
+                "optional": true,
+                "id": "random",
+                "name": "Random Sequence Test"
+            },
+            {
+                "command-line-flag": "-ends",
+                "description": "Check this many sequences at each end of the database.",
+                "value-key": "[ENDS]",
+                "type": "Number",
+                "minimum": 1,
+                "optional": true,
+                "id": "ends",
+                "name": "Database End Integrity Test"
+            },
+            {
+                "command-line-flag": "-no_isam",
+                "description": "Disable ISAM testing.",
+                "value-key": "[NO_ISAM]",
+                "optional": true,
+                "type": "Flag",
+                "id": "no_isam",
+                "name": "NO ISAM Testing"
+            },
+            {
+                "command-line-flag": "-legacy",
+                "description": "Enable check for existence of temporary files.",
+                "value-key": "[LEGACY]",
+                "optional": true,
+                "type": "Flag",
+                "id": "legacy",
+                "name": "Legacy temp file existence check"
+            },
+            {
+                "command-line-flag": "-must_have_taxids",
+                "description": "Require that all sequences in the database have taxid set.",
+                "value-key": "[MUST_HAVE_TAXIDS]",
+                "optional": true,
+                "type": "Flag",
+                "id": "must_have_taxids",
+                "name": "Must Have taxid set"
+            },
+            {
+                "command-line-flag": "-cdd_delta",
+                "description": "Do aditional tests for a CDD database for DELTA-BLAST",
+                "value-key": "[CDD_DELTA]",
+                "optional": true,
+                "type": "Flag",
+                "id": "cdd_delta",
+                "name": "Do CDD database tests for DELTA-BLAST"
+            }
+        ],
+        "description": "BLAST database integrity and validity checking application",
+        "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/blastdbcheck [DB] [DBTYPE] [DIR] [RECURSIVE] [VERBOSITY] [FULL] [STRIDE] [RANDOM] [ENDS] [NO_ISAM] [LEGACY] [MUST_HAVE_TAXIDS] [CDD_DELTA]",
+        "author": "Altschul et al.",
+        "tool-version": "v2.7.1",
+        "tags": {
+            "domain": [
+                "bioinformatics",
+                "blast"
+            ]
+        },
+        "container-image": {
+            "index": "docker://",
+            "image": "c3genomics/genpipes",
+            "type": "singularity"
+        },
+        "schema-version": "0.5",
+        "suggested-resources": {
+            "walltime-estimate": 60,
+            "ram": 1,
+            "cpu-cores": 1
+        },
+        "name": "blastdbcheck"
+    },
+    {
+        "author": "Shawn T. Brown, McGill University <stbrown@mcin.ca>",
+        "command-line": "mkdir -p [OUTPUT_DIR] ; /run.py [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [PARTICIPANT_LABEL] [SESSION_LABEL] [N_CPUS] [STAGES] [STEPS] [TEMPLATE_NAME] [LICENSE_FILE] [ACQUISITION_LABEL] [REFINE_PIAL_ACQUISITION_LABEL] [MULTIPLE_SESSIONS] [REFINE_PIAL] [HIRES_MODE] [PARCELLATIONS] [MEASUREMENTS] [VERSION] [BIDS_VALIDATOR_CONFIG] [SKIP_BIDS_VALIDATOR] [3T]",
+        "container-image": {
+            "image": "shots47s/bids-freesurfer-6.0",
+            "type": "singularity"
+        },
+        "description": "BIDS App version of freesurfer 6.0, from https://github.com/BIDS-Apps/freesurfer, see the readme there for more details, note it needs a license file to run",
+        "groups": [
+            {
+                "description": "For a participants analysis, an output directory name must be specified. For a group analysis, a directory containing the output of participant-level analyses must be selected. ",
+                "id": "output_directory",
+                "members": [
+                    "output_dir",
+                    "participant_level_analysis_dir"
+                ],
+                "mutually-exclusive": true,
+                "name": "Output Directory",
+                "one-is-required": true
+            }
+        ],
+        "inputs": [
+            {
+                "description": "The directory with the input dataset formatted according to the BIDS standard.",
+                "id": "bids_dir",
+                "name": "bids_dir",
+                "optional": false,
+                "type": "String",
+                "value-key": "[BIDS_DIR]"
+            },
+            {
+                "description": "The directory where the output files should be stored. If you are running group level analysis this folder should be prepopulated with the results of theparticipant level analysis.",
+                "id": "output_dir",
+                "name": "output_dir",
+                "optional": true,
+                "type": "String",
+                "value-key": "[OUTPUT_DIR]"
+            },
+            {
+                "description": "Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel) using the same output_dir. \"group1\" creates study specific group template. \"group2\" exports group stats tables for cortical parcellation, subcortical segmentation a table with euler numbers.",
+                "id": "analysis_level",
+                "name": "analysis_level",
+                "optional": false,
+                "type": "String",
+                "value-choices": [
+                    "participant",
+                    "group1",
+                    "group2"
+                ],
+                "value-key": "[ANALYSIS_LEVEL]"
+            },
+            {
+                "command-line-flag": "--participant_label",
+                "description": "The label of the participant that should be analyzed. The label corresponds to sub-<participant_label> from the BIDS spec (so it does not include \"sub-\"). If this parameter is not provided all subjects should be analyzed. Multiple participants can be specified with a space separated list.",
+                "id": "participant_label",
+                "list": true,
+                "name": "participant_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[PARTICIPANT_LABEL]"
+            },
+            {
+                "command-line-flag": "--session_label",
+                "description": "The label of the session that should be analyzed. The label corresponds to ses-<session_label> from the BIDS spec (so it does not include \"ses-\"). If this parameter is not provided all sessions should be analyzed. Multiple sessions can be specified with a space separated list.",
+                "id": "session_label",
+                "list": true,
+                "name": "session_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[SESSION_LABEL]"
+            },
+            {
+                "command-line-flag": "--n_cpus",
+                "default-value": 1,
+                "description": "Number of CPUs/cores available to use.",
+                "id": "n_cpus",
+                "name": "n_cpus",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[N_CPUS]"
+            },
+            {
+                "command-line-flag": "--stages",
+                "default-value": [
+                    "autorecon-all"
+                ],
+                "description": "Autorecon stages to run.",
+                "id": "stages",
+                "list": true,
+                "name": "stages",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "autorecon1",
+                    "autorecon2",
+                    "autorecon2-cp",
+                    "autorecon2-wm",
+                    "autorecon-pial",
+                    "autorecon3",
+                    "autorecon-all",
+                    "all"
+                ],
+                "value-key": "[STAGES]"
+            },
+            {
+                "command-line-flag": "--steps",
+                "default-value": [
+                    "cross-sectional",
+                    "template",
+                    "longitudinal"
+                ],
+                "description": "Longitudinal pipeline steps to run.",
+                "id": "steps",
+                "list": true,
+                "name": "steps",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "cross-sectional",
+                    "template",
+                    "longitudinal"
+                ],
+                "value-key": "[STEPS]"
+            },
+            {
+                "command-line-flag": "--template_name",
+                "default-value": "average",
+                "description": "Name for the custom group level template generated for this dataset",
+                "id": "template_name",
+                "name": "template_name",
+                "optional": true,
+                "type": "String",
+                "value-key": "[TEMPLATE_NAME]"
+            },
+            {
+                "command-line-flag": "--license_file",
+                "description": "Path to FreeSurfer license key file. To obtain it you need to register (for free) at https://surfer.nmr.mgh.harvard.edu/registration.html",
+                "id": "license_file",
+                "name": "license_file",
+                "optional": false,
+                "type": "String",
+                "value-key": "[LICENSE_FILE]"
+            },
+            {
+                "command-line-flag": "--acquisition_label",
+                "description": "If the dataset contains multiple T1 weighted images from different acquisitions which one should be used? Corresponds to \"acq-<acquisition_label>\"",
+                "id": "acquisition_label",
+                "name": "acquisition_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[ACQUISITION_LABEL]"
+            },
+            {
+                "command-line-flag": "--refine_pial_acquisition_label",
+                "description": "If the dataset contains multiple T2 or FLAIR weighted images from different acquisitions which one should be used? Corresponds to \"acq-<acquisition_label>\"",
+                "id": "refine_pial_acquisition_label",
+                "name": "refine_pial_acquisition_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[REFINE_PIAL_ACQUISITION_LABEL]"
+            },
+            {
+                "command-line-flag": "--multiple_sessions",
+                "default-value": "longitudinal",
+                "description": "For datasets with multiday sessions where you do not want to use the longitudinal pipeline, i.e., sessions were back-to-back, set this to multiday, otherwise sessions with T1w data will be considered independent sessions for longitudinal analysis.",
+                "id": "multiple_sessions",
+                "name": "multiple_sessions",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "longitudinal",
+                    "multiday"
+                ],
+                "value-key": "[MULTIPLE_SESSIONS]"
+            },
+            {
+                "command-line-flag": "--refine_pial",
+                "default-value": [
+                    "T2"
+                ],
+                "description": "If the dataset contains 3D T2 or T2 FLAIR weighted images (~1x1x1), these can be used to refine the pial surface. If you want to ignore these, specify None or  T1only to base surfaces on the T1 alone.",
+                "id": "refine_pial",
+                "name": "refine_pial",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "T2",
+                    "FLAIR",
+                    "None",
+                    "T1only"
+                ],
+                "value-key": "[REFINE_PIAL]"
+            },
+            {
+                "command-line-flag": "--hires_mode",
+                "default-value": "auto",
+                "description": "Submilimiter (high resolution) processing. 'auto' - use only if <1.0mm data detected, 'enable' - force on, 'disable' - force off",
+                "id": "hires_mode",
+                "name": "hires_mode",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "auto",
+                    "enable",
+                    "disable"
+                ],
+                "value-key": "[HIRES_MODE]"
+            },
+            {
+                "command-line-flag": "--parcellations",
+                "default-value": [
+                    "aparc"
+                ],
+                "description": "Group2 option: cortical parcellation(s) to extract stats from.",
+                "id": "parcellations",
+                "list": true,
+                "name": "parcellations",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "aparc",
+                    "aparc.a2009s"
+                ],
+                "value-key": "[PARCELLATIONS]"
+            },
+            {
+                "command-line-flag": "--measurements",
+                "default-value": [
+                    "thickness"
+                ],
+                "description": "Group2 option: cortical measurements to extract stats for.",
+                "id": "measurements",
+                "list": true,
+                "name": "measurements",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "area",
+                    "volume",
+                    "thickness",
+                    "thicknessstd",
+                    "meancurv",
+                    "gauscurv",
+                    "foldind",
+                    "curvind"
+                ],
+                "value-key": "[MEASUREMENTS]"
+            },
+            {
+                "command-line-flag": "-v",
+                "default-value": "==SUPPRESS==",
+                "description": "show program's version number and exit",
+                "id": "version",
+                "name": "version",
+                "optional": true,
+                "type": "String",
+                "value-key": "[VERSION]"
+            },
+            {
+                "command-line-flag": "--bids_validator_config",
+                "description": "JSON file specifying configuration of bids-validator: See https://github.com/INCF/bids-validator for more info",
+                "id": "bids_validator_config",
+                "name": "bids_validator_config",
+                "optional": true,
+                "type": "String",
+                "value-key": "[BIDS_VALIDATOR_CONFIG]"
+            },
+            {
+                "command-line-flag": "--skip_bids_validator",
+                "description": "skips bids validation",
+                "id": "skip_bids_validator",
+                "name": "skip_bids_validator",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[SKIP_BIDS_VALIDATOR]"
+            },
+            {
+                "command-line-flag": "--3T",
+                "default-value": "true",
+                "description": "enables the two 3T specific options that recon-all supports: nu intensity correction params, and the special schwartz atlas",
+                "id": "3T",
+                "name": "3T",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "value-key": "[3T]"
+            },
+            {
+                "description": "Directory containing the output of the participants analysis.",
+                "id": "participant_level_analysis_dir",
+                "name": "Participants dir",
+                "optional": true,
+                "type": "File",
+                "value-key": "[OUTPUT_DIR]"
+            }
+        ],
+        "invocation-schema": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "anyOf": [
+                        {
+                            "required": [
+                                "output_dir"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "participant_level_analysis_dir"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "dependencies": {
+                "output_dir": {
+                    "properties": {
+                        "participant_level_analysis_dir": {
+                            "not": {}
+                        }
+                    }
+                },
+                "participant_level_analysis_dir": {
+                    "properties": {
+                        "output_dir": {
+                            "not": {}
+                        }
+                    }
+                }
+            },
+            "description": "Invocation schema for tool name.",
+            "properties": {
+                "3T": {
+                    "enum": [
+                        "true",
+                        "false"
+                    ]
+                },
+                "acquisition_label": {
+                    "type": "string"
+                },
+                "analysis_level": {
+                    "enum": [
+                        "participant",
+                        "group1",
+                        "group2"
+                    ]
+                },
+                "bids_dir": {
+                    "type": "string"
+                },
+                "bids_validator_config": {
+                    "type": "string"
+                },
+                "hires_mode": {
+                    "enum": [
+                        "auto",
+                        "enable",
+                        "disable"
+                    ]
+                },
+                "license_file": {
+                    "type": "string"
+                },
+                "measurements": {
+                    "items": {
+                        "enum": [
+                            "area",
+                            "volume",
+                            "thickness",
+                            "thicknessstd",
+                            "meancurv",
+                            "gauscurv",
+                            "foldind",
+                            "curvind"
+                        ]
+                    },
+                    "type": "array"
+                },
+                "multiple_sessions": {
+                    "enum": [
+                        "longitudinal",
+                        "multiday"
+                    ]
+                },
+                "n_cpus": {
+                    "type": "number"
+                },
+                "output_dir": {
+                    "type": "string"
+                },
+                "parcellations": {
+                    "items": {
+                        "enum": [
+                            "aparc",
+                            "aparc.a2009s"
+                        ]
+                    },
+                    "type": "array"
+                },
+                "participant_label": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "participant_level_analysis_dir": {
+                    "type": "string"
+                },
+                "refine_pial": {
+                    "enum": [
+                        "T2",
+                        "FLAIR",
+                        "None",
+                        "T1only"
+                    ]
+                },
+                "refine_pial_acquisition_label": {
+                    "type": "string"
+                },
+                "session_label": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "skip_bids_validator": {
+                    "type": "boolean"
+                },
+                "stages": {
+                    "items": {
+                        "enum": [
+                            "autorecon1",
+                            "autorecon2",
+                            "autorecon2-cp",
+                            "autorecon2-wm",
+                            "autorecon-pial",
+                            "autorecon3",
+                            "autorecon-all",
+                            "all"
+                        ]
+                    },
+                    "type": "array"
+                },
+                "steps": {
+                    "items": {
+                        "enum": [
+                            "cross-sectional",
+                            "template",
+                            "longitudinal"
+                        ]
+                    },
+                    "type": "array"
+                },
+                "template_name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "bids_dir",
+                "analysis_level",
+                "license_file"
+            ],
+            "title": "tool name.invocationSchema",
+            "type": "object"
+        },
+        "name": "BIDS App - FreeSurfer 6.0",
+        "schema-version": "0.5",
+        "suggested-resources": {
+            "cpu-cores": 1,
+            "ram": 1,
+            "walltime-estimate": 60
+        },
+        "tags": {},
+        "tool-version": "v6.0.0"
+    },
+    {
+        "tool-version": "0.3.1",
+        "name": "ICA_AROMA",
+        "author": "Maarten Mennes",
+        "command-line": "python /ICA-AROMA/ica-aroma-wrapper.py [OUTPUT_DIR] [INPUT_FILE] [AFFINE_FILE] [WARP_FILE] [REALIGNMENT_FILE] [MASK_FILE] [MELODIC_DIR] [FEAT_DIR] [TR_NUM] [DIMS_NUM] [DENOISING_STRATEGY]",
+        "inputs": [
+            {
+                "command-line-flag": "-out",
+                "description": "Output directory name.",
+                "default-value": "AROMA_output",
+                "value-key": "[OUTPUT_DIR]",
+                "type": "String",
+                "list": false,
+                "optional": false,
+                "id": "outdir",
+                "name": "Output directory"
+            },
+            {
+                "command-line-flag": "-in",
+                "description": "Input file name of fMRI data (.nii.gz).",
+                "value-key": "[INPUT_FILE]",
+                "type": "File",
+                "list": false,
+                "requires-inputs": [
+                    "realignment_file",
+                    "affine_file",
+                    "warp_file"
+                ],
+                "optional": true,
+                "id": "infile",
+                "name": "Input file"
+            },
+            {
+                "command-line-flag": "-affmat",
+                "description": "File name of the mat-file describing the affine registration (e.g. FSL FLIRT) of the functional data to structural space (.mat file).",
+                "value-key": "[AFFINE_FILE]",
+                "type": "File",
+                "list": false,
+                "requires-inputs": [
+                    "infile"
+                ],
+                "optional": true,
+                "id": "affine_file",
+                "name": "Affine registration file"
+            },
+            {
+                "command-line-flag": "-warp",
+                "description": "File name of the warp-file describing the non-linear registration (e.g. FSL FNIRT) of the structural data to MNI152 space (.nii.gz format).",
+                "value-key": "[WARP_FILE]",
+                "type": "File",
+                "list": false,
+                "requires-inputs": [
+                    "infile"
+                ],
+                "optional": true,
+                "id": "warp_file",
+                "name": "Non-linear registration warp file"
+            },
+            {
+                "command-line-flag": "-mc",
+                "description": "File name of the text file containing the six (column-wise) realignment parameters time-courses derived from volume-realignment (e.g. MCFLIRT). (Usually .par format).",
+                "value-key": "[REALIGNMENT_FILE]",
+                "type": "File",
+                "list": false,
+                "requires-inputs": [
+                    "infile"
+                ],
+                "optional": true,
+                "id": "realignment_file",
+                "name": "Realignment file"
+            },
+            {
+                "command-line-flag": "-mask",
+                "description": "Input fMRI data should be masked (i.e. brain-extracted) or a specific mask has to be specified (-m, -mask) when running ICA-AROMA. Note the mask determined by FEAT is not recommended to be used; rather, a mask can be created via the Brain Extraction Tool of FSL (e.g. bet input output -f 0.3 -n -m -R). Not strictly required in generic mode. (Usually .nii.gz format.)",
+                "value-key": "[MASK_FILE]",
+                "type": "File",
+                "list": false,
+                "requires-inputs": [
+                    "infile"
+                ],
+                "optional": true,
+                "id": "mask_file",
+                "name": "Mask file"
+            },
+            {
+                "command-line-flag": "-md",
+                "description": "When you have already run MELODIC you can specify the melodic directory as additional input to avoid running MELODIC again. Note that MELODIC should have been run on the fMRI data prior to temporal filtering and after spatial smoothing. Further, unless you have a good reason for doing otherwise, we advise to run MELODIC as part of ICA-AROMA so that it runs with optimal settings. (Usually .ica extension.)",
+                "value-key": "[MELODIC_DIR]",
+                "type": "File",
+                "list": false,
+                "optional": true,
+                "id": "melodic_dir",
+                "name": "Melodic directory"
+            },
+            {
+                "command-line-flag": "-feat",
+                "description": "Runs ICA-AROMA in post-FEAT mode. In this case, only the FEAT directory has to be specified, as well as an output directory. ICA-AROMA will automatically define the appropriate files, create an appropriate mask (see ICA-AROMA manual, section 4.1) and use the melodic.ica directory if available, in case \u2018MELODIC ICA data exploration\u2019 was checked in FEAT. (.feat extension.)",
+                "value-key": "[FEAT_DIR]",
+                "type": "File",
+                "list": false,
+                "disables-inputs": [
+                    "realignment_file",
+                    "affine_file",
+                    "warp_file",
+                    "mask_file"
+                ],
+                "optional": true,
+                "id": "feat_dir",
+                "name": "FEAT directory"
+            },
+            {
+                "command-line-flag": "-tr",
+                "description": "TR in seconds. If this is not specified the TR will be extracted from the header of the fMRI file using \u2018fslinfo\u2019. In that case, make sure the TR in the header is correct!",
+                "value-key": "[TR_NUM]",
+                "type": "Number",
+                "list": false,
+                "minimum": 0,
+                "optional": true,
+                "id": "tr_num",
+                "name": "TR"
+            },
+            {
+                "command-line-flag": "-dim",
+                "description": "Dimensionality reduction into a defined number of dimensions when running MELODIC (default is 0; automatic estimation).",
+                "value-key": "[DIMS_NUM]",
+                "type": "Number",
+                "list": false,
+                "minimum": 0,
+                "integer": true,
+                "optional": true,
+                "id": "dims_num",
+                "name": "Dimensionality reduction level"
+            },
+            {
+                "command-line-flag": "-den",
+                "description": "Type of denoising strategy (default is nonaggr). Can be \"no\" (only classification, no denoising), \"nonaggr\" (non-aggressive denoising, i.e. partial component regression; default), \"aggr\" (aggressive denoising, i.e. full component regression), \"both\" (both aggressive and non-aggressive denoising, two outputs).",
+                "value-key": "[DENOISING_STRATEGY]",
+                "optional": true,
+                "list": false,
+                "value-choices": [
+                    "no",
+                    "nonaggr",
+                    "aggr",
+                    "both"
+                ],
+                "type": "String",
+                "id": "denoising_strategy",
+                "name": "Denoising strategy"
+            }
+        ],
+        "container-image": {
+            "index": "index.docker.io",
+            "image": "mcin/ica-aroma:latest",
+            "type": "docker"
+        },
+        "schema-version": "0.5",
+        "groups": [
+            {
+                "description": "Either input a .nii.gz file or a Feat directory. The former allows running ICA-AROMA in generic mode; the latter runs it in Feat mode.",
+                "one-is-required": true,
+                "mutually-exclusive": true,
+                "members": [
+                    "infile",
+                    "feat_dir"
+                ],
+                "id": "input_data_group",
+                "name": "Input Data"
+            },
+            {
+                "description": "Input files used in generic mode. The realignment, affine registration, and warp files are required in this mode.",
+                "id": "generic_mode_group",
+                "members": [
+                    "realignment_file",
+                    "affine_file",
+                    "warp_file",
+                    "mask_file"
+                ],
+                "name": "Generic Mode Parameters"
+            },
+            {
+                "description": "Optional parameters that can be specified in either mode of ICA-AROMA.",
+                "id": "optional_args_group",
+                "members": [
+                    "tr_num",
+                    "denoising_strategy",
+                    "dims_num",
+                    "melodic_dir"
+                ],
+                "name": "Optional Parameters"
+            }
+        ],
+        "output-files": [
+            {
+                "description": "A folder containing the output files for ICA-AROMA (see ICA-AROMA manual, sec. 6). Should include a denoised fMRI data file (.nii.gz), text files indicating classification and feature results, and Melodic-related files (spatial maps in .nii.gz, a mask in .nii.gz, and the .ica output directory).",
+                "list": false,
+                "id": "folder_out",
+                "optional": false,
+                "path-template": "[OUTPUT_DIR]",
+                "name": "Output folder"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 5000
+        },
+        "description": "ICA-AROMA (i.e. Independent Component Analyis-based Automatic Removal Of Motion Artifacts) is a data-driven method to identify and remove motion-related independent components from fMRI data.",
+        "tags": {
+            "domain": "fmri"
+        }
+    },
+    {
+        "tool-version": "1.0.0",
+        "name": "fsl_probtrackx2",
+        "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+        "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_probtrackx2.json",
+        "command-line": "cp -rL [INPUT_DIR] [OUTPUT_DIR]; probtrackx2 -s [OUTPUT_DIR]/[BASENAME] -m [OUTPUT_DIR]/[MASKNAME] -x [SEEDFILE] --dir=[OUTPUT_DIR]/[FINALDIR] [FORCEDIR] [OPD] [PD] [OS2T] --targetmasks=[TARGETMASKS] --xfm=[OUTPUT_DIR]/[XFM] --invxfm=[OUTPUT_DIR]/[INVXFM]",
+        "inputs": [
+            {
+                "description": "A bedpostX directory",
+                "value-key": "[INPUT_DIR]",
+                "type": "File",
+                "optional": false,
+                "id": "inputdir",
+                "name": "Input Directory"
+            },
+            {
+                "description": "Basename for samples files - e.g. 'merged'",
+                "value-key": "[BASENAME]",
+                "type": "String",
+                "optional": false,
+                "id": "basename",
+                "name": "Base name"
+            },
+            {
+                "description": "Bet binary mask file in diffusion space",
+                "value-key": "[MASKNAME]",
+                "type": "String",
+                "optional": false,
+                "id": "maskname",
+                "name": "Mask name"
+            },
+            {
+                "description": "Seed volume or list (ascii text file) of volumes and/or surfaces",
+                "value-key": "[SEEDFILE]",
+                "type": "File",
+                "optional": false,
+                "id": "seedfile",
+                "name": "Seed file"
+            },
+            {
+                "description": "Directory to put the final volumes in - code makes this directory - default='logdir'",
+                "value-key": "[FINALDIR]",
+                "type": "String",
+                "optional": false,
+                "id": "finaldir",
+                "name": "Directory to put the final volumes in"
+            },
+            {
+                "command-line-flag": "--forcedir",
+                "description": "Use the actual directory name given - i.e. don't add + to make a new directory",
+                "default-value": true,
+                "value-key": "[FORCEDIR]",
+                "optional": true,
+                "type": "Flag",
+                "id": "forcedir",
+                "name": "Use the actual directory name given"
+            },
+            {
+                "command-line-flag": "--opd",
+                "description": "Output path distribution",
+                "default-value": true,
+                "value-key": "[OPD]",
+                "optional": true,
+                "type": "Flag",
+                "id": "outputpath",
+                "name": "Output path"
+            },
+            {
+                "command-line-flag": "--pd",
+                "description": "Correct path distribution for the length of the pathways",
+                "default-value": true,
+                "value-key": "[PD]",
+                "optional": true,
+                "type": "Flag",
+                "id": "pathdistribution",
+                "name": "Correct path distribution"
+            },
+            {
+                "command-line-flag": "--os2t",
+                "description": "Output seeds to targets",
+                "default-value": true,
+                "value-key": "[OS2T]",
+                "optional": true,
+                "type": "Flag",
+                "id": "outseeds",
+                "name": "Output seeds"
+            },
+            {
+                "description": "File containing a list of target masks - for seeds_to_targets classification",
+                "value-key": "[TARGETMASKS]",
+                "type": "File",
+                "optional": false,
+                "id": "targetmasks",
+                "name": "File containing a list of target masks"
+            },
+            {
+                "description": "Transform taking seed space to DTI space (either FLIRT matrix or FNIRT warpfield) - default is identity",
+                "value-key": "[XFM]",
+                "type": "String",
+                "optional": false,
+                "id": "xfm",
+                "name": "Transform taking seed space to DTI space"
+            },
+            {
+                "description": "Transform taking DTI space to seed space (compulsory when using a warpfield for seeds_to_dti)",
+                "value-key": "[INVXFM]",
+                "type": "String",
+                "optional": false,
+                "id": "infxfm",
+                "name": "Transform taking DTI space to seed space"
+            },
+            {
+                "description": "Output directory name.",
+                "default-value": "probtrackx2_output",
+                "value-key": "[OUTPUT_DIR]",
+                "type": "String",
+                "list": false,
+                "optional": false,
+                "id": "outdir",
+                "name": "Output directory"
+            }
+        ],
+        "container-image": {
+            "index": "index.docker.io",
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker"
+        },
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "description": "A folder containing the output result.",
+                "list": false,
+                "id": "folder_out",
+                "optional": false,
+                "path-template": "[OUTPUT_DIR]",
+                "name": "Output folder"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 331200
+        },
+        "description": "probabilistic tracking with crossing fibres",
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "dmri"
+            ]
+        }
+    },
+    {
+        "name": "DTIFit",
+        "command-line": "dtifit [DWI] [BASE_NAME] [MASK] [BVECS] [BVALS] [CNI] [GRADNONLIN] [LITTLE_BIT] [MAX_X] [MAX_Y] [MAX_Z] [MIN_X] [MIN_Y] [MIN_Z] [SAVE_TENSOR] [SSE]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "DTIFit, as implemented in Nipype (module: nipype.interfaces.fsl, interface: DTIFit).",
+        "inputs": [
+            {
+                "id": "base_name",
+                "name": "Base name",
+                "type": "String",
+                "value-key": "[BASE_NAME]",
+                "command-line-flag": "-o",
+                "description": "A unicode string. Base_name that all output files will start with.",
+                "optional": true,
+                "default-value": "dtifit_"
+            },
+            {
+                "id": "bvals",
+                "name": "Bvals",
+                "type": "File",
+                "value-key": "[BVALS]",
+                "command-line-flag": "-b",
+                "description": "An existing file name. B values file.",
+                "optional": false
+            },
+            {
+                "id": "bvecs",
+                "name": "Bvecs",
+                "type": "File",
+                "value-key": "[BVECS]",
+                "command-line-flag": "-r",
+                "description": "An existing file name. B vectors file.",
+                "optional": false
+            },
+            {
+                "id": "cni",
+                "name": "Cni",
+                "type": "File",
+                "value-key": "[CNI]",
+                "command-line-flag": "--cni",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Input confound regressors.",
+                "optional": true
+            },
+            {
+                "id": "dwi",
+                "name": "Dwi",
+                "type": "File",
+                "value-key": "[DWI]",
+                "command-line-flag": "-k",
+                "description": "An existing file name. Diffusion weighted image data file.",
+                "optional": false
+            },
+            {
+                "id": "gradnonlin",
+                "name": "Gradnonlin",
+                "type": "File",
+                "value-key": "[GRADNONLIN]",
+                "command-line-flag": "--gradnonlin",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Gradient non linearities.",
+                "optional": true
+            },
+            {
+                "id": "little_bit",
+                "name": "Little bit",
+                "type": "Flag",
+                "value-key": "[LITTLE_BIT]",
+                "command-line-flag": "--littlebit",
+                "description": "A boolean. Only process small area of brain.",
+                "optional": true
+            },
+            {
+                "id": "mask",
+                "name": "Mask",
+                "type": "File",
+                "value-key": "[MASK]",
+                "command-line-flag": "-m",
+                "description": "An existing file name. Bet binary mask file.",
+                "optional": false
+            },
+            {
+                "id": "max_x",
+                "name": "Max x",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[MAX_X]",
+                "command-line-flag": "-X",
+                "description": "An integer (int or long). Max x.",
+                "optional": true
+            },
+            {
+                "id": "max_y",
+                "name": "Max y",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[MAX_Y]",
+                "command-line-flag": "-Y",
+                "description": "An integer (int or long). Max y.",
+                "optional": true
+            },
+            {
+                "id": "max_z",
+                "name": "Max z",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[MAX_Z]",
+                "command-line-flag": "-Z",
+                "description": "An integer (int or long). Max z.",
+                "optional": true
+            },
+            {
+                "id": "min_x",
+                "name": "Min x",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[MIN_X]",
+                "command-line-flag": "-x",
+                "description": "An integer (int or long). Min x.",
+                "optional": true
+            },
+            {
+                "id": "min_y",
+                "name": "Min y",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[MIN_Y]",
+                "command-line-flag": "-y",
+                "description": "An integer (int or long). Min y.",
+                "optional": true
+            },
+            {
+                "id": "min_z",
+                "name": "Min z",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[MIN_Z]",
+                "command-line-flag": "-z",
+                "description": "An integer (int or long). Min z.",
+                "optional": true
+            },
+            {
+                "id": "save_tensor",
+                "name": "Save tensor",
+                "type": "Flag",
+                "value-key": "[SAVE_TENSOR]",
+                "command-line-flag": "--save_tensor",
+                "description": "A boolean. Save the elements of the tensor.",
+                "optional": true
+            },
+            {
+                "id": "sse",
+                "name": "Sse",
+                "type": "Flag",
+                "value-key": "[SSE]",
+                "command-line-flag": "--sse",
+                "description": "A boolean. Output sum of squared errors.",
+                "optional": true
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Fa",
+                "id": "FA",
+                "path-template": "dtifit__FA.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the fractional anisotropy."
+            },
+            {
+                "name": "L1",
+                "id": "L1",
+                "path-template": "dtifit__L1.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the 1st eigenvalue."
+            },
+            {
+                "name": "L2",
+                "id": "L2",
+                "path-template": "dtifit__L2.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the 2nd eigenvalue."
+            },
+            {
+                "name": "L3",
+                "id": "L3",
+                "path-template": "dtifit__L3.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the 3rd eigenvalue."
+            },
+            {
+                "name": "Md",
+                "id": "MD",
+                "path-template": "dtifit__MD.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the mean diffusivity."
+            },
+            {
+                "name": "Mo",
+                "id": "MO",
+                "path-template": "dtifit__MO.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the mode of anisotropy."
+            },
+            {
+                "name": "S0",
+                "id": "S0",
+                "path-template": "dtifit__S0.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the raw t2 signal with no diffusion weighting."
+            },
+            {
+                "name": "V1",
+                "id": "V1",
+                "path-template": "dtifit__V1.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the 1st eigenvector."
+            },
+            {
+                "name": "V2",
+                "id": "V2",
+                "path-template": "dtifit__V2.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the 2nd eigenvector."
+            },
+            {
+                "name": "V3",
+                "id": "V3",
+                "path-template": "dtifit__V3.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the 3rd eigenvector."
+            },
+            {
+                "name": "Sse",
+                "id": "sse_outfile",
+                "path-template": "dtifit__sse.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the summed squared error."
+            },
+            {
+                "name": "Tensor",
+                "id": "tensor",
+                "path-template": "dtifit__tensor.nii",
+                "optional": true,
+                "description": "An existing file name. Path/name of file with the 4d tensor volume."
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "dmri"
+            ],
+            "source": "nipype-interface"
+        },
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/dti.py"
+    },
+    {
+        "tool-version": "3.19.0-centos7",
+        "name": "FreeSurferPipelineBatch-CentOS7",
+        "author": "Washington University",
+        "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/freesurfer-exec-centos7-freesurferbuild-centos4.json",
+        "command-line": "freesurfer-command-line-script.sh [SUBJECT_FOLDER] [NAME] [LICENSE]",
+        "inputs": [
+            {
+                "description": "HCP subject folder, downloaded from http://www.humanconnectome.org/documentation/S500.",
+                "value-key": "[SUBJECT_FOLDER]",
+                "type": "File",
+                "optional": false,
+                "id": "subject_folder",
+                "name": "HCP subject folder"
+            },
+            {
+                "description": "Use this parameter to give a name to the execution. Example: \"Exec-CentOS7-FreeSurferbuild-CentOS4\". The results will be written in a folder named [SUBJECT]-[EXECUTION-NAME] (a unique identifier will be appended in case a file with the same name already exists).",
+                "default-value": "Exec-CentOS-[X]-FreeSurferbuild-CentOS-[Y]",
+                "value-key": "[NAME]",
+                "optional": false,
+                "type": "String",
+                "id": "execution_name",
+                "name": "Execution name"
+            },
+            {
+                "description": "Use this parameter to add the content of the license file in the freesurfer directory",
+                "default-value": "",
+                "value-key": "[LICENSE]",
+                "optional": false,
+                "type": "File",
+                "id": "freesurfer_license",
+                "name": "FreeSurfer License"
+            }
+        ],
+        "container-image": {
+            "image": "bigdatalabteam/hcp-prefreesurfer:exec-centos7.freesurferbuild-centos4-latest",
+            "type": "docker"
+        },
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[SUBJECT_FOLDER]-[NAME]",
+                "description": "This directory will contain 3 directories (T1w, T2w and MNINonLinear), a monitoring file (monitor.txt) and the input data.",
+                "optional": false,
+                "id": "results",
+                "name": "Results"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 25200
+        },
+        "description": "FreeSurferPipelineBatch HCP pipeline",
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ]
+        }
+    },
+    {
+        "author": "Plodrack lab",
+        "command-line": "mriqc_run.py [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [VERSION] [PARTICIPANT_LABEL] [SESSION_ID] [RUN_ID] [TASK_ID] [MODALITIES] [DSNAME] [WORK_DIR] [VERBOSE_REPORTS] [WRITE_GRAPH] [DRY_RUN] [PROFILE] [USE_PLUGIN] [NO_SUB] [EMAIL] [VERBOSE_COUNT] [WEBAPI_URL] [WEBAPI_PORT] [UPLOAD_STRICT] [N_PROCS] [MEM_GB] [TESTING] [FLOAT32] [ICA] [HMC_AFNI] [HMC_FSL] [FFT_SPIKES_DETECTOR] [FD_THRES] [ANTS_NTHREADS] [ANTS_FLOAT] [ANTS_SETTINGS] [DEOBLIQUE] [DESPIKE] [START_IDX] [STOP_IDX] [CORRECT_SLICE_TIMING]",
+        "description": "tool description",
+        "inputs": [
+            {
+                "description": "The directory with the input dataset formatted according to the BIDS standard.",
+                "id": "bids_dir",
+                "name": "bids_dir",
+                "optional": false,
+                "type": "File",
+                "value-key": "[BIDS_DIR]"
+            },
+            {
+                "description": "The directory where the output files should be stored. If you are running group level analysis this folder should be prepopulated with the results of theparticipant level analysis.",
+                "id": "output_dir_name",
+                "name": "output_dir_name",
+                "optional": false,
+                "type": "String",
+                "value-key": "[OUTPUT_DIR]"
+            },
+            {
+                "description": "Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel) using the same output_dir.",
+                "id": "analysis_level",
+                "list": true,
+                "name": "analysis_level",
+                "optional": false,
+                "type": "String",
+                "value-choices": [
+                    "participant",
+                    "group"
+                ],
+                "value-key": "[ANALYSIS_LEVEL]"
+            },
+            {
+                "command-line-flag": "--version",
+                "default-value": false,
+                "description": "show program's version number and exit",
+                "id": "version",
+                "name": "version",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[VERSION]"
+            },
+            {
+                "command-line-flag": "--participant_label",
+                "description": "one or more participant identifiers (the sub- prefix can be removed)",
+                "id": "participant_label",
+                "name": "participant_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[PARTICIPANT_LABEL]"
+            },
+            {
+                "command-line-flag": "--session-id",
+                "description": "filter input dataset by session id",
+                "id": "session_id",
+                "name": "session_id",
+                "optional": true,
+                "type": "String",
+                "value-key": "[SESSION_ID]"
+            },
+            {
+                "command-line-flag": "--run-id",
+                "description": "filter input dataset by run id (only integer run ids are valid)",
+                "id": "run_id",
+                "name": "run_id",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[RUN_ID]"
+            },
+            {
+                "command-line-flag": "--task-id",
+                "description": "filter input dataset by task id",
+                "id": "task_id",
+                "name": "task_id",
+                "optional": true,
+                "type": "String",
+                "value-key": "[TASK_ID]"
+            },
+            {
+                "command-line-flag": "-m",
+                "description": "filter input dataset by MRI type (\"T1w\", \"T2w\", or \"bold\")",
+                "id": "modalities",
+                "name": "modalities",
+                "optional": true,
+                "list": true,
+                "type": "String",
+                "value-choices": [
+                    "T1w",
+                    "bold",
+                    "T2w"
+                ],
+                "value-key": "[MODALITIES]"
+            },
+            {
+                "command-line-flag": "--dsname",
+                "description": "a dataset name",
+                "id": "dsname",
+                "name": "dsname",
+                "optional": true,
+                "type": "String",
+                "value-key": "[DSNAME]"
+            },
+            {
+                "command-line-flag": "-w",
+                "default-value": "work",
+                "description": "The folder used to store intermediate results",
+                "id": "work_dir",
+                "name": "work_dir",
+                "optional": true,
+                "type": "String",
+                "value-key": "[WORK_DIR]"
+            },
+            {
+                "command-line-flag": "--verbose-reports",
+                "description": "Should MRIQC print verbose reports",
+                "id": "verbose_reports",
+                "name": "verbose_reports",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[VERBOSE_REPORTS]"
+            },
+            {
+                "command-line-flag": "--write-graph",
+                "description": "Write workflow graph.",
+                "id": "write_graph",
+                "name": "write_graph",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[WRITE_GRAPH]"
+            },
+            {
+                "command-line-flag": "--dry-run",
+                "description": "Do not run the workflow.",
+                "id": "dry_run",
+                "name": "dry_run",
+                "optional": true,
+                "type": "Flag",
+                "default-value": false,
+                "value-key": "[DRY_RUN]"
+            },
+            {
+                "command-line-flag": "--profile",
+                "description": "hook up the resource profiler callback to nipype",
+                "id": "profile",
+                "name": "profile",
+                "optional": true,
+                "type": "Flag",
+                "default-value": false,
+                "value-key": "[PROFILE]"
+            },
+            {
+                "command-line-flag": "--use-plugin",
+                "description": "Path to nipype plugin configuration file",
+                "id": "use_plugin",
+                "name": "use_plugin",
+                "optional": true,
+                "type": "String",
+                "value-key": "[USE_PLUGIN]"
+            },
+            {
+                "command-line-flag": "--no-sub",
+                "description": "Turn off submission of anonymized quality metrics to MRIQC's metrics repository.",
+                "id": "no_sub",
+                "name": "no_sub",
+                "optional": true,
+                "type": "Flag",
+                "default-value": false,
+                "value-key": "[NO_SUB]"
+            },
+            {
+                "command-line-flag": "--email",
+                "description": "Email address to include with quality metric submission.",
+                "id": "email",
+                "name": "email",
+                "optional": true,
+                "type": "String",
+                "value-key": "[EMAIL]"
+            },
+            {
+                "command-line-flag": "-v",
+                "description": "increases log verbosity for each occurence, debug level is -vvv",
+                "id": "verbose_count",
+                "name": "verbose_count",
+                "optional": true,
+                "type": "String",
+                "value-key": "[VERBOSE_COUNT]"
+            },
+            {
+                "command-line-flag": "--webapi-url",
+                "default-value": "https://mriqc.nimh.nih.gov/api/v1",
+                "description": "IP address where the MRIQC WebAPI is listening",
+                "id": "webapi_url",
+                "name": "webapi_url",
+                "optional": true,
+                "type": "String",
+                "value-key": "[WEBAPI_URL]"
+            },
+            {
+                "command-line-flag": "--webapi-port",
+                "description": "port where the MRIQC WebAPI is listening",
+                "id": "webapi_port",
+                "name": "webapi_port",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[WEBAPI_PORT]"
+            },
+            {
+                "command-line-flag": "--upload-strict",
+                "description": "upload will fail if if upload is strict",
+                "id": "upload_strict",
+                "name": "upload_strict",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[UPLOAD_STRICT]"
+            },
+            {
+                "command-line-flag": "--n_procs",
+                "description": "number of threads",
+                "id": "n_procs",
+                "name": "n_procs",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[N_PROCS]"
+            },
+            {
+                "command-line-flag": "--mem_gb",
+                "description": "available total memory",
+                "id": "mem_gb",
+                "name": "mem_gb",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[MEM_GB]"
+            },
+            {
+                "command-line-flag": "--testing",
+                "description": "use testing settings for a minimal footprint",
+                "id": "testing",
+                "name": "testing",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[TESTING]"
+            },
+            {
+                "command-line-flag": "-f",
+                "description": "Cast the input data to float32 if it's represented in higher precision (saves space and improves perfomance)",
+                "id": "float32",
+                "name": "float32",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[FLOAT32]"
+            },
+            {
+                "command-line-flag": "--ica",
+                "description": "Run ICA on the raw data and include the componentsin the individual reports (slow but potentially very insightful)",
+                "id": "ica",
+                "name": "ica",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[ICA]"
+            },
+            {
+                "command-line-flag": "--hmc-afni",
+                "default-value": true,
+                "description": "Use ANFI 3dvolreg for head motion correction (HMC) - default",
+                "id": "hmc_afni",
+                "name": "hmc_afni",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[HMC_AFNI]"
+            },
+            {
+                "command-line-flag": "--hmc-fsl",
+                "description": "Use FSL MCFLIRT instead of AFNI for head motion correction (HMC)",
+                "id": "hmc_fsl",
+                "name": "hmc_fsl",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[HMC_FSL]"
+            },
+            {
+                "command-line-flag": "--fft-spikes-detector",
+                "description": "Turn on FFT based spike detector (slow).",
+                "id": "fft_spikes_detector",
+                "name": "fft_spikes_detector",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[FFT_SPIKES_DETECTOR]"
+            },
+            {
+                "command-line-flag": "--fd_thres",
+                "default-value": 0.2,
+                "description": "motion threshold for FD computation",
+                "id": "fd_thres",
+                "name": "fd_thres",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[FD_THRES]"
+            },
+            {
+                "command-line-flag": "--ants-nthreads",
+                "default-value": 1,
+                "description": "number of threads that will be set in ANTs processes",
+                "id": "ants_nthreads",
+                "name": "ants_nthreads",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[ANTS_NTHREADS]"
+            },
+            {
+                "command-line-flag": "--ants-float",
+                "description": "use float number precision on ANTs computations",
+                "id": "ants_float",
+                "name": "ants_float",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[ANTS_FLOAT]"
+            },
+            {
+                "command-line-flag": "--ants-settings",
+                "description": "path to JSON file with settings for ANTS",
+                "id": "ants_settings",
+                "name": "ants_settings",
+                "optional": true,
+                "type": "String",
+                "value-key": "[ANTS_SETTINGS]"
+            },
+            {
+                "command-line-flag": "--deoblique",
+                "description": "Deoblique the functional scans during head motion correction preprocessing",
+                "id": "deoblique",
+                "name": "deoblique",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[DEOBLIQUE]"
+            },
+            {
+                "command-line-flag": "--despike",
+                "description": "Despike the functional scans during head motion correction preprocessing",
+                "id": "despike",
+                "name": "despike",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[DESPIKE]"
+            },
+            {
+                "command-line-flag": "--start-idx",
+                "description": "Initial volume in functional timeseries that should be considered for preprocessing",
+                "id": "start_idx",
+                "name": "start_idx",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[START_IDX]"
+            },
+            {
+                "command-line-flag": "--stop-idx",
+                "description": "Final volume in functional timeseries that should be considered for preprocessing",
+                "id": "stop_idx",
+                "name": "stop_idx",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[STOP_IDX]"
+            },
+            {
+                "command-line-flag": "--correct-slice-timing",
+                "description": "Perform slice timing correction",
+                "id": "correct_slice_timing",
+                "name": "correct_slice_timing",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[CORRECT_SLICE_TIMING]"
+            }
+        ],
+        "output-files": [
+            {
+                "description": "This is the directory where the overall outputs are to be stored.",
+                "id": "output_directory",
+                "name": "Output Directory",
+                "optional": false,
+                "path-template": "[OUTPUT_DIR]"
+            }
+        ],
+        "groups": [
+            {
+                "name": "Instrumentation Options",
+                "description": "Instrumental Options",
+                "id": "instrument_options",
+                "members": [
+                    "work_dir",
+                    "verbose_reports",
+                    "write_graph",
+                    "dry_run",
+                    "profile",
+                    "use_plugin",
+                    "no_sub",
+                    "email",
+                    "webapi_url",
+                    "webapi_port",
+                    "upload_strict"
+                ]
+            },
+            {
+                "name": "Performance Options",
+                "description": "Options to handle performance",
+                "id": "performance_options",
+                "members": [
+                    "n_procs",
+                    "mem_gb",
+                    "testing",
+                    "float32"
+                ]
+            },
+            {
+                "name": "Workflow Options",
+                "description": "Workflow options",
+                "id": "workflow_options",
+                "members": [
+                    "ica",
+                    "hmc_afni",
+                    "hmc_fsl",
+                    "fft_spikes_detector",
+                    "fd_thres"
+                ]
+            },
+            {
+                "name": "ANTs specific settings",
+                "description": "ANTs specific settings",
+                "id": "ants_specific_settings",
+                "members": [
+                    "ants_settings",
+                    "ants_float",
+                    "ants_nthreads"
+                ]
+            },
+            {
+                "name": "AFNI specific settings",
+                "description": "AFNI specific settings",
+                "id": "afni_specific_settings",
+                "members": [
+                    "deoblique",
+                    "despike",
+                    "start_idx",
+                    "stop_idx",
+                    "correct_slice_timing"
+                ]
+            }
+        ],
+        "name": "MRIQC",
+        "schema-version": "0.5",
+        "suggested-resources": {
+            "cpu-cores": 1,
+            "ram": 4,
+            "walltime-estimate": 172000
+        },
+        "tags": {
+            "application-type": [
+                "bids"
+            ],
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ]
+        },
+        "tool-version": "v0.14.2",
+        "url": "https://mriqc.readthedocs.io/en/0.14.2"
+    },
+    {
+        "tool-version": "3.19.0-centos7",
+        "name": "PostFreeSurferPipelineBatch-CentOS7",
+        "author": "Washington University",
+        "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/postfreesurfer-exec-centos7.json",
+        "command-line": "postfreesurfer-command-line-script.sh [SUBJECT_FOLDER] [NAME] [LICENSE]",
+        "inputs": [
+            {
+                "description": "HCP subject folder, downloaded from http://www.humanconnectome.org/documentation/S500.",
+                "value-key": "[SUBJECT_FOLDER]",
+                "type": "File",
+                "optional": false,
+                "id": "subject_folder",
+                "name": "HCP subject folder"
+            },
+            {
+                "description": "Use this parameter to give a name to the execution. Example: \"Exec-CentOS5-PostFreeSurfer\". The results will be written in a folder named [SUBJECT]-[EXECUTION-NAME] (a unique identifier will be appended in case a file with the same name already exists).",
+                "default-value": "Exec-CentOS-[X]-PostFreeSurfer",
+                "value-key": "[NAME]",
+                "optional": false,
+                "type": "String",
+                "id": "execution_name",
+                "name": "Execution name"
+            },
+            {
+                "description": "Use this parameter to add the content of the license file in the freesurfer directory",
+                "default-value": "",
+                "value-key": "[LICENSE]",
+                "optional": false,
+                "type": "File",
+                "id": "freesurfer_license",
+                "name": "FreeSurfer License"
+            }
+        ],
+        "container-image": {
+            "image": "bigdatalabteam/hcp-prefreesurfer:exec-centos7.freesurferbuild-centos4-latest",
+            "type": "docker"
+        },
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[SUBJECT_FOLDER]-[NAME]",
+                "description": "This directory will contain 3 directories (T1w, T2w and MNINonLinear), a monitoring file (monitor.txt) and the input data.",
+                "optional": false,
+                "id": "results",
+                "name": "Results"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 25200
+        },
+        "description": "PostFreeSurferPipelineBatch HCP pipeline",
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ]
+        }
+    },
+    {
+        "tool-version": "v0.1.0",
+        "name": "ndmg",
+        "author": "Greg Kiar",
+        "descriptor-url": "https://github.com/neurodata/boutiques-tools/blob/8d5274754e2d5b3b146f2b3cc581400b96bb6081/cbrain_task_descriptors/ndmg-docker.json",
+        "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN]",
+        "inputs": [
+            {
+                "value-key": "[DTI]",
+                "optional": false,
+                "type": "File",
+                "id": "dti_file",
+                "name": "Diffusion Tensor Image"
+            },
+            {
+                "value-key": "[BVAL]",
+                "optional": false,
+                "type": "File",
+                "id": "bval_file",
+                "name": "B-values file"
+            },
+            {
+                "value-key": "[BVEC]",
+                "optional": false,
+                "type": "File",
+                "id": "bvec_file",
+                "name": "Gradient vectors file"
+            },
+            {
+                "value-key": "[MPRAGE]",
+                "optional": false,
+                "type": "File",
+                "id": "mprage_file",
+                "name": "Structural scan file"
+            },
+            {
+                "name": "Atlas image (MNI152)",
+                "value-key": "[ATLAS]",
+                "type": "String",
+                "value-choices": [
+                    "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
+                ],
+                "optional": false,
+                "id": "atlas"
+            },
+            {
+                "name": "Atlas brain mask",
+                "value-key": "[MASK]",
+                "type": "String",
+                "value-choices": [
+                    "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
+                ],
+                "optional": false,
+                "id": "mask"
+            },
+            {
+                "value-key": "[OUTDIR]",
+                "optional": false,
+                "type": "String",
+                "id": "outdir",
+                "name": "Output directory"
+            },
+            {
+                "name": "Desikan parcellation",
+                "value-key": "[DESIKAN]",
+                "type": "String",
+                "value-choices": [
+                    "/ndmg_atlases/labels/desikan.nii.gz"
+                ],
+                "optional": true,
+                "id": "desikan"
+            },
+            {
+                "name": "JHU parcellation",
+                "value-key": "[JHU]",
+                "type": "String",
+                "value-choices": [
+                    "/ndmg_atlases/labels/JHU.nii.gz"
+                ],
+                "optional": true,
+                "id": "jhu"
+            },
+            {
+                "name": "Talairach parcellation",
+                "value-key": "[TALAIRACH]",
+                "type": "String",
+                "value-choices": [
+                    "/ndmg_atlases/labels/Talairach.nii.gz"
+                ],
+                "optional": true,
+                "id": "talairach"
+            },
+            {
+                "name": "AAL parcellation",
+                "value-key": "[AAL]",
+                "type": "String",
+                "value-choices": [
+                    "/ndmg_atlases/labels/AAL.nii.gz"
+                ],
+                "optional": true,
+                "id": "aal"
+            },
+            {
+                "name": "Harvard-Oxford parcellation",
+                "value-key": "[HARVARDOXFORD]",
+                "type": "String",
+                "value-choices": [
+                    "/ndmg_atlases/labels/HarvardOxford.nii.gz"
+                ],
+                "optional": true,
+                "id": "harvardoxford"
+            },
+            {
+                "name": "CPAC200 parcellation",
+                "value-key": "[CPAC200]",
+                "type": "String",
+                "value-choices": [
+                    "/ndmg_atlases/labels/CPAC200.nii.gz"
+                ],
+                "optional": true,
+                "id": "cpac200"
+            },
+            {
+                "command-line-flag": "-c",
+                "name": "Clean-up flag",
+                "value-key": "[CLEAN]",
+                "type": "Flag",
+                "optional": true,
+                "id": "clean"
+            }
+        ],
+        "container-image": {
+            "index": "index.docker.io",
+            "image": "neurodata/ndmg:v0.1.0",
+            "type": "docker"
+        },
+        "schema-version": "0.5",
+        "groups": [
+            {
+                "one-is-required": true,
+                "id": "parcellation_group",
+                "members": [
+                    "desikan",
+                    "jhu",
+                    "talairach",
+                    "aal",
+                    "harvardoxford",
+                    "cpac200"
+                ],
+                "name": "Group of all used parcellations"
+            }
+        ],
+        "output-files": [
+            {
+                "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz",
+                "optional": true,
+                "id": "aligned_dti",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "Aligned DTI volume"
+            },
+            {
+                "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz",
+                "optional": true,
+                "id": "tensors",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "Tensor maps"
+            },
+            {
+                "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz",
+                "optional": true,
+                "id": "fibers",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "Fiber streamlines"
+            },
+            {
+                "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle",
+                "optional": true,
+                "id": "desikan_graph",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "Desikan graph"
+            },
+            {
+                "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle",
+                "optional": true,
+                "id": "jhu_graph",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "JHU graph"
+            },
+            {
+                "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle",
+                "optional": true,
+                "id": "talairach_graph",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "Talairach graph"
+            },
+            {
+                "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle",
+                "optional": true,
+                "id": "aal_graph",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "AAL graph"
+            },
+            {
+                "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle",
+                "optional": true,
+                "id": "harvardoxford_graph",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "Harvard-Oxford graph"
+            },
+            {
+                "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle",
+                "optional": true,
+                "id": "cpac200_graph",
+                "path-template-stripped-extensions": [
+                    ".nii",
+                    ".nii.gz"
+                ],
+                "name": "CPAC200 graph"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 7400
+        },
+        "description": "dwi connectome estimation pipeline",
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "dmri"
+            ]
+        }
+    },
+    {
+        "tool-version": "5.0.0",
+        "name": "fsl_first",
+        "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+        "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_first.json",
+        "command-line": "mkdir -p [OUTPUT_DIR]; run_first_all [METHOD] [BRAIN_EXTRACTED] [SPECIFIED_STRUCTURE] [AFFINE] [THREE_STAGE] [VERBOSE] [INPUT_FILE] -o [OUTPUT_DIR]/[PREFIX]",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "inputs": [
+            {
+                "command-line-flag": "-m",
+                "description": "Method must be one of 'auto' (default), 'fast', 'none', or it can be a numerical threshold value. This specifies the boundary correction method. Auto chooses different options for different structures using the settings that were found to be empirically optimal for each structure. Other options use: fast (using FAST-based, mixture-model, tissue-type classification) or threshold (thresholds a simple single-Gaussian intensity model).",
+                "value-key": "[METHOD]",
+                "type": "String",
+                "list": false,
+                "optional": true,
+                "id": "method",
+                "name": "Method"
+            },
+            {
+                "command-line-flag": "-i",
+                "description": "Input image file (e.g. img.nii.gz).",
+                "value-key": "[INPUT_FILE]",
+                "type": "File",
+                "list": false,
+                "optional": false,
+                "id": "input_file",
+                "name": "Input file"
+            },
+            {
+                "command-line-flag": "-b",
+                "description": "Whether the input is already brain extracted.",
+                "value-key": "[BRAIN_EXTRACTED]",
+                "type": "Flag",
+                "list": false,
+                "optional": true,
+                "id": "brain_extracted",
+                "name": "Brain extracted"
+            },
+            {
+                "command-line-flag": "-s",
+                "description": "Run only on one specified structure (e.g. L_Hipp) or a comma-separated list (no spaces). Choose from: 'L_Hipp', 'R_Hipp', 'L_Accu', 'R_Accu', 'L_Amyg', 'R_Amyg', 'L_Caud', 'R_Caud', 'L_Pall', 'R_Pall', 'L_Puta', 'R_Puta', 'L_Thal', 'R_Thal', 'BrStem'.",
+                "value-key": "[SPECIFIED_STRUCTURE]",
+                "type": "String",
+                "list": false,
+                "optional": true,
+                "id": "specified_structure",
+                "name": "Specify structure"
+            },
+            {
+                "command-line-flag": "-a",
+                "description": "Use affine matrix (i.e. do not re-run registration).",
+                "value-key": "[AFFINE]",
+                "type": "File",
+                "list": false,
+                "optional": true,
+                "id": "affine",
+                "name": "Use Affine Matrix"
+            },
+            {
+                "command-line-flag": "-3",
+                "description": "Use 3-stage affine registration. Only currently implemented for the hippocampus.",
+                "value-key": "[THREE_STAGE]",
+                "type": "Flag",
+                "list": false,
+                "optional": true,
+                "id": "three_stage",
+                "name": "Three stage registration"
+            },
+            {
+                "command-line-flag": "-v",
+                "description": "Verbose output.",
+                "value-key": "[VERBOSE]",
+                "type": "Flag",
+                "list": false,
+                "optional": true,
+                "id": "verbose",
+                "name": "Verbose"
+            },
+            {
+                "description": "Prefix for each files in the directory output.",
+                "value-key": "[PREFIX]",
+                "type": "String",
+                "optional": false,
+                "list": false,
+                "default-value": "output",
+                "id": "prefix",
+                "name": "Prefix"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "id": "outputs",
+                "name": "First Outputs",
+                "description": "Output directory of First",
+                "value-key": "[OUTPUT_DIR]",
+                "path-template": "[INPUT_FILE]",
+                "list": false,
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ]
+            },
+            {
+                "id": "std_sub_outputs",
+                "name": "Registered outputs",
+                "description": "Std sub output",
+                "path-template": "[INPUT_FILE]_to_std_sub*",
+                "list": true,
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ]
+            }
+        ],
+        "tests": [
+            {
+                "name": "fsl_first_test",
+                "invocation": {
+                    "input_file": "sub-01_T1w.nii.gz",
+                    "prefix": "img_first"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "outputs"
+                        }
+                    ]
+                }
+            }
+        ],
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ]
+        },
+        "description": "FIRST is a model-based segmentation and registration tool, based on a Bayesian model of shape and appearance for subcortical structures."
+    },
+    {
+        "author": "Greg Kiar",
+        "command-line": "python3 /opt/mask2boundary.py [MASK] [OUTPUT] [WIDTH] [BOUTIQUES]",
+        "container-image": {
+            "image": "gkiar/mask2boundary:v0.1.0",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "description": "Transforms a binary mask of a niftii image (such as a brain or white matter mask) into a boundary mask. This tool was originally developed to transform a white matter mask into a mask of seed locations for performing tractography in diffusion images.",
+        "inputs": [
+            {
+                "description": "Nifti image containing a binary mask.",
+                "id": "mask",
+                "name": "mask",
+                "optional": false,
+                "type": "String",
+                "value-key": "[MASK]"
+            },
+            {
+                "description": "Path for output Nifti image containing the mask boundary.",
+                "id": "output",
+                "name": "output",
+                "optional": false,
+                "type": "String",
+                "value-key": "[OUTPUT]"
+            },
+            {
+                "command-line-flag": "--width",
+                "default-value": 3,
+                "description": "Width of the boundary to be stored.",
+                "id": "width",
+                "integer": true,
+                "minimum": 1,
+                "name": "width",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[WIDTH]"
+            },
+            {
+                "command-line-flag": "--boutiques",
+                "description": "Toggles creation of a Boutiques descriptor and invocation from the tool and inputs.",
+                "id": "boutiques",
+                "name": "boutiques",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[BOUTIQUES]"
+            }
+        ],
+        "name": "mask2boundary",
+        "output-files": [
+            {
+                "path-template": "[OUTPUT]",
+                "optional": false,
+                "id": "mask_boundary",
+                "name": "Boundary Mask"
+            }
+        ],
+        "schema-version": "0.5",
+        "suggested-resources": {
+            "cpu-cores": 1,
+            "ram": 1,
+            "walltime-estimate": 20
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri",
+                "nifti",
+                "dmri"
+            ]
+        },
+        "tool-version": "v0.1.0"
+    },
+    {
+        "author": "Gilles Mathieu, using GATE application",
+        "command-line": "unzip [INDATA]; source [GATERELEASEPATH]/env.sh [GATERELEASEPATH]; [GATERELEASEPATH]/shared_libs/ld-linux-x86-64.so.2 --library-path [GATERELEASEPATH]/root/lib:[GATERELEASEPATH]/shared_libs/ [GATERELEASEPATH]/Gate -a [Source_ID,[ORGANID]][particle,[PARTICLETYPE]][energy,[ENERGY]][nb,[NBPRIMARIES]] [MACFILE] > output.log;  tar czf [RESULTS] ./output output.log",
+        "description": "Descriptor for the GATE command with input parameters, used for import in VIP via Boutiques",
+        "error-codes": [
+            {
+                "code": 1,
+                "description": "Crashed"
+            }
+        ],
+        "inputs": [
+            {
+                "command-line-flag": "",
+                "command-line-flag-separator": "",
+                "id": "gatereleasepath",
+                "name": "Path to the Gate Release used by the application",
+                "optional": false,
+                "type": "String",
+                "value-key": "[GATERELEASEPATH]"
+            },
+            {
+                "id": "indata",
+                "name": "LFN of the archive containing all input data",
+                "optional": false,
+                "type": "File",
+                "value-key": "[INDATA]"
+            },
+            {
+                "command-line-flag": "",
+                "command-line-flag-separator": "",
+                "id": "organid",
+                "name": "Organ ID ref to the organs table",
+                "optional": false,
+                "type": "String",
+                "value-key": "[ORGANID]"
+            },
+            {
+                "command-line-flag": "",
+                "command-line-flag-separator": "",
+                "id": "particletype",
+                "name": "Type of Particle to simulate",
+                "optional": false,
+                "type": "String",
+                "value-key": "[PARTICLETYPE]"
+            },
+            {
+                "command-line-flag": "",
+                "command-line-flag-separator": "",
+                "id": "energy",
+                "name": "The level of energy to simulate",
+                "optional": false,
+                "type": "String",
+                "value-key": "[ENERGY]"
+            },
+            {
+                "command-line-flag": "",
+                "command-line-flag-separator": "",
+                "id": "nbprimaries",
+                "name": "The number of primaries to simulate",
+                "optional": false,
+                "type": "String",
+                "value-key": "[NBPRIMARIES]"
+            },
+            {
+                "id": "macfile",
+                "name": "The name of the main macro file",
+                "optional": false,
+                "type": "String",
+                "value-key": "[MACFILE]"
+            }
+        ],
+        "name": "GateCLforOpenDose",
+        "output-files": [
+            {
+                "description": "archive of the output folder containing execution results, and the output of the command",
+                "id": "results",
+                "name": "results",
+                "optional": false,
+                "path-template": "OpenDose_[ORGANID]_[PARTICLETYPE]_[ENERGY]_[NBPRIMARIES].tar.gz",
+                "value-key": "[RESULTS]"
+            }
+        ],
+        "schema-version": "0.5",
+        "tags": {
+            "application": "GATE",
+            "domain": "nuclear medicine"
+        },
+        "tool-version": "v0.2.0"
+    },
+    {
+        "tool-version": "3.19.0-centos7",
+        "name": "PreFreeSurferPipelineBatch",
+        "author": "Washington University",
+        "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/prefreesurfer-exec-centos7-fslbuild-centos5.json",
+        "command-line": "command-line-script.sh [SUBJECT_FOLDER] [NAME]",
+        "inputs": [
+            {
+                "description": "HCP subject folder, downloaded from http://www.humanconnectome.org/documentation/S500.",
+                "value-key": "[SUBJECT_FOLDER]",
+                "type": "File",
+                "optional": false,
+                "id": "subject_folder",
+                "name": "HCP subject folder"
+            },
+            {
+                "description": "Use this parameter to give a name to the execution. Example: \"Exec-CentOS5-FSLbuild-CentOS5\". The results will be written in a folder named [SUBJECT]-[EXECUTION-NAME] (a unique identifier will be appended in case a file with the same name already exists).",
+                "default-value": "Exec-CentOS-[X]-FSLbuild-CentOS-[Y]",
+                "value-key": "[NAME]",
+                "optional": false,
+                "type": "String",
+                "id": "execution_name",
+                "name": "Execution name"
+            }
+        ],
+        "container-image": {
+            "image": "bigdatalabteam/hcp-prefreesurfer:exec-centos7-fslbuild-centos5-latest",
+            "type": "docker"
+        },
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[SUBJECT_FOLDER]-[NAME]",
+                "description": "This directory will contain 3 directories (T1w, T2w and MNINonLinear), a monitoring file (monitor.txt) and the input data.",
+                "optional": false,
+                "id": "results",
+                "name": "Results"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 25200
+        },
+        "description": "PreFreeSurferPipelineBatch HCP pipeline",
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ]
+        }
+    },
+    {
+        "tool-version": "5.0.0",
+        "name": "fsl_fast",
+        "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+        "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_fast.json",
+        "command-line": "fast [NUM_CLASSES] [LOOP_ITERS] [BF_SMOOTHING] [IMG_TYPE] [INIT_SEG_SMOOTHNESS] [BINARY_SEGMENTS] [PRIOR_INIT] [NO_PVE] [BIAS_FIELD] [BIAS_CORR_IMG] [NO_BIAS_RM] [OUTPUT_BASENAME] [PRIORS_THROUGHOUT] [SEG_INIT_ITERS] [MIXEL_SMOOTHNESS] [NUM_MAIN_LOOP_ITERS] [HYPER_SEG_SMOOTHNESS] [VERBOSE] [MANUAL_INTENSITIES_FILE] [OUTPUT_PROB_MAPS] [IN_FILES]; mkdir [OUTPUT_DIRECTORY]; mv [OUTPUT_DIRECTORY]_* [OUTPUT_DIRECTORY]",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "inputs": [
+            {
+                "command-line-flag": "-n",
+                "description": "Number of tissue-type classes; default = 3.",
+                "value-key": "[NUM_CLASSES]",
+                "type": "Number",
+                "list": false,
+                "minimum": 1,
+                "integer": true,
+                "optional": true,
+                "id": "num_classes",
+                "name": "Number of tissue-type classes"
+            },
+            {
+                "command-line-flag": "-I",
+                "description": "Number of main-loop iterations during bias-field removal (default = 4).",
+                "value-key": "[LOOP_ITERS]",
+                "type": "Number",
+                "list": false,
+                "minimum": 1,
+                "integer": true,
+                "optional": true,
+                "id": "loop_iters",
+                "name": "Bias removal main-loop iterations"
+            },
+            {
+                "command-line-flag": "-l",
+                "description": "Bias field smoothing extent (FWHM) in mm (default = 20).",
+                "value-key": "[BF_SMOOTHING]",
+                "optional": true,
+                "list": false,
+                "minimum": 0,
+                "type": "Number",
+                "id": "bf_smoothing",
+                "name": "Bias field smoothing"
+            },
+            {
+                "command-line-flag": "-t",
+                "description": "Type of image: 1 = T1, 2 = T2, 3 = PD. Default = T1.",
+                "value-key": "[IMG_TYPE]",
+                "type": "String",
+                "list": false,
+                "value-choices": [
+                    "1",
+                    "2",
+                    "3"
+                ],
+                "optional": true,
+                "id": "img_type",
+                "name": "Image type"
+            },
+            {
+                "command-line-flag": "-f",
+                "description": "Initial segmentation spatial smoothness (during bias field estimation); default = 0.02.",
+                "value-key": "[INIT_SEG_SMOOTHNESS]",
+                "type": "Number",
+                "list": false,
+                "optional": true,
+                "id": "init_seg_smoothness",
+                "name": "Initial segmentation smoothness"
+            },
+            {
+                "command-line-flag": "-g",
+                "description": "Outputs a separate binary image for each tissue type",
+                "value-key": "[BINARY_SEGMENTS]",
+                "type": "Flag",
+                "list": false,
+                "optional": true,
+                "id": "binary_segments",
+                "name": "Binary images"
+            },
+            {
+                "command-line-flag": "-a",
+                "description": "Initialize using priors. A FLIRT transform must be provided (e.g. std2input.mat)",
+                "value-key": "[PRIOR_INIT]",
+                "type": "File",
+                "list": false,
+                "optional": true,
+                "id": "prior_init",
+                "name": "Prior Initialization"
+            },
+            {
+                "command-line-flag": "--nopve",
+                "description": "Turn off PVE (partial volume estimation).",
+                "value-key": "[NO_PVE]",
+                "optional": true,
+                "list": false,
+                "type": "Flag",
+                "id": "no_pve",
+                "name": "No PVE"
+            },
+            {
+                "command-line-flag": "-b",
+                "description": "Output estimated bias field.",
+                "value-key": "[BIAS_FIELD]",
+                "type": "Flag",
+                "list": false,
+                "optional": true,
+                "id": "bias_field",
+                "name": "Bias field"
+            },
+            {
+                "command-line-flag": "-B",
+                "description": "Output bias corrected image.",
+                "value-key": "[BIAS_CORR_IMG]",
+                "type": "Flag",
+                "list": false,
+                "optional": true,
+                "id": "bias_corr_img",
+                "name": "Bias corrected image"
+            },
+            {
+                "command-line-flag": "-N",
+                "description": "Does not remove the bias field.",
+                "value-key": "[NO_BIAS_RM]",
+                "type": "Flag",
+                "list": false,
+                "optional": true,
+                "id": "no_bias_rm",
+                "name": "No bias removal"
+            },
+            {
+                "command-line-flag": "-o",
+                "description": "The basename of the output files.",
+                "default-value": "fast",
+                "value-key": "[OUTPUT_BASENAME]",
+                "type": "String",
+                "list": false,
+                "optional": false,
+                "id": "output_basename",
+                "name": "Output basename"
+            },
+            {
+                "command-line-flag": "-P",
+                "description": "Use priors throughout the process",
+                "value-key": "[PRIORS_THROUGHOUT]",
+                "type": "Flag",
+                "list": false,
+                "requires-inputs": [
+                    "prior_init"
+                ],
+                "optional": true,
+                "id": "priors_throughout",
+                "name": "Use priors throughout"
+            },
+            {
+                "command-line-flag": "-W",
+                "description": "Number of segmentation-initialisation iterations; default = 15.",
+                "value-key": "[SEG_INIT_ITERS]",
+                "optional": true,
+                "list": false,
+                "minimum": 1,
+                "integer": true,
+                "type": "Number",
+                "id": "seg_init_iters",
+                "name": "Segmentation initialization iterations"
+            },
+            {
+                "command-line-flag": "-R",
+                "description": "Spatial smoothness of mixeltype; default = 0.3.",
+                "value-key": "[MIXEL_SMOOTHNESS]",
+                "type": "Number",
+                "list": false,
+                "optional": true,
+                "id": "mixel_smoothness",
+                "name": "Mixeltype Smoothness"
+            },
+            {
+                "command-line-flag": "-O",
+                "description": "Number of main-loop iterations after bias-field removal (default = 4).",
+                "value-key": "[NUM_MAIN_LOOP_ITERS]",
+                "optional": true,
+                "list": false,
+                "minimum": 1,
+                "integer": true,
+                "type": "Number",
+                "id": "num_main_loop_iters",
+                "name": "Main loop iterations"
+            },
+            {
+                "command-line-flag": "-H",
+                "description": "Segmentation spatial smoothness; default = 0.1.",
+                "value-key": "[HYPER_SEG_SMOOTHNESS]",
+                "type": "Number",
+                "list": false,
+                "optional": true,
+                "id": "hyper_seg_smoothness",
+                "name": "Segmentation spatial smoothness"
+            },
+            {
+                "command-line-flag": "-v",
+                "description": "Verbose mode",
+                "value-key": "[VERBOSE]",
+                "type": "Flag",
+                "list": false,
+                "optional": true,
+                "id": "verbose",
+                "name": "Verbose"
+            },
+            {
+                "command-line-flag": "-s",
+                "description": "Filename containing the intensities",
+                "value-key": "[MANUAL_INTENSITIES_FILE]",
+                "type": "File",
+                "list": false,
+                "optional": true,
+                "id": "manual_intensities_file",
+                "name": "Manual segmentation"
+            },
+            {
+                "command-line-flag": "-p",
+                "description": "Output individual probability maps",
+                "value-key": "[OUTPUT_PROB_MAPS]",
+                "optional": true,
+                "list": false,
+                "type": "Flag",
+                "id": "output_prob_maps",
+                "name": "Single probability maps"
+            },
+            {
+                "description": "Input file",
+                "value-key": "[IN_FILES]",
+                "type": "File",
+                "list": false,
+                "optional": false,
+                "id": "in_files",
+                "name": "Input file"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "description": "Output files from FSL FAST",
+                "value-key": "[OUTPUT_DIRECTORY]",
+                "id": "output_dir",
+                "optional": false,
+                "path-template": "[OUTPUT_BASENAME]",
+                "name": "Output Directory"
+            }
+        ],
+        "tests": [
+            {
+                "name": "fsl_fast_test",
+                "invocation": {
+                    "in_files": "sub-01_T1w.nii.gz",
+                    "output_basename": "img_fast"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "output_dir"
+                        }
+                    ]
+                }
+            }
+        ],
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ]
+        },
+        "description": "FAST (FMRIB's Automated Segmentation Tool) segments a 3D image of the brain into different tissue types (Grey Matter, White Matter, CSF, etc.), whilst also correcting for spatial intensity variations (also known as bias field or RF inhomogeneities), via a hidden Markov random field model and an associated EM algorithm. Note that the alternative priors option is not supported at this time."
+    },
+    {
+        "name": "FNIRT",
+        "command-line": "fnirt [AFFINE_FILE] [APPLY_INMASK] [APPLY_INTENSITY_MAPPING] [APPLY_REFMASK] [BIAS_REGULARIZATION_LAMBDA] [BIASFIELD_RESOLUTION] [CONFIG_FILE] [DERIVE_FROM_REF] [FIELD_FILE] [FIELDCOEFF_FILE] [HESSIAN_PRECISION] [IN_FILE] [IN_FWHM] [IN_INTENSITYMAP_FILE] [INMASK_FILE] [INMASK_VAL] [INTENSITY_MAPPING_MODEL] [INTENSITY_MAPPING_ORDER] [INWARP_FILE] [JACOBIAN_FILE] [JACOBIAN_RANGE] [LOG_FILE] [MAX_NONLIN_ITER] [MODULATEDREF_FILE] [OUT_INTENSITYMAP_FILE] [REF_FILE] [REF_FWHM] [REFMASK_FILE] [REFMASK_VAL] [REGULARIZATION_LAMBDA] [REGULARIZATION_MODEL] [SKIP_IMPLICIT_IN_MASKING] [SKIP_IMPLICIT_REF_MASKING] [SKIP_INMASK] [SKIP_INTENSITY_MAPPING] [SKIP_LAMBDA_SSQ] [SKIP_REFMASK] [SPLINE_ORDER] [SUBSAMPLING_SCHEME] [WARP_RESOLUTION] [WARPED_FILE]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "FNIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FNIRT).",
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/preprocess.py",
+        "inputs": [
+            {
+                "id": "affine_file",
+                "name": "Affine file",
+                "type": "File",
+                "value-key": "[AFFINE_FILE]",
+                "command-line-flag": "--aff",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of file containing affine transform.",
+                "optional": true
+            },
+            {
+                "id": "apply_inmask",
+                "name": "Apply inmask",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ],
+                "list-separator": ",",
+                "value-key": "[APPLY_INMASK]",
+                "command-line-flag": "--applyinmask",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are 0 or 1. List of iterations to use input mask on (1 to use, 0 to skip).",
+                "optional": true
+            },
+            {
+                "id": "apply_intensity_mapping",
+                "name": "Apply intensity mapping",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ],
+                "list-separator": ",",
+                "value-key": "[APPLY_INTENSITY_MAPPING]",
+                "command-line-flag": "--estint",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are 0 or 1. List of subsampling levels to apply intensity mapping for (0 to skip, 1 to apply).",
+                "optional": true
+            },
+            {
+                "id": "apply_refmask",
+                "name": "Apply refmask",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ],
+                "list-separator": ",",
+                "value-key": "[APPLY_REFMASK]",
+                "command-line-flag": "--applyrefmask",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are 0 or 1. List of iterations to use reference mask on (1 to use, 0 to skip).",
+                "optional": true
+            },
+            {
+                "id": "bias_regularization_lambda",
+                "name": "Bias regularization lambda",
+                "type": "Number",
+                "value-key": "[BIAS_REGULARIZATION_LAMBDA]",
+                "command-line-flag": "--biaslambda",
+                "command-line-flag-separator": "=",
+                "description": "A float. Weight of regularisation for bias-field, default 10000.",
+                "optional": true
+            },
+            {
+                "id": "biasfield_resolution",
+                "name": "Biasfield resolution",
+                "type": "Number",
+                "list": true,
+                "list-separator": ",",
+                "min-list-entries": 3,
+                "max-list-entries": 3,
+                "integer": true,
+                "value-key": "[BIASFIELD_RESOLUTION]",
+                "command-line-flag": "--biasres",
+                "command-line-flag-separator": "=",
+                "description": "A tuple of the form: (an integer (int or long), an integer (int or long), an integer (int or long)). Resolution (in mm) of bias-field modelling local intensities, default 50, 50, 50.",
+                "optional": true
+            },
+            {
+                "id": "config_file_choices",
+                "name": "Config file",
+                "type": "String",
+                "value-key": "[CONFIG_FILE]",
+                "command-line-flag": "--config",
+                "command-line-flag-separator": "=",
+                "description": "'t1_2_mni152_2mm' or 'fa_2_fmrib58_1mm' or an existing file name. Name of config file specifying command line arguments.",
+                "optional": true,
+                "value-choices": [
+                    "T1_2_MNI152_2mm",
+                    "FA_2_FMRIB58_1mm"
+                ]
+            },
+            {
+                "id": "config_file",
+                "name": "Config file",
+                "type": "File",
+                "value-key": "[CONFIG_FILE]",
+                "command-line-flag": "--config",
+                "command-line-flag-separator": "=",
+                "description": "'t1_2_mni152_2mm' or 'fa_2_fmrib58_1mm' or an existing file name. Name of config file specifying command line arguments.",
+                "optional": true
+            },
+            {
+                "id": "derive_from_ref",
+                "name": "Derive from ref",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[DERIVE_FROM_REF]",
+                "command-line-flag": "--refderiv",
+                "command-line-flag-separator": "=",
+                "description": "A boolean. If true, ref image is used to calculate derivatives. default false.",
+                "optional": true,
+                "value-choices": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "id": "field_file",
+                "name": "Field file",
+                "type": "File",
+                "value-key": "[FIELD_FILE]",
+                "command-line-flag": "--fout",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Name of output file with field.",
+                "optional": true
+            },
+            {
+                "id": "fieldcoeff_file",
+                "name": "Fieldcoeff file",
+                "type": "File",
+                "value-key": "[FIELDCOEFF_FILE]",
+                "command-line-flag": "--cout",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Name of output file with field coefficients.",
+                "optional": true
+            },
+            {
+                "id": "hessian_precision",
+                "name": "Hessian precision",
+                "type": "String",
+                "value-key": "[HESSIAN_PRECISION]",
+                "command-line-flag": "--numprec",
+                "command-line-flag-separator": "=",
+                "description": "'double' or 'float'. Precision for representing hessian, double or float. default double.",
+                "optional": true,
+                "value-choices": [
+                    "double",
+                    "float"
+                ]
+            },
+            {
+                "id": "in_file",
+                "name": "In file",
+                "type": "File",
+                "value-key": "[IN_FILE]",
+                "command-line-flag": "--in",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of input image.",
+                "optional": false
+            },
+            {
+                "id": "in_fwhm",
+                "name": "In fwhm",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "list-separator": ",",
+                "value-key": "[IN_FWHM]",
+                "command-line-flag": "--infwhm",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are an integer (int or long). Fwhm (in mm) of gaussian smoothing kernel for input volume, default [6, 4, 2, 2].",
+                "optional": true
+            },
+            {
+                "id": "in_intensitymap_file",
+                "name": "In intensitymap file",
+                "type": "File",
+                "list": true,
+                "min-list-entries": 1,
+                "max-list-entries": 2,
+                "value-key": "[IN_INTENSITYMAP_FILE]",
+                "command-line-flag": "--intin",
+                "command-line-flag-separator": "=",
+                "description": "A list of from 1 to 2 items which are an existing file name. Name of file/files containing initial intensity mapping usually generated by previous fnirt run.",
+                "optional": true
+            },
+            {
+                "id": "inmask_file",
+                "name": "Inmask file",
+                "type": "File",
+                "value-key": "[INMASK_FILE]",
+                "command-line-flag": "--inmask",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of file with mask in input image space.",
+                "optional": true
+            },
+            {
+                "id": "inmask_val",
+                "name": "Inmask val",
+                "type": "Number",
+                "value-key": "[INMASK_VAL]",
+                "command-line-flag": "--impinval",
+                "command-line-flag-separator": "=",
+                "description": "A float. Value to mask out in --in image. default =0.0.",
+                "optional": true
+            },
+            {
+                "id": "intensity_mapping_model",
+                "name": "Intensity mapping model",
+                "type": "String",
+                "value-key": "[INTENSITY_MAPPING_MODEL]",
+                "command-line-flag": "--intmod",
+                "command-line-flag-separator": "=",
+                "description": "'none' or 'global_linear' or 'global_non_linear' or 'local_linear' or 'global_non_linear_with_bias' or 'local_non_linear'. Model for intensity-mapping.",
+                "optional": true,
+                "value-choices": [
+                    "none",
+                    "global_linear",
+                    "global_non_linear",
+                    "local_linear",
+                    "global_non_linear_with_bias",
+                    "local_non_linear"
+                ]
+            },
+            {
+                "id": "intensity_mapping_order",
+                "name": "Intensity mapping order",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[INTENSITY_MAPPING_ORDER]",
+                "command-line-flag": "--intorder",
+                "command-line-flag-separator": "=",
+                "description": "An integer (int or long). Order of poynomial for mapping intensities, default 5.",
+                "optional": true
+            },
+            {
+                "id": "inwarp_file",
+                "name": "Inwarp file",
+                "type": "File",
+                "value-key": "[INWARP_FILE]",
+                "command-line-flag": "--inwarp",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of file containing initial non-linear warps.",
+                "optional": true
+            },
+            {
+                "id": "jacobian_file",
+                "name": "Jacobian file",
+                "type": "File",
+                "value-key": "[JACOBIAN_FILE]",
+                "command-line-flag": "--jout",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Name of file for writing out the jacobian of the field (for diagnostic or vbm purposes).",
+                "optional": true
+            },
+            {
+                "id": "jacobian_range",
+                "name": "Jacobian range",
+                "type": "Number",
+                "list": true,
+                "list-separator": ",",
+                "min-list-entries": 2,
+                "max-list-entries": 2,
+                "value-key": "[JACOBIAN_RANGE]",
+                "command-line-flag": "--jacrange",
+                "command-line-flag-separator": "=",
+                "description": "A tuple of the form: (a float, a float). Allowed range of jacobian determinants, default 0.01, 100.0.",
+                "optional": true
+            },
+            {
+                "id": "log_file",
+                "name": "Log file",
+                "type": "File",
+                "value-key": "[LOG_FILE]",
+                "command-line-flag": "--logout",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Name of log-file.",
+                "optional": true
+            },
+            {
+                "id": "max_nonlin_iter",
+                "name": "Max nonlin iter",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "list-separator": ",",
+                "value-key": "[MAX_NONLIN_ITER]",
+                "command-line-flag": "--miter",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are an integer (int or long). Max # of non-linear iterations list, default [5, 5, 5, 5].",
+                "optional": true
+            },
+            {
+                "id": "modulatedref_file",
+                "name": "Modulatedref file",
+                "type": "File",
+                "value-key": "[MODULATEDREF_FILE]",
+                "command-line-flag": "--refout",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Name of file for writing out intensity modulated --ref (for diagnostic purposes).",
+                "optional": true
+            },
+            {
+                "id": "out_intensitymap_file",
+                "name": "Out intensitymap file",
+                "type": "File",
+                "value-key": "[OUT_INTENSITYMAP_FILE]",
+                "command-line-flag": "--intout",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Name of files for writing information pertaining to intensity mapping.",
+                "optional": true
+            },
+            {
+                "id": "ref_file",
+                "name": "Ref file",
+                "type": "File",
+                "value-key": "[REF_FILE]",
+                "command-line-flag": "--ref",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of reference image.",
+                "optional": false
+            },
+            {
+                "id": "ref_fwhm",
+                "name": "Ref fwhm",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "list-separator": ",",
+                "value-key": "[REF_FWHM]",
+                "command-line-flag": "--reffwhm",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are an integer (int or long). Fwhm (in mm) of gaussian smoothing kernel for ref volume, default [4, 2, 0, 0].",
+                "optional": true
+            },
+            {
+                "id": "refmask_file",
+                "name": "Refmask file",
+                "type": "File",
+                "value-key": "[REFMASK_FILE]",
+                "command-line-flag": "--refmask",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of file with mask in reference space.",
+                "optional": true
+            },
+            {
+                "id": "refmask_val",
+                "name": "Refmask val",
+                "type": "Number",
+                "value-key": "[REFMASK_VAL]",
+                "command-line-flag": "--imprefval",
+                "command-line-flag-separator": "=",
+                "description": "A float. Value to mask out in --ref image. default =0.0.",
+                "optional": true
+            },
+            {
+                "id": "regularization_lambda",
+                "name": "Regularization lambda",
+                "type": "Number",
+                "list": true,
+                "list-separator": ",",
+                "value-key": "[REGULARIZATION_LAMBDA]",
+                "command-line-flag": "--lambda",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are a float. Weight of regularisation, default depending on --ssqlambda and --regmod switches. see user documetation.",
+                "optional": true
+            },
+            {
+                "id": "regularization_model",
+                "name": "Regularization model",
+                "type": "String",
+                "value-key": "[REGULARIZATION_MODEL]",
+                "command-line-flag": "--regmod",
+                "command-line-flag-separator": "=",
+                "description": "'membrane_energy' or 'bending_energy'. Model for regularisation of warp-field [membrane_energy bending_energy], default bending_energy.",
+                "optional": true,
+                "value-choices": [
+                    "membrane_energy",
+                    "bending_energy"
+                ]
+            },
+            {
+                "id": "skip_implicit_in_masking",
+                "name": "Skip implicit in masking",
+                "type": "Flag",
+                "value-key": "[SKIP_IMPLICIT_IN_MASKING]",
+                "command-line-flag": "--impinm=0",
+                "description": "A boolean. Skip implicit masking  based on value in --in image. default = 0.",
+                "optional": true
+            },
+            {
+                "id": "skip_implicit_ref_masking",
+                "name": "Skip implicit ref masking",
+                "type": "Flag",
+                "value-key": "[SKIP_IMPLICIT_REF_MASKING]",
+                "command-line-flag": "--imprefm=0",
+                "description": "A boolean. Skip implicit masking  based on value in --ref image. default = 0.",
+                "optional": true
+            },
+            {
+                "id": "skip_inmask",
+                "name": "Skip inmask",
+                "type": "Flag",
+                "value-key": "[SKIP_INMASK]",
+                "command-line-flag": "--applyinmask=0",
+                "description": "A boolean. Skip specified inmask if set, default false.",
+                "optional": true
+            },
+            {
+                "id": "skip_intensity_mapping",
+                "name": "Skip intensity mapping",
+                "type": "Flag",
+                "value-key": "[SKIP_INTENSITY_MAPPING]",
+                "command-line-flag": "--estint=0",
+                "description": "A boolean. Skip estimate intensity-mapping default false.",
+                "optional": true
+            },
+            {
+                "id": "skip_lambda_ssq",
+                "name": "Skip lambda ssq",
+                "type": "Flag",
+                "value-key": "[SKIP_LAMBDA_SSQ]",
+                "command-line-flag": "--ssqlambda=0",
+                "description": "A boolean. If true, lambda is not weighted by current ssq, default false.",
+                "optional": true
+            },
+            {
+                "id": "skip_refmask",
+                "name": "Skip refmask",
+                "type": "Flag",
+                "value-key": "[SKIP_REFMASK]",
+                "command-line-flag": "--applyrefmask=0",
+                "description": "A boolean. Skip specified refmask if set, default false.",
+                "optional": true
+            },
+            {
+                "id": "spline_order",
+                "name": "Spline order",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[SPLINE_ORDER]",
+                "command-line-flag": "--splineorder",
+                "command-line-flag-separator": "=",
+                "description": "An integer (int or long). Order of spline, 2->quadratic spline, 3->cubic spline. default=3.",
+                "optional": true,
+                "value-choices": [
+                    2,
+                    3
+                ]
+            },
+            {
+                "id": "subsampling_scheme",
+                "name": "Subsampling scheme",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "list-separator": ",",
+                "value-key": "[SUBSAMPLING_SCHEME]",
+                "command-line-flag": "--subsamp",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are an integer (int or long). Sub-sampling scheme, list, default [4, 2, 1, 1].",
+                "optional": true
+            },
+            {
+                "id": "warp_resolution",
+                "name": "Warp resolution",
+                "type": "Number",
+                "list": true,
+                "list-separator": ",",
+                "min-list-entries": 3,
+                "max-list-entries": 3,
+                "integer": true,
+                "value-key": "[WARP_RESOLUTION]",
+                "command-line-flag": "--warpres",
+                "command-line-flag-separator": "=",
+                "description": "A tuple of the form: (an integer (int or long), an integer (int or long), an integer (int or long)). (approximate) resolution (in mm) of warp basis in x-, y- and z-direction, default 10, 10, 10.",
+                "optional": true
+            },
+            {
+                "id": "warped_file",
+                "name": "Warped file",
+                "type": "File",
+                "value-key": "[WARPED_FILE]",
+                "command-line-flag": "--iout",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Name of output image.",
+                "optional": true
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Field file",
+                "id": "field_file_outfile",
+                "path-template": "[FIELD_FILE]",
+                "optional": true,
+                "description": "A file name. File with warp field."
+            },
+            {
+                "name": "Fieldcoeff file",
+                "id": "fieldcoeff_file_outfile",
+                "path-template": "[FIELDCOEFF_FILE]",
+                "optional": true,
+                "description": "An existing file name. File with field coefficients."
+            },
+            {
+                "name": "Jacobian file",
+                "id": "jacobian_file_outfile",
+                "path-template": "[JACOBIAN_FILE]",
+                "optional": true,
+                "description": "A file name. File containing jacobian of the field."
+            },
+            {
+                "name": "Log file",
+                "id": "log_file_outfile",
+                "path-template": "[LOG_FILE]",
+                "optional": true,
+                "description": "A file name. Name of log-file."
+            },
+            {
+                "name": "Modulatedref file",
+                "id": "modulatedref_file_outfile",
+                "path-template": "[MODULATEDREF_FILE]",
+                "optional": true,
+                "description": "A file name. File containing intensity modulated --ref."
+            },
+            {
+                "name": "Out intensitymap file",
+                "id": "out_intensitymap_file_outfile",
+                "path-template": "[OUT_INTENSITYMAP_FILE]",
+                "optional": true,
+                "description": "A list of from 2 to 2 items which are a file name. Files containing info pertaining to intensity mapping.",
+                "list": true
+            },
+            {
+                "name": "Warped file",
+                "id": "warped_file_outfile",
+                "path-template": "[WARPED_FILE]",
+                "optional": true,
+                "description": "An existing file name. Warped image."
+            }
+        ],
+        "groups": [
+            {
+                "id": "config_file_group",
+                "name": "Config file group",
+                "members": [
+                    "config_file",
+                    "config_file_choices"
+                ],
+                "mutually-exclusive": true
+            },
+            {
+                "id": "mutex_group",
+                "name": "Mutex group",
+                "members": [
+                    "apply_refmask",
+                    "skip_refmask"
+                ],
+                "mutually-exclusive": true
+            },
+            {
+                "id": "mutex_group_2",
+                "name": "Mutex group 2",
+                "members": [
+                    "apply_inmask",
+                    "skip_inmask"
+                ],
+                "mutually-exclusive": true
+            },
+            {
+                "id": "mutex_group_3",
+                "name": "Mutex group 3",
+                "members": [
+                    "skip_intensity_mapping",
+                    "apply_intensity_mapping"
+                ],
+                "mutually-exclusive": true
+            }
+        ],
+        "tool-version": "1.0.1",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "fmri"
+            ],
+            "source": "nipype-interface"
+        }
+    },
+    {
+        "author": "Greg Kiar, using FSL from FMRIB at Oxford",
+        "command-line": "python3 /opt/preprocessing_pipeline.py [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [PARTICIPANT_LABEL] [SESSION_LABEL] [VERBOSE] [BOUTIQUES] [GPU] [FSLDIR] [PARCELLATION]",
+        "container-image": {
+            "image": "gkiar/dwipreproc_fsl-5.0.11_minified",
+            "index": "docker.io",
+            "type": "docker"
+        },
+        "description": "Preprocessing pipeline for diffusion MRI data using the FSL software suite.",
+        "inputs": [
+            {
+                "description": "Directory to a BIDS-organized dataset.",
+                "id": "bids_dir",
+                "name": "bids_dir",
+                "optional": false,
+                "type": "String",
+                "value-key": "[BIDS_DIR]"
+            },
+            {
+                "description": "Directory to store the preprocessed derivatives.",
+                "id": "output_dir",
+                "name": "output_dir",
+                "optional": false,
+                "type": "String",
+                "value-key": "[OUTPUT_DIR]"
+            },
+            {
+                "description": "Level of analysis to perform. Options: session",
+                "id": "analysis_level",
+                "name": "analysis_level",
+                "optional": false,
+                "type": "String",
+                "value-choices": [
+                    "session"
+                ],
+                "value-key": "[ANALYSIS_LEVEL]"
+            },
+            {
+                "command-line-flag": "--participant_label",
+                "description": "Label of the participant(s) to process, omitting the 'sub-' portion of the directory name. Supplying none means the entire dataset will be processed.",
+                "id": "participant_label",
+                "name": "participant_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[PARTICIPANT_LABEL]"
+            },
+            {
+                "command-line-flag": "--session_label",
+                "description": "Label of the session(s) to process, omitting the 'ses-' portion of the directory name. Supplying none means the entire dataset will be processed.",
+                "id": "session_label",
+                "name": "session_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[SESSION_LABEL]"
+            },
+            {
+                "command-line-flag": "--verbose",
+                "description": "Flag toggling verbose output statements.",
+                "id": "verbose",
+                "name": "verbose",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[VERBOSE]"
+            },
+            {
+                "command-line-flag": "--boutiques",
+                "description": "Flag toggling descriptor creation.",
+                "id": "boutiques",
+                "name": "boutiques",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[BOUTIQUES]"
+            },
+            {
+                "command-line-flag": "--gpu",
+                "description": "Toggles using GPU accelerated eddy.",
+                "id": "gpu",
+                "name": "gpu",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[GPU]"
+            },
+            {
+                "command-line-flag": "--fsldir",
+                "default-value": "/usr/share/fsl/",
+                "description": "Path to local installation of FSL. Defaults to /usr/share/fsl/.",
+                "id": "fsldir",
+                "name": "fsldir",
+                "optional": true,
+                "type": "String",
+                "value-key": "[FSLDIR]"
+            },
+            {
+                "command-line-flag": "--parcellation",
+                "description": "Parcellation/Label volumes which will be transformed into the subject/session DWI space.",
+                "id": "parcellation",
+                "list": true,
+                "name": "parcellation",
+                "optional": true,
+                "type": "String",
+                "value-key": "[PARCELLATION]"
+            }
+        ],
+        "name": "BIDS App - FSL Diffusion Preprocessing",
+        "output-files": [
+            {
+                "description": "Directory to store the preprocessed derivatives.",
+                "id": "output_dir_path",
+                "name": "Output directory",
+                "optional": false,
+                "path-template": "[OUTPUT_DIR]"
+            }
+        ],
+        "schema-version": "0.5",
+        "suggested-resources": {
+            "cpu-cores": 1,
+            "ram": 8,
+            "walltime-estimate": 10800
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "diffusion MRI",
+                "dwi"
+            ]
+        },
+        "tool-version": "5.0.9"
+    },
+    {
+        "author": "Poldrack lab",
+        "command-line": "fmriprep [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [PARTICIPANT_LABEL] [TASK_ID] [VERSION] [NTHREADS] [OMP_NTHREADS] [MEM_MB] [LOW_MEM] [USE_PLUGIN] [ANAT_ONLY] [BOILERPLATE] [IGNORE_AROMA_DENOISING_ERRORS] [VERBOSE_COUNT] [DEBUG] [IGNORE] [LONGITUDINAL] [T2S_COREG] [BOLD2T1W_DOF] [OUTPUT_SPACE] [USE_BBR] [TEMPLATE] [OUTPUT_GRID_REFERENCE] [TEMPLATE_RESAMPLING_GRID] [MEDIAL_SURFACE_NAN] [USE_AROMA] [AROMA_MELODIC_DIMENSIONALITY] [SKULL_STRIP_TEMPLATE] [SKULL_STRIP_FIXED_SEED] [FMAP_BSPLINE] [FMAP_NO_DEMEAN] [USE_SYN_SDC] [FORCE_SYN] [FS_LICENSE_FILE] [HIRES] [CIFTI_OUTPUT] [RUN_RECONALL] [WORK_DIR] [RESOURCE_MONITOR] [REPORTS_ONLY] [RUN_UUID] [WRITE_GRAPH] [STOP_ON_FIRST_CRASH] [NOTRACK] [SLOPPY]",
+        "container-image": {
+            "image": "shots47s/bids-fmriprep-1.2.3",
+            "type": "singularity"
+        },
+        "custom": {
+            "cbrain:readonly-input-files": true
+        },
+        "description": "fMRIprep is a functional magneticresonance image pre-processing pipeline that is designed to provide an easily accessible, state-of-the-art interface that is robust to differences in scan acquisition protocols and that requires minimal user input, while providing easily interpretable and comprehensive error and output reporting. https://fmriprep.readthedocs.io",
+        "groups": [
+            {
+                "description": "Paramters used to define memory requirements and multithreading",
+                "id": "memory_and_parallelism",
+                "members": [
+                    "nthreads",
+                    "omp_nthreads",
+                    "mem_mb",
+                    "low_mem"
+                ],
+                "name": "Memory and Parallel Control Parameters"
+            },
+            {
+                "description": "Diagnostic parameters for debugging fMRIprep",
+                "id": "debugging",
+                "members": [
+                    "version",
+                    "verbose_count",
+                    "resource_monitor",
+                    "reports_only",
+                    "run_uuid",
+                    "stop_on_first_crash",
+                    "notrack",
+                    "write_graph",
+                    "sloppy"
+                ],
+                "name": "Debugging Parameters"
+            },
+            {
+                "description": "Parameters that one should use at their own risk.",
+                "id": "experimental",
+                "members": [
+                    "use_syn_sdc",
+                    "force_syn"
+                ],
+                "name": "Experimental Parameters"
+            },
+            {
+                "description": "Parameters that are no longer useful or supported",
+                "id": "deprecated",
+                "members": [
+                    "debug",
+                    "output_grid_reference"
+                ],
+                "name": "Deprecated Parameters"
+            }
+        ],
+        "inputs": [
+            {
+                "description": "the root folder of a BIDS valid dataset (sub-XXXXX folders should be found at the top level in this folder).",
+                "id": "bids_dir",
+                "name": "bids_dir",
+                "optional": false,
+                "type": "File",
+                "value-key": "[BIDS_DIR]"
+            },
+            {
+                "description": "the output path for the outcomes of preprocessing and visual reports",
+                "id": "output_dir",
+                "name": "output_dir",
+                "optional": false,
+                "type": "String",
+                "value-key": "[OUTPUT_DIR]"
+            },
+            {
+                "description": "processing stage to be run, only \"participant\" in the case of FMRIPREP (see BIDS-Apps specification).",
+                "id": "analysis_level",
+                "name": "analysis_level",
+                "optional": false,
+                "type": "String",
+                "value-choices": [
+                    "participant"
+                ],
+                "value-key": "[ANALYSIS_LEVEL]"
+            },
+            {
+                "command-line-flag": "--version",
+                "default-value": false,
+                "description": "show program's version number and exit",
+                "id": "version",
+                "name": "version",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[VERSION]"
+            },
+            {
+                "command-line-flag": "--participant_label",
+                "description": "a space delimited list of participant identifiers or a single identifier (the sub- prefix can be removed)",
+                "id": "participant_label",
+                "list": true,
+                "name": "participant_label",
+                "optional": true,
+                "type": "String",
+                "value-key": "[PARTICIPANT_LABEL]"
+            },
+            {
+                "command-line-flag": "-t",
+                "description": "select a specific task to be processed",
+                "id": "task_id",
+                "name": "task_id",
+                "optional": true,
+                "type": "String",
+                "value-key": "[TASK_ID]"
+            },
+            {
+                "command-line-flag": "--fs-license-file",
+                "description": "Path to FreeSurfer license key file. Get it (for free) by registering at https://surfer.nmr.mgh.harvard.edu/registration.html",
+                "id": "fs_license_file",
+                "name": "fs_license_file",
+                "optional": true,
+                "type": "File",
+                "uses-absolute-path": true,
+                "value-key": "[FS_LICENSE_FILE]"
+            },
+            {
+                "command-line-flag": "--nthreads",
+                "default-value": 4,
+                "description": "maximum number of threads across all processes",
+                "id": "nthreads",
+                "name": "nthreads",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[NTHREADS]"
+            },
+            {
+                "command-line-flag": "--omp-nthreads",
+                "default-value": 4,
+                "description": "maximum number of threads per-process",
+                "id": "omp_nthreads",
+                "name": "omp_nthreads",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[OMP_NTHREADS]"
+            },
+            {
+                "command-line-flag": "--mem_mb",
+                "default-value": 8192,
+                "description": "upper bound memory limit for FMRIPREP processes",
+                "id": "mem_mb",
+                "name": "mem_mb",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[MEM_MB]"
+            },
+            {
+                "command-line-flag": "--low-mem",
+                "description": "attempt to reduce memory usage (will increase disk usage in working directory)",
+                "id": "low_mem",
+                "name": "low_mem",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[LOW_MEM]"
+            },
+            {
+                "command-line-flag": "--use-plugin",
+                "description": "nipype plugin configuration file",
+                "id": "use_plugin",
+                "name": "use_plugin",
+                "optional": true,
+                "type": "String",
+                "value-key": "[USE_PLUGIN]"
+            },
+            {
+                "command-line-flag": "--anat-only",
+                "description": "run anatomical workflows only",
+                "id": "anat_only",
+                "name": "anat_only",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[ANAT_ONLY]"
+            },
+            {
+                "command-line-flag": "--boilerplate",
+                "description": "generate boilerplate only",
+                "id": "boilerplate",
+                "name": "boilerplate",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[BOILERPLATE]"
+            },
+            {
+                "command-line-flag": "--ignore-aroma-denoising-errors",
+                "description": "ignores the errors ICA_AROMA returns when there are no components classified as either noise or signal",
+                "id": "ignore_aroma_denoising_errors",
+                "name": "ignore_aroma_denoising_errors",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[IGNORE_AROMA_DENOISING_ERRORS]"
+            },
+            {
+                "command-line-flag": "-v",
+                "description": "increases log verbosity for each occurence, debug level is -vvv",
+                "id": "verbose_count",
+                "name": "verbose_count",
+                "optional": true,
+                "type": "String",
+                "value-key": "[VERBOSE_COUNT]"
+            },
+            {
+                "command-line-flag": "--debug",
+                "description": "DEPRECATED - Does not do what you want.",
+                "id": "debug",
+                "name": "debug",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[DEBUG]"
+            },
+            {
+                "command-line-flag": "--ignore",
+                "description": "ignore selected aspects of the input dataset to disable corresponding parts of the workflow (a space delimited list)",
+                "id": "ignore",
+                "list": true,
+                "name": "ignore",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "fieldmaps",
+                    "slicetiming",
+                    "sbref"
+                ],
+                "value-key": "[IGNORE]"
+            },
+            {
+                "command-line-flag": "--longitudinal",
+                "description": "treat dataset as longitudinal - may increase runtime",
+                "id": "longitudinal",
+                "name": "longitudinal",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[LONGITUDINAL]"
+            },
+            {
+                "command-line-flag": "--t2s-coreg",
+                "description": "If provided with multi-echo BOLD dataset, create T2*-map and perform T2*-driven coregistration. When multi-echo data is provided and this option is not enabled, standard EPI-T1 coregistration is performed using the middle echo.",
+                "id": "t2s_coreg",
+                "name": "t2s_coreg",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[T2S_COREG]"
+            },
+            {
+                "command-line-flag": "--bold2t1w-dof",
+                "default-value": 6,
+                "description": "Degrees of freedom when registering BOLD to T1w images. 6 degrees (rotation and translation) are used by default.",
+                "id": "bold2t1w_dof",
+                "name": "bold2t1w_dof",
+                "optional": true,
+                "type": "Number",
+                "value-choices": [
+                    6,
+                    9,
+                    12
+                ],
+                "value-key": "[BOLD2T1W_DOF]"
+            },
+            {
+                "command-line-flag": "--output-space",
+                "description": "volume and surface spaces to resample functional series into\n - T1w: subject anatomical volume\n - template: normalization target specified by --template\n - fsnative: individual subject surface\n - fsaverage*: FreeSurfer average meshes\nthis argument can be single value or a space delimited list,\nfor example: --output-space T1w fsnative",
+                "id": "output_space",
+                "list": true,
+                "name": "output_space",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "T1w",
+                    "template",
+                    "fsnative",
+                    "fsaverage",
+                    "fsaverage6",
+                    "fsaverage5"
+                ],
+                "value-key": "[OUTPUT_SPACE]"
+            },
+            {
+                "command-line-flag": "--force-bbr",
+                "description": "Always use boundary-based registration (no goodness-of-fit checks)",
+                "id": "use_bbr",
+                "name": "use_bbr",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[USE_BBR]"
+            },
+            {
+                "command-line-flag": "--template",
+                "default-value": "MNI152NLin2009cAsym",
+                "description": "volume template space (default: MNI152NLin2009cAsym)",
+                "id": "template",
+                "name": "template",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "MNI152NLin2009cAsym"
+                ],
+                "value-key": "[TEMPLATE]"
+            },
+            {
+                "command-line-flag": "--output-grid-reference",
+                "description": "Deprecated after FMRIPREP 1.0.8. Please use --template-resampling-grid instead.",
+                "id": "output_grid_reference",
+                "name": "output_grid_reference",
+                "optional": true,
+                "type": "String",
+                "value-key": "[OUTPUT_GRID_REFERENCE]"
+            },
+            {
+                "command-line-flag": "--template-resampling-grid",
+                "default-value": "native",
+                "description": "Keyword (\"native\", \"1mm\", or \"2mm\") or path to an existing file. Allows to define a reference grid for the resampling of BOLD images in template space. Keyword \"native\" will use the original BOLD grid as reference. Keywords \"1mm\" and \"2mm\" will use the corresponding isotropic template resolutions. If a path is given, the grid of that image will be used. It determines the field of view and resolution of the output images, but is not used in normalization.",
+                "id": "template_resampling_grid",
+                "name": "template_resampling_grid",
+                "optional": true,
+                "type": "String",
+                "value-key": "[TEMPLATE_RESAMPLING_GRID]"
+            },
+            {
+                "command-line-flag": "--medial-surface-nan",
+                "description": "Replace medial wall values with NaNs on functional GIFTI files. Only performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).",
+                "id": "medial_surface_nan",
+                "name": "medial_surface_nan",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[MEDIAL_SURFACE_NAN]"
+            },
+            {
+                "command-line-flag": "--use-aroma",
+                "description": "add ICA_AROMA to your preprocessing stream",
+                "id": "use_aroma",
+                "name": "use_aroma",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[USE_AROMA]"
+            },
+            {
+                "command-line-flag": "--aroma-melodic-dimensionality",
+                "default-value": -200,
+                "description": "Exact or maximum number of MELODIC components to estimate (positive = exact, negative = maximum)",
+                "id": "aroma_melodic_dimensionality",
+                "name": "aroma_melodic_dimensionality",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[AROMA_MELODIC_DIMENSIONALITY]"
+            },
+            {
+                "command-line-flag": "--skull-strip-template",
+                "default-value": "OASIS",
+                "description": "select ANTs skull-stripping template (default: OASIS))",
+                "id": "skull_strip_template",
+                "name": "skull_strip_template",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "OASIS",
+                    "NKI"
+                ],
+                "value-key": "[SKULL_STRIP_TEMPLATE]"
+            },
+            {
+                "command-line-flag": "--skull-strip-fixed-seed",
+                "description": "do not use a random seed for skull-stripping - will ensure run-to-run replicability when used with --omp-nthreads 1",
+                "id": "skull_strip_fixed_seed",
+                "name": "skull_strip_fixed_seed",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[SKULL_STRIP_FIXED_SEED]"
+            },
+            {
+                "command-line-flag": "--fmap-bspline",
+                "description": "fit a B-Spline field using least-squares (experimental)",
+                "id": "fmap_bspline",
+                "name": "fmap_bspline",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[FMAP_BSPLINE]"
+            },
+            {
+                "command-line-flag": "--fmap-no-demean",
+                "default-value": true,
+                "description": "do not remove median (within mask) from fieldmap",
+                "id": "fmap_no_demean",
+                "name": "fmap_no_demean",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[FMAP_NO_DEMEAN]"
+            },
+            {
+                "command-line-flag": "--use-syn-sdc",
+                "description": "EXPERIMENTAL: Use fieldmap-free distortion correction",
+                "id": "use_syn_sdc",
+                "name": "use_syn_sdc",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[USE_SYN_SDC]"
+            },
+            {
+                "command-line-flag": "--force-syn",
+                "description": "EXPERIMENTAL/TEMPORARY: Use SyN correction in addition to fieldmap correction, if available",
+                "id": "force_syn",
+                "name": "force_syn",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[FORCE_SYN]"
+            },
+            {
+                "command-line-flag": "--no-submm-recon",
+                "default-value": true,
+                "description": "disable sub-millimeter (hires) reconstruction",
+                "id": "hires",
+                "name": "hires",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[HIRES]"
+            },
+            {
+                "command-line-flag": "--cifti-output",
+                "description": "output BOLD files as CIFTI dtseries",
+                "id": "cifti_output",
+                "name": "cifti_output",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[CIFTI_OUTPUT]"
+            },
+            {
+                "command-line-flag": "--fs-no-reconall",
+                "default-value": true,
+                "description": "disable FreeSurfer surface preprocessing. Note : `--no-freesurfer` is deprecated and will be removed in 1.2. Use `--fs-no-reconall` instead.",
+                "id": "run_reconall",
+                "name": "run_reconall",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[RUN_RECONALL]"
+            },
+            {
+                "command-line-flag": "-w",
+                "description": "path where intermediate results should be stored",
+                "id": "work_dir",
+                "name": "work_dir",
+                "optional": true,
+                "type": "String",
+                "value-key": "[WORK_DIR]"
+            },
+            {
+                "command-line-flag": "--resource-monitor",
+                "description": "enable Nipype's resource monitoring to keep track of memory and CPU usage",
+                "id": "resource_monitor",
+                "name": "resource_monitor",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[RESOURCE_MONITOR]"
+            },
+            {
+                "command-line-flag": "--reports-only",
+                "description": "only generate reports, don't run workflows. This will only rerun report aggregation, not reportlet generation for specific nodes.",
+                "id": "reports_only",
+                "name": "reports_only",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[REPORTS_ONLY]"
+            },
+            {
+                "command-line-flag": "--run-uuid",
+                "description": "Specify UUID of previous run, to include error logs in report. No effect without --reports-only.",
+                "id": "run_uuid",
+                "name": "run_uuid",
+                "optional": true,
+                "type": "String",
+                "value-key": "[RUN_UUID]"
+            },
+            {
+                "command-line-flag": "--write-graph",
+                "description": "Write workflow graph.",
+                "id": "write_graph",
+                "name": "write_graph",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[WRITE_GRAPH]"
+            },
+            {
+                "command-line-flag": "--stop-on-first-crash",
+                "description": "Force stopping on first crash, even if a work directory was specified.",
+                "id": "stop_on_first_crash",
+                "name": "stop_on_first_crash",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[STOP_ON_FIRST_CRASH]"
+            },
+            {
+                "command-line-flag": "--notrack",
+                "description": "Opt-out of sending tracking information of this run to the FMRIPREP developers. This information helps to improve FMRIPREP and provides an indicator of real world usage crucial for obtaining funding.",
+                "id": "notrack",
+                "name": "notrack",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[NOTRACK]"
+            },
+            {
+                "command-line-flag": "--sloppy",
+                "description": "Use low-quality tools for speed - TESTING ONLY",
+                "id": "sloppy",
+                "name": "sloppy",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[SLOPPY]"
+            }
+        ],
+        "name": "BIDS App - fmriprep",
+        "output-files": [
+            {
+                "description": "This is the directory where the overall outputs are to be stored.",
+                "id": "output_directory",
+                "name": "Output Directory",
+                "optional": false,
+                "path-template": "[OUTPUT_DIR]"
+            }
+        ],
+        "schema-version": "0.5",
+        "suggested-resources": {
+            "cpu-cores": 4,
+            "ram": 4,
+            "walltime-estimate": 172000
+        },
+        "tags": {
+            "application-type": [
+                "bids"
+            ],
+            "domain": [
+                "neuroinformatics",
+                "fmri"
+            ]
+        },
+        "tool-version": "1.2.3",
+        "url": "https://fmriprep.readthedocs.io"
+    },
+    {
+        "command-line": "$BEST_DIR/run_BEst.sh $MCR_ROOT [RECORDINGS] [LEADFIELD] [ADJACENCY_MATRIX] [SOURCES] [MEM_METHOD] \"[SENSOR_TYPES]\" \"[RECONSTRUCTION_WINDOW]\" \"[BASELINE_WINDOW]\" [BASELINE] [NORMALIZATION] [CLUSTERING_METHOD] [MSP_WINDOW] [MSP_THRESHOLD_METHOD] [MSP_THRESHOLD] [NEIGHBORHOOD_ORDER] [SPATIAL_SMOOTHING] [ACTIVE_MEAN_INIT] [ACTIVE_PROBA_INIT] [LAMBDA_INIT] [ACTIVE_PROBA_THRESHOLD] [ACTIVE_VAR_COEF] [INACTIVE_VAR_COEF] [NOISE_COV_METHOD] [OPTIM_METHOD] [USE_PARALLEL]",
+        "container-image": {
+            "image": "MontrealSergiy/BEst",
+            "type": "singularity"
+        },
+        "name": "BEst",
+        "author": "Oba\u00ef Bin Ka\u2019b Ali",
+        "description": "EEG/MEG source localisation techniques based upon the Maximum Entropy on the Mean framework",
+        "inputs": [
+            {
+                "id": "recordings",
+                "name": "Recording data",
+                "type": "File",
+                "optional": false,
+                "value-key": "[RECORDINGS]"
+            },
+            {
+                "id": "leadfield",
+                "name": "Lead field data",
+                "type": "File",
+                "optional": false,
+                "value-key": "[LEADFIELD]"
+            },
+            {
+                "id": "adjacency_matrix",
+                "name": "Adjacency matrix",
+                "type": "File",
+                "optional": false,
+                "value-key": "[ADJACENCY_MATRIX]"
+            },
+            {
+                "id": "outfile",
+                "name": "Output file",
+                "description": "Name of the output file with extension '.mat'",
+                "type": "String",
+                "optional": false,
+                "default-value": "sources.mat",
+                "value-key": "[OUTFILE]"
+            },
+            {
+                "id": "mem_method",
+                "name": "MEM method",
+                "type": "String",
+                "optional": false,
+                "value-choices": [
+                    "cMEM"
+                ],
+                "default-value": "cMEM",
+                "value-key": "[MEM_METHOD]"
+            },
+            {
+                "id": "sensor_types",
+                "name": "Sensor types",
+                "description": "The data sensors types to process. If, for instance, your input recording data contains both EEG and MEG channels, then, you could choose to process only the EEG channels by setting this parameter to 'EEG'.",
+                "type": "String",
+                "optional": false,
+                "list": true,
+                "max-list-entries": 2,
+                "min-list-entries": 1,
+                "value-choices": [
+                    "EEG",
+                    "MEG"
+                ],
+                "value-key": "[SENSOR_TYPES]"
+            },
+            {
+                "id": "reconstruction_window",
+                "name": "Reconstruction time window",
+                "description": "This is the portion of your input recording data to reconstruct.",
+                "type": "Number",
+                "optional": false,
+                "list": true,
+                "max-list-entries": 2,
+                "min-list-entries": 2,
+                "minimum": 0,
+                "value-key": "[RECONSTRUCTION_WINDOW]"
+            },
+            {
+                "id": "baseline_window",
+                "name": "Baseline time window",
+                "description": "This is the portion of your baseline data to use for estimating a noise covariance matrix.",
+                "type": "Number",
+                "optional": false,
+                "list": true,
+                "max-list-entries": 2,
+                "min-list-entries": 2,
+                "minimum": 0,
+                "value-key": "[BASELINE_WINDOW]"
+            },
+            {
+                "id": "baseline",
+                "name": "Baseline data",
+                "description": "This is the path to your baseline file if any. If no baseline file is specified, then the baseline data will be extracted from within the recording data.",
+                "type": "File",
+                "optional": true,
+                "command-line-flag": "baseline",
+                "value-key": "[BASELINE]"
+            },
+            {
+                "id": "normalization",
+                "name": "Normalization",
+                "description": "Normalization strategy used for computing the solution. If adaptive, a minimum solution is used to normalize the data.",
+                "type": "String",
+                "optional": true,
+                "default-value": "adaptive",
+                "value-choices": [
+                    "adaptive",
+                    "fixed"
+                ],
+                "command-line-flag": "normalization",
+                "value-key": "[NORMALIZATION]"
+            },
+            {
+                "id": "clustering_method",
+                "name": "Clustering method",
+                "description": "If dynamic, then the cortical parcels are computed within consecutive time windows specified with the option: MSP window. If static, then one set of cortical parcels is computed for the whole data.",
+                "type": "String",
+                "optional": true,
+                "default-value": "static",
+                "value-choices": [
+                    "static",
+                    "dynamic"
+                ],
+                "value-disables": {
+                    "static": [
+                        "msp_window"
+                    ],
+                    "dynamic": []
+                },
+                "value-requires": {
+                    "static": [],
+                    "dynamic": [
+                        "msp_window"
+                    ]
+                },
+                "command-line-flag": "clusteringMethod",
+                "value-key": "[CLUSTERING_METHOD]"
+            },
+            {
+                "id": "msp_window",
+                "name": "MSP window",
+                "description": "Used when clustering method is set to 'dynamic', this is the size of the sliding window in millisecond (ms).",
+                "type": "Number",
+                "optional": true,
+                "minimum": 0,
+                "default-value": 10,
+                "command-line-flag": "mspWindow",
+                "value-key": "[MSP_WINDOW]"
+            },
+            {
+                "id": "msp_threshold_method",
+                "name": "MSP scores threshold method",
+                "description": "Thresholding method applied to the MSP scores. If set to 'fdr' then thresholds are learned from baseline. Otherwise, the option 'MSP scores threshold' is used.",
+                "type": "String",
+                "optional": true,
+                "default-value": "arbitrary",
+                "value-choices": [
+                    "arbitrary",
+                    "fdr"
+                ],
+                "value-disables": {
+                    "arbitrary": [],
+                    "fdr": [
+                        "msp_threshold"
+                    ]
+                },
+                "value-requires": {
+                    "arbitrary": [
+                        "msp_threshold"
+                    ],
+                    "fdr": []
+                },
+                "command-line-flag": "mspThresholdMethod",
+                "value-key": "[MSP_THRESHOLD_METHOD]"
+            },
+            {
+                "id": "msp_threshold",
+                "name": "MSP scores threshold",
+                "description": "Used when MSP scores threshold method is set to 'arbitrary', whole brain parcellation is set to 0.",
+                "type": "Number",
+                "optional": true,
+                "minimum": 0,
+                "maximum": 1,
+                "default-value": 0,
+                "command-line-flag": "mspThreshold",
+                "value-key": "[MSP_THRESHOLD]"
+            },
+            {
+                "id": "neighborhood_order",
+                "name": "Neighborhood order",
+                "description": "Sets maximal size of cortical parcels (initial source configuration for MEM).",
+                "type": "Number",
+                "optional": true,
+                "integer": true,
+                "minimum": 0,
+                "default-value": 4,
+                "command-line-flag": "neighborhoodOrder",
+                "value-key": "[NEIGHBORHOOD_ORDER]"
+            },
+            {
+                "id": "spatial_smoothing",
+                "name": "Spatial smoothing",
+                "description": "Smoothness of MEM solution: spatial regularization of the MEM (linear decay of spatial source correlations).",
+                "type": "Number",
+                "optional": true,
+                "minimum": 0,
+                "maximum": 1,
+                "default-value": 0.6,
+                "command-line-flag": "spatialSmoothing",
+                "value-key": "[SPATIAL_SMOOTHING]"
+            },
+            {
+                "id": "active_mean_init",
+                "name": "Active mean initialization",
+                "description": "Initialization method of the active mean of each cluster.",
+                "type": "Number",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
+                "default-value": 2,
+                "command-line-flag": "activeMeanInit",
+                "value-key": "[ACTIVE_MEAN_INIT]"
+            },
+            {
+                "id": "active_proba_init",
+                "name": "Active probability initialization",
+                "description": "Initialization method of the active probability of each cluster.",
+                "type": "Number",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                "default-value": 3,
+                "command-line-flag": "activeProbaInit",
+                "value-key": "[ACTIVE_PROBA_INIT]"
+            },
+            {
+                "id": "lambda_init",
+                "name": "Lambda initialization",
+                "description": "Initialization method of the sensor weights vector.",
+                "type": "Number",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ],
+                "default-value": 1,
+                "command-line-flag": "lambdaInit",
+                "value-key": "[LAMBDA_INIT]"
+            },
+            {
+                "id": "active_proba_threshold",
+                "name": "Active probability threshold",
+                "description": "Used to exclude clusters with low probability from the computed solution.",
+                "type": "Number",
+                "optional": true,
+                "minimum": 0,
+                "maximum": 1,
+                "default-value": 0,
+                "command-line-flag": "activeProbaThreshold",
+                "value-key": "[ACTIVE_PROBA_THRESHOLD]"
+            },
+            {
+                "id": "active_var_coef",
+                "name": "Active variance coefficient",
+                "description": "A weight applied to the active variance of each cluster.",
+                "type": "Number",
+                "optional": true,
+                "minimum": 0,
+                "maximum": 1,
+                "default-value": 0.05,
+                "command-line-flag": "activeVarCoef",
+                "value-key": "[ACTIVE_VAR_COEF]"
+            },
+            {
+                "id": "inactive_var_coef",
+                "name": "Inactive variance coefficient",
+                "description": "A weight applied to the inactive variance of each cluster.",
+                "type": "Number",
+                "optional": true,
+                "minimum": 0,
+                "maximum": 1,
+                "default-value": 0,
+                "command-line-flag": "inactiveVarCoef",
+                "value-key": "[INACTIVE_VAR_COEF]"
+            },
+            {
+                "id": "noise_cov_method",
+                "name": "Noise covariance method",
+                "description": "The performance of the MEM is tied to a consistent estimation of the noise covariance matrix. We recommend using the 'diagonal' method.",
+                "type": "Number",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                ],
+                "default-value": 2,
+                "command-line-flag": "noiseCovMethod",
+                "value-key": "[NOISE_COV_METHOD]"
+            },
+            {
+                "id": "optim_method",
+                "name": "Optimization routine",
+                "description": "'fminunc': MATLAB standard unconstrained optimization (optimization toolbox required). 'minFunc': Unconstrained optimization, copyright Mark Schmidt, INRIA.",
+                "type": "String",
+                "optional": true,
+                "default-value": "fminunc",
+                "value-choices": [
+                    "fminunc",
+                    "minfunc"
+                ],
+                "command-line-flag": "optimMethod",
+                "value-key": "[OPTIM_METHOD]"
+            },
+            {
+                "id": "use_parallel",
+                "name": "Parallel computing",
+                "description": "0: default - false, 1: true",
+                "type": "Number",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ],
+                "default-value": 0,
+                "command-line-flag": "useParallel",
+                "value-key": "[USE_PARALLEL]"
+            }
+        ],
+        "output-files": [
+            {
+                "id": "sources",
+                "name": "Sources",
+                "path-template": "[OUTFILE].mat",
+                "path-template-stripped-extensions": [
+                    ".mat"
+                ],
+                "optional": false,
+                "value-key": "[SOURCES]"
+            }
+        ],
+        "groups": [
+            {
+                "id": "data_definition",
+                "name": "Data definition",
+                "members": [
+                    "sensor_types",
+                    "reconstruction_window",
+                    "baseline",
+                    "baseline_window",
+                    "normalization"
+                ]
+            },
+            {
+                "id": "clustering",
+                "name": "Clustering",
+                "members": [
+                    "clustering_method",
+                    "msp_window",
+                    "msp_threshold_method",
+                    "msp_threshold",
+                    "neighborhood_order",
+                    "spatial_smoothing"
+                ]
+            },
+            {
+                "id": "model_priors",
+                "name": "Model priors",
+                "members": [
+                    "active_mean_init",
+                    "active_proba_init",
+                    "lambda_init",
+                    "active_proba_threshold",
+                    "active_var_coef",
+                    "inactive_var_coef"
+                ]
+            },
+            {
+                "id": "solver_options",
+                "name": "Solver options",
+                "members": [
+                    "noise_cov_method",
+                    "optim_method",
+                    "use_parallel"
+                ]
+            }
+        ],
+        "schema-version": "0.5",
+        "tags": {
+            "domain": "neuroinformatics"
+        },
+        "tool-version": "1.0"
+    },
+    {
+        "author": "Greg Kiar <gkiar.github.io>",
+        "command-line": "python3 /opt/oneVoxel.py [IMAGE_FILE] [OUTPUT_DIRECTORY] [MASK_FILE] [NO_SCALE] [INTENSITY] [ERODE] [LOCATION] [FORCE] [MODE] [CLEAN] [APPLY_NOISE] [VERBOSE] [BOUTIQUES]",
+        "container-image": {
+            "image": "gkiar/onevoxel:v0.2.0",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "description": "Adds 1-voxel noise to a Nifti image at either a provided or random location within a mask.",
+        "groups": [
+            {
+                "id": "noise_position_group",
+                "members": [
+                    "mask_file",
+                    "apply_noise"
+                ],
+                "name": "noise_position_group",
+                "one-is-required": true
+            }
+        ],
+        "inputs": [
+            {
+                "description": "Nifti image to be injected with one-voxel noise. Default behaviour is that this will be done at a random location within an image mask.",
+                "id": "image_file",
+                "name": "image_file",
+                "optional": false,
+                "type": "File",
+                "value-key": "[IMAGE_FILE]"
+            },
+            {
+                "description": "Path for where the resulting Nifti image with one voxel noise will be stored.",
+                "id": "output_directory",
+                "name": "output_directory",
+                "optional": false,
+                "type": "File",
+                "value-key": "[OUTPUT_DIRECTORY]"
+            },
+            {
+                "command-line-flag": "--mask_file",
+                "description": "Nifti image containing a binary mask for the input image. The noise location will be selected randomly within this mask, unless a location is provided.",
+                "id": "mask_file",
+                "name": "mask_file",
+                "optional": true,
+                "type": "File",
+                "value-key": "[MASK_FILE]"
+            },
+            {
+                "command-line-flag": "--no_scale",
+                "description": "Dictates the way in which noise is aplpied to the image. If set, the value specified with the intensity flag will be set to the new value. If not set, the intensity value will be multiplied by the original image value at the location.",
+                "id": "scale",
+                "name": "scale",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[NO_SCALE]"
+            },
+            {
+                "command-line-flag": "--intensity",
+                "default-value": 0.01,
+                "description": "The intensity of the noise to be injected in the image. Default value is 0.01 so specifying the scale flag alone will result in a 1%% intensity change at the target location.",
+                "id": "intensity",
+                "minimum": 0,
+                "name": "intensity",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[INTENSITY]"
+            },
+            {
+                "command-line-flag": "--erode",
+                "default-value": 3,
+                "description": "Value dictating how much to erode the binary mask before selecting a location for noise. The default value assumes a slightly generous mask.",
+                "id": "erode",
+                "integer": true,
+                "minimum": 0,
+                "name": "erode",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[ERODE]"
+            },
+            {
+                "command-line-flag": "--location",
+                "description": "Specifies a target location for injecting noise. This location must live within the provided mask in voxel coordinates. If not provided, a random location within the mask will be used.",
+                "id": "location",
+                "integer": true,
+                "list": true,
+                "name": "location",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[LOCATION]"
+            },
+            {
+                "command-line-flag": "--force",
+                "description": "Disables checks and restrictions on noise that may be not recommended for a typical workflow. By default, locations can only be specified within the mask, but this overrides that behaviour.",
+                "id": "force",
+                "name": "force",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[FORCE]"
+            },
+            {
+                "command-line-flag": "--mode",
+                "default-value": "single",
+                "description": "Determines where noise will be injected in the case of higher-dimensional images than masks. 'Single' (default) will choose a single position in all higher dimensions, resulting in 1 point of noise. 'Uniform' will choose a location within the mask and apply it uniformly across all other dimensions. 'Independent' will generate a random location within the mask for each volume in the remaining dimensions, and is mutually exclusive with providing a location.",
+                "id": "mode",
+                "name": "mode",
+                "optional": true,
+                "type": "String",
+                "value-choices": [
+                    "single",
+                    "uniform",
+                    "independent"
+                ],
+                "value-key": "[MODE]"
+            },
+            {
+                "command-line-flag": "--clean",
+                "description": "Deletes the noisy Nifti image from disk. This is intended to be used to save space, and the images can be regenerated using the 'apply' option and providing the associated JSON file.",
+                "id": "clean",
+                "name": "clean",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[CLEAN]"
+            },
+            {
+                "command-line-flag": "--apply_noise",
+                "description": "Provided with a path to 1-voxel noise associated JSON file, will apply noise to the image. A hash is stored in this file to verify that the same noise is injected each time the file is created.",
+                "id": "apply_noise",
+                "name": "apply_noise",
+                "optional": true,
+                "type": "File",
+                "value-key": "[APPLY_NOISE]"
+            },
+            {
+                "command-line-flag": "--verbose",
+                "description": "Toggles verbose output printing.",
+                "id": "verbose",
+                "name": "verbose",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[VERBOSE]"
+            },
+            {
+                "command-line-flag": "--boutiques",
+                "description": "Toggles creation of a Boutiques descriptor and invocation from the tool and inputs.",
+                "id": "boutiques",
+                "name": "boutiques",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[BOUTIQUES]"
+            }
+        ],
+        "name": "oneVoxel",
+        "output-files": [
+            {
+                "id": "noisy_image",
+                "name": "Noisy Image",
+                "path-template": "[OUTPUT_DIRECTORY]*_1vox-*.nii.gz",
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ],
+                "optional": true
+            },
+            {
+                "id": "noise_summary",
+                "name": "Noise Summary",
+                "path-template": "[OUTPUT_DIRECTORY]*_1vox-*.json",
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ],
+                "optional": true
+            }
+        ],
+        "schema-version": "0.5",
+        "suggested-resources": {
+            "cpu-cores": 1,
+            "ram": 2,
+            "walltime-estimate": 20
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "image processing",
+                "mri",
+                "noise"
+            ]
+        },
+        "tool-version": "v0.1.0"
+    },
+    {
+        "author": "Greg Kiar",
+        "command-line": "ndmg_bids BIDS_DIR OUTPUT_DIR ANALYSIS_LEVEL PARTICIPANT_LABEL SESSION_LABEL BUCKET REMOTE_PATH PUSH_DATA DATASET ATLAS MINIMAL HEMISPHERES LOG DEBUG STC",
+        "container-image": {
+            "image": "bids/ndmg:v0.1.0",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "description": "ndmg connectome estimation pipeline",
+        "inputs": [
+            {
+                "description": "The directory with the input dataset formatted according to the BIDS standard.",
+                "id": "bids_dir",
+                "name": "bids_dir",
+                "optional": false,
+                "type": "File",
+                "value-key": "BIDS_DIR"
+            },
+            {
+                "description": "The directory where the output files should be stored. If you are running group level analysis this folder should be prepopulated with the results of the participant level analysis.",
+                "id": "output_dir",
+                "name": "output_dir",
+                "optional": false,
+                "type": "File",
+                "value-key": "OUTPUT_DIR"
+            },
+            {
+                "description": "Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel) using the same output_dir.",
+                "id": "analysis_level",
+                "name": "analysis_level",
+                "optional": false,
+                "type": "String",
+                "value-choices": [
+                    "participant",
+                    "group"
+                ],
+                "value-key": "ANALYSIS_LEVEL"
+            },
+            {
+                "command-line-flag": "--participant_label",
+                "description": "The label(s) of the participant(s) that should be analyzed. The label corresponds to sub-<participant_label> from the BIDS spec (so it does not include \"sub-\"). If this parameter is not provided all subjects should be analyzed. Multiple participants can be specified with a space separated list.",
+                "id": "participant_label",
+                "name": "participant_label",
+                "optional": true,
+                "type": "String",
+                "list": true,
+                "value-key": "PARTICIPANT_LABEL"
+            },
+            {
+                "command-line-flag": "--session_label",
+                "description": "The label(s) of the session that should be analyzed. The label corresponds to ses-<participant_label> from the BIDS spec (so it does not include \"ses-\"). If this parameter is not provided all sessions should be analyzed. Multiple sessions can be specified with a space separated list.",
+                "id": "session_label",
+                "name": "session_label",
+                "optional": true,
+                "type": "String",
+                "list": true,
+                "value-key": "SESSION_LABEL"
+            },
+            {
+                "command-line-flag": "--bucket",
+                "description": "The name of an S3 bucket which holds BIDS organized data. You must have built your bucket with credentials to the S3 bucket you wish to access.",
+                "id": "bucket",
+                "name": "bucket",
+                "optional": true,
+                "type": "String",
+                "value-key": "BUCKET"
+            },
+            {
+                "command-line-flag": "--remote_path",
+                "description": "The path to the data on your S3 bucket. The data will be downloaded to the provided bids_dir on your machine.",
+                "id": "remote_path",
+                "name": "remote_path",
+                "optional": true,
+                "type": "String",
+                "value-key": "REMOTE_PATH"
+            },
+            {
+                "command-line-flag": "--push_data",
+                "description": "flag to push derivatives back up to S3.",
+                "id": "push_data",
+                "name": "push_data",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "PUSH_DATA"
+            },
+            {
+                "command-line-flag": "--dataset",
+                "description": "The name of the dataset you are perfoming QC on.",
+                "id": "dataset",
+                "name": "dataset",
+                "optional": true,
+                "type": "String",
+                "value-key": "DATASET"
+            },
+            {
+                "command-line-flag": "--atlas",
+                "description": "The atlas being analyzed in QC (if you only want one).",
+                "id": "atlas",
+                "name": "atlas",
+                "optional": true,
+                "type": "String",
+                "value-key": "ATLAS"
+            },
+            {
+                "command-line-flag": "--minimal",
+                "description": "Determines whether to show a minimal or full set of plots.",
+                "id": "minimal",
+                "name": "minimal",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "MINIMAL"
+            },
+            {
+                "command-line-flag": "--hemispheres",
+                "description": "Whether or not to break degrees into hemispheres or not",
+                "id": "hemispheres",
+                "name": "hemispheres",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "HEMISPHERES"
+            },
+            {
+                "command-line-flag": "--log",
+                "description": "Determines axis scale for plotting.",
+                "id": "log",
+                "name": "log",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "LOG"
+            },
+            {
+                "command-line-flag": "--debug",
+                "description": "flag to store temp files along the path of processing.",
+                "id": "debug",
+                "name": "debug",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "DEBUG"
+            }
+        ],
+        "name": "BIDS App - ndmg",
+        "output-files": [
+            {
+                "id": "output_directory",
+                "name": "BIDS derivatives directory from ndmg",
+                "optional": false,
+                "path-template": "OUTPUT_DIR"
+            }
+        ],
+        "schema-version": "0.5",
+        "suggested-resources": {
+            "cpu-cores": 1,
+            "ram": 12,
+            "walltime-estimate": 7200
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "diffusion",
+                "mri",
+                "bids"
+            ]
+        },
+        "tool-version": "v0.1.0"
+    },
+    {
+        "name": "FLIRT",
+        "command-line": "flirt [ANGLE_REP] [APPLY_ISOXFM] [APPLY_XFM] [BBRSLOPE] [BBRTYPE] [BGVALUE] [BINS] [COARSE_SEARCH] [COST] [COST_FUNC] [DATATYPE] [DOF] [ECHOSPACING] [FIELDMAP] [FIELDMAPMASK] [FINE_SEARCH] [FORCE_SCALING] [IN_FILE] [IN_MATRIX_FILE] [IN_WEIGHT] [INTERP] [MIN_SAMPLING] [NO_CLAMP] [NO_RESAMPLE] [NO_RESAMPLE_BLUR] [NO_SEARCH] [PADDING_SIZE] [PEDIR] [REF_WEIGHT] [REFERENCE] [RIGID2D] [SCHEDULE] [SEARCHR_X] [SEARCHR_Y] [SEARCHR_Z] [SINC_WIDTH] [SINC_WINDOW] [USES_QFORM] [VERBOSE] [WM_SEG] [WMCOORDS] [WMNORMS] [OUT_FILE] [OUT_MATRIX_FILE]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "FLIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FLIRT).",
+        "inputs": [
+            {
+                "id": "angle_rep",
+                "name": "Angle rep",
+                "type": "String",
+                "value-key": "[ANGLE_REP]",
+                "command-line-flag": "-anglerep",
+                "description": "'quaternion' or 'euler'. Representation of rotation angles.",
+                "optional": true,
+                "value-choices": [
+                    "quaternion",
+                    "euler"
+                ]
+            },
+            {
+                "id": "apply_isoxfm",
+                "name": "Apply isoxfm",
+                "type": "Number",
+                "value-key": "[APPLY_ISOXFM]",
+                "command-line-flag": "-applyisoxfm",
+                "description": "A float. As applyxfm but forces isotropic resampling.",
+                "optional": true
+            },
+            {
+                "id": "apply_xfm",
+                "name": "Apply xfm",
+                "type": "Flag",
+                "value-key": "[APPLY_XFM]",
+                "command-line-flag": "-applyxfm",
+                "description": "A boolean. Apply transformation supplied by in_matrix_file or uses_qform to use the affine matrix stored in the reference header.",
+                "optional": true
+            },
+            {
+                "id": "bbrslope",
+                "name": "Bbrslope",
+                "type": "Number",
+                "value-key": "[BBRSLOPE]",
+                "command-line-flag": "-bbrslope",
+                "description": "A float. Value of bbr slope.",
+                "optional": true
+            },
+            {
+                "id": "bbrtype",
+                "name": "Bbrtype",
+                "type": "String",
+                "value-key": "[BBRTYPE]",
+                "command-line-flag": "-bbrtype",
+                "description": "'signed' or 'global_abs' or 'local_abs'. Type of bbr cost function: signed [default], global_abs, local_abs.",
+                "optional": true,
+                "value-choices": [
+                    "signed",
+                    "global_abs",
+                    "local_abs"
+                ]
+            },
+            {
+                "id": "bgvalue",
+                "name": "Bgvalue",
+                "type": "Number",
+                "value-key": "[BGVALUE]",
+                "command-line-flag": "-setbackground",
+                "description": "A float. Use specified background value for points outside fov.",
+                "optional": true
+            },
+            {
+                "id": "bins",
+                "name": "Bins",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[BINS]",
+                "command-line-flag": "-bins",
+                "description": "An integer (int or long). Number of histogram bins.",
+                "optional": true
+            },
+            {
+                "id": "coarse_search",
+                "name": "Coarse search",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[COARSE_SEARCH]",
+                "command-line-flag": "-coarsesearch",
+                "description": "An integer (int or long). Coarse search delta angle.",
+                "optional": true
+            },
+            {
+                "id": "cost",
+                "name": "Cost",
+                "type": "String",
+                "value-key": "[COST]",
+                "command-line-flag": "-cost",
+                "description": "'mutualinfo' or 'corratio' or 'normcorr' or 'normmi' or 'leastsq' or 'labeldiff' or 'bbr'. Cost function.",
+                "optional": true,
+                "value-choices": [
+                    "mutualinfo",
+                    "corratio",
+                    "normcorr",
+                    "normmi",
+                    "leastsq",
+                    "labeldiff",
+                    "bbr"
+                ]
+            },
+            {
+                "id": "cost_func",
+                "name": "Cost func",
+                "type": "String",
+                "value-key": "[COST_FUNC]",
+                "command-line-flag": "-searchcost",
+                "description": "'mutualinfo' or 'corratio' or 'normcorr' or 'normmi' or 'leastsq' or 'labeldiff' or 'bbr'. Cost function.",
+                "optional": true,
+                "value-choices": [
+                    "mutualinfo",
+                    "corratio",
+                    "normcorr",
+                    "normmi",
+                    "leastsq",
+                    "labeldiff",
+                    "bbr"
+                ]
+            },
+            {
+                "id": "datatype",
+                "name": "Datatype",
+                "type": "String",
+                "value-key": "[DATATYPE]",
+                "command-line-flag": "-datatype",
+                "description": "'char' or 'short' or 'int' or 'float' or 'double'. Force output data type.",
+                "optional": true,
+                "value-choices": [
+                    "char",
+                    "short",
+                    "int",
+                    "float",
+                    "double"
+                ]
+            },
+            {
+                "id": "dof",
+                "name": "Dof",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[DOF]",
+                "command-line-flag": "-dof",
+                "description": "An integer (int or long). Number of transform degrees of freedom.",
+                "optional": true
+            },
+            {
+                "id": "echospacing",
+                "name": "Echospacing",
+                "type": "Number",
+                "value-key": "[ECHOSPACING]",
+                "command-line-flag": "-echospacing",
+                "description": "A float. Value of epi echo spacing - units of seconds.",
+                "optional": true
+            },
+            {
+                "id": "fieldmap",
+                "name": "Fieldmap",
+                "type": "File",
+                "value-key": "[FIELDMAP]",
+                "command-line-flag": "-fieldmap",
+                "description": "A file name. Fieldmap image in rads/s - must be already registered to the reference image.",
+                "optional": true
+            },
+            {
+                "id": "fieldmapmask",
+                "name": "Fieldmapmask",
+                "type": "File",
+                "value-key": "[FIELDMAPMASK]",
+                "command-line-flag": "-fieldmapmask",
+                "description": "A file name. Mask for fieldmap image.",
+                "optional": true
+            },
+            {
+                "id": "fine_search",
+                "name": "Fine search",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[FINE_SEARCH]",
+                "command-line-flag": "-finesearch",
+                "description": "An integer (int or long). Fine search delta angle.",
+                "optional": true
+            },
+            {
+                "id": "force_scaling",
+                "name": "Force scaling",
+                "type": "Flag",
+                "value-key": "[FORCE_SCALING]",
+                "command-line-flag": "-forcescaling",
+                "description": "A boolean. Force rescaling even for low-res images.",
+                "optional": true
+            },
+            {
+                "id": "in_file",
+                "name": "In file",
+                "type": "File",
+                "value-key": "[IN_FILE]",
+                "command-line-flag": "-in",
+                "description": "An existing file name. Input file.",
+                "optional": false
+            },
+            {
+                "id": "in_matrix_file",
+                "name": "In matrix file",
+                "type": "File",
+                "value-key": "[IN_MATRIX_FILE]",
+                "command-line-flag": "-init",
+                "description": "A file name. Input 4x4 affine matrix.",
+                "optional": true
+            },
+            {
+                "id": "in_weight",
+                "name": "In weight",
+                "type": "File",
+                "value-key": "[IN_WEIGHT]",
+                "command-line-flag": "-inweight",
+                "description": "An existing file name. File for input weighting volume.",
+                "optional": true
+            },
+            {
+                "id": "interp",
+                "name": "Interp",
+                "type": "String",
+                "value-key": "[INTERP]",
+                "command-line-flag": "-interp",
+                "description": "'trilinear' or 'nearestneighbour' or 'sinc' or 'spline'. Final interpolation method used in reslicing.",
+                "optional": true,
+                "value-choices": [
+                    "trilinear",
+                    "nearestneighbour",
+                    "sinc",
+                    "spline"
+                ]
+            },
+            {
+                "id": "min_sampling",
+                "name": "Min sampling",
+                "type": "Number",
+                "value-key": "[MIN_SAMPLING]",
+                "command-line-flag": "-minsampling",
+                "description": "A float. Set minimum voxel dimension for sampling.",
+                "optional": true
+            },
+            {
+                "id": "no_clamp",
+                "name": "No clamp",
+                "type": "Flag",
+                "value-key": "[NO_CLAMP]",
+                "command-line-flag": "-noclamp",
+                "description": "A boolean. Do not use intensity clamping.",
+                "optional": true
+            },
+            {
+                "id": "no_resample",
+                "name": "No resample",
+                "type": "Flag",
+                "value-key": "[NO_RESAMPLE]",
+                "command-line-flag": "-noresample",
+                "description": "A boolean. Do not change input sampling.",
+                "optional": true
+            },
+            {
+                "id": "no_resample_blur",
+                "name": "No resample blur",
+                "type": "Flag",
+                "value-key": "[NO_RESAMPLE_BLUR]",
+                "command-line-flag": "-noresampblur",
+                "description": "A boolean. Do not use blurring on downsampling.",
+                "optional": true
+            },
+            {
+                "id": "no_search",
+                "name": "No search",
+                "type": "Flag",
+                "value-key": "[NO_SEARCH]",
+                "command-line-flag": "-nosearch",
+                "description": "A boolean. Set all angular searches to ranges 0 to 0.",
+                "optional": true
+            },
+            {
+                "id": "padding_size",
+                "name": "Padding size",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[PADDING_SIZE]",
+                "command-line-flag": "-paddingsize",
+                "description": "An integer (int or long). For applyxfm: interpolates outside image by size.",
+                "optional": true
+            },
+            {
+                "id": "pedir",
+                "name": "Pedir",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[PEDIR]",
+                "command-line-flag": "-pedir",
+                "description": "An integer (int or long). Phase encode direction of epi - 1/2/3=x/y/z & -1/-2/-3=-x/-y/-z.",
+                "optional": true
+            },
+            {
+                "id": "ref_weight",
+                "name": "Ref weight",
+                "type": "File",
+                "value-key": "[REF_WEIGHT]",
+                "command-line-flag": "-refweight",
+                "description": "An existing file name. File for reference weighting volume.",
+                "optional": true
+            },
+            {
+                "id": "reference",
+                "name": "Reference",
+                "type": "File",
+                "value-key": "[REFERENCE]",
+                "command-line-flag": "-ref",
+                "description": "An existing file name. Reference file.",
+                "optional": false
+            },
+            {
+                "id": "rigid2D",
+                "name": "Rigid2d",
+                "type": "Flag",
+                "value-key": "[RIGID2D]",
+                "command-line-flag": "-2D",
+                "description": "A boolean. Use 2d rigid body mode - ignores dof.",
+                "optional": true
+            },
+            {
+                "id": "schedule",
+                "name": "Schedule",
+                "type": "File",
+                "value-key": "[SCHEDULE]",
+                "command-line-flag": "-schedule",
+                "description": "An existing file name. Replaces default schedule.",
+                "optional": true
+            },
+            {
+                "id": "searchr_x",
+                "name": "Searchr x",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "min-list-entries": 2,
+                "max-list-entries": 2,
+                "value-key": "[SEARCHR_X]",
+                "command-line-flag": "-searchrx",
+                "description": "A list of from 2 to 2 items which are an integer (int or long). Search angles along x-axis, in degrees.",
+                "optional": true
+            },
+            {
+                "id": "searchr_y",
+                "name": "Searchr y",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "min-list-entries": 2,
+                "max-list-entries": 2,
+                "value-key": "[SEARCHR_Y]",
+                "command-line-flag": "-searchry",
+                "description": "A list of from 2 to 2 items which are an integer (int or long). Search angles along y-axis, in degrees.",
+                "optional": true
+            },
+            {
+                "id": "searchr_z",
+                "name": "Searchr z",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "min-list-entries": 2,
+                "max-list-entries": 2,
+                "value-key": "[SEARCHR_Z]",
+                "command-line-flag": "-searchrz",
+                "description": "A list of from 2 to 2 items which are an integer (int or long). Search angles along z-axis, in degrees.",
+                "optional": true
+            },
+            {
+                "id": "sinc_width",
+                "name": "Sinc width",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[SINC_WIDTH]",
+                "command-line-flag": "-sincwidth",
+                "description": "An integer (int or long). Full-width in voxels.",
+                "optional": true
+            },
+            {
+                "id": "sinc_window",
+                "name": "Sinc window",
+                "type": "String",
+                "value-key": "[SINC_WINDOW]",
+                "command-line-flag": "-sincwindow",
+                "description": "'rectangular' or 'hanning' or 'blackman'. Sinc window.",
+                "optional": true,
+                "value-choices": [
+                    "rectangular",
+                    "hanning",
+                    "blackman"
+                ]
+            },
+            {
+                "id": "uses_qform",
+                "name": "Uses qform",
+                "type": "Flag",
+                "value-key": "[USES_QFORM]",
+                "command-line-flag": "-usesqform",
+                "description": "A boolean. Initialize using sform or qform.",
+                "optional": true
+            },
+            {
+                "id": "verbose",
+                "name": "Verbose",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[VERBOSE]",
+                "command-line-flag": "-verbose",
+                "description": "An integer (int or long). Verbose mode, 0 is least.",
+                "optional": true
+            },
+            {
+                "id": "wm_seg",
+                "name": "Wm seg",
+                "type": "File",
+                "value-key": "[WM_SEG]",
+                "command-line-flag": "-wmseg",
+                "description": "A file name. White matter segmentation volume needed by bbr cost function.",
+                "optional": true
+            },
+            {
+                "id": "wmcoords",
+                "name": "Wmcoords",
+                "type": "File",
+                "value-key": "[WMCOORDS]",
+                "command-line-flag": "-wmcoords",
+                "description": "A file name. White matter boundary coordinates for bbr cost function.",
+                "optional": true
+            },
+            {
+                "id": "wmnorms",
+                "name": "Wmnorms",
+                "type": "File",
+                "value-key": "[WMNORMS]",
+                "command-line-flag": "-wmnorms",
+                "description": "A file name. White matter boundary normals for bbr cost function.",
+                "optional": true
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Out file",
+                "id": "out_file",
+                "path-template": "[IN_FILE]_flirt",
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ],
+                "optional": true,
+                "description": "An existing file name. Path/name of registered file (if generated).",
+                "value-key": "[OUT_FILE]",
+                "command-line-flag": "-out"
+            },
+            {
+                "name": "Out matrix file",
+                "id": "out_matrix_file",
+                "path-template": "[IN_FILE]_flirt.mat",
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ],
+                "optional": true,
+                "description": "An existing file name. Path/name of calculated affine transform (if generated).",
+                "value-key": "[OUT_MATRIX_FILE]",
+                "command-line-flag": "-omat"
+            }
+        ],
+        "groups": [
+            {
+                "id": "mutex_group",
+                "name": "Mutex group",
+                "members": [
+                    "apply_xfm",
+                    "apply_isoxfm"
+                ],
+                "mutually-exclusive": true
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "fmri"
+            ],
+            "source": "nipype-interface"
+        }
+    },
+    {
+        "name": "BEDPOSTX5",
+        "command-line": "bedpostx [OUT_DIR] [ALL_ARD] [BURN_IN] [BURN_IN_NO_ARD] [BVALS] [BVECS] [CNLINEAR] [DWI] [F0_ARD] [F0_NOARD] [FORCE_DIR] [FUDGE] [GRAD_DEV] [GRADNONLIN] [LOGDIR] [MASK] [MODEL] [N_FIBRES] [N_JUMPS] [NO_ARD] [NO_SPAT] [NON_LINEAR] [RICIAN] [SAMPLE_EVERY] [SEED] [UPDATE_PROPOSAL_EVERY] [USE_GPU]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "BEDPOSTX5, as implemented in Nipype (module: nipype.interfaces.fsl, interface: BEDPOSTX5).",
+        "inputs": [
+            {
+                "id": "all_ard",
+                "name": "All ard",
+                "type": "Flag",
+                "value-key": "[ALL_ARD]",
+                "command-line-flag": "--allard",
+                "description": "A boolean. Turn ard on on all fibres.",
+                "optional": true
+            },
+            {
+                "id": "burn_in",
+                "name": "Burn in",
+                "type": "Number",
+                "minimum": 0,
+                "value-key": "[BURN_IN]",
+                "command-line-flag": "-b",
+                "description": "A long integer >= 0. Total num of jumps at start of mcmc to be discarded.",
+                "optional": true,
+                "default-value": 0
+            },
+            {
+                "id": "burn_in_no_ard",
+                "name": "Burn in no ard",
+                "type": "Number",
+                "minimum": 0,
+                "value-key": "[BURN_IN_NO_ARD]",
+                "command-line-flag": "--burnin_noard",
+                "command-line-flag-separator": "=",
+                "description": "A long integer >= 0. Num of burnin jumps before the ard is imposed.",
+                "optional": true,
+                "default-value": 0
+            },
+            {
+                "id": "bvals",
+                "name": "Bvals",
+                "type": "File",
+                "value-key": "[BVALS]",
+                "description": "An existing file name. B values file.",
+                "optional": false
+            },
+            {
+                "id": "bvecs",
+                "name": "Bvecs",
+                "type": "File",
+                "value-key": "[BVECS]",
+                "description": "An existing file name. B vectors file.",
+                "optional": false
+            },
+            {
+                "id": "cnlinear",
+                "name": "Cnlinear",
+                "type": "Flag",
+                "value-key": "[CNLINEAR]",
+                "command-line-flag": "--cnonlinear",
+                "description": "A boolean. Initialise with constrained nonlinear fitting.",
+                "optional": true
+            },
+            {
+                "id": "dwi",
+                "name": "Dwi",
+                "type": "File",
+                "value-key": "[DWI]",
+                "description": "An existing file name. Diffusion weighted image data file.",
+                "optional": false
+            },
+            {
+                "id": "f0_ard",
+                "name": "F0 ard",
+                "type": "Flag",
+                "value-key": "[F0_ARD]",
+                "command-line-flag": "--f0 --ardf0",
+                "description": "A boolean. Noise floor model: add to the model an unattenuated signal compartment f0.",
+                "optional": true
+            },
+            {
+                "id": "f0_noard",
+                "name": "F0 noard",
+                "type": "Flag",
+                "value-key": "[F0_NOARD]",
+                "command-line-flag": "--f0",
+                "description": "A boolean. Noise floor model: add to the model an unattenuated signal compartment f0.",
+                "optional": true
+            },
+            {
+                "id": "force_dir",
+                "name": "Force dir",
+                "type": "Flag",
+                "value-key": "[FORCE_DIR]",
+                "command-line-flag": "--forcedir",
+                "description": "A boolean. Use the actual directory name given (do not add + to make a new directory).",
+                "optional": true,
+                "default-value": true
+            },
+            {
+                "id": "fudge",
+                "name": "Fudge",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[FUDGE]",
+                "command-line-flag": "-w",
+                "description": "An integer (int or long). Ard fudge factor.",
+                "optional": true
+            },
+            {
+                "id": "grad_dev",
+                "name": "Grad dev",
+                "type": "File",
+                "value-key": "[GRAD_DEV]",
+                "description": "An existing file name. Grad_dev file, if gradnonlin, -g is true.",
+                "optional": true
+            },
+            {
+                "id": "gradnonlin",
+                "name": "Gradnonlin",
+                "type": "Flag",
+                "value-key": "[GRADNONLIN]",
+                "command-line-flag": "-g",
+                "description": "A boolean. Consider gradient nonlinearities, default off.",
+                "optional": true
+            },
+            {
+                "id": "logdir",
+                "name": "Logdir",
+                "type": "File",
+                "value-key": "[LOGDIR]",
+                "command-line-flag": "--logdir",
+                "command-line-flag-separator": "=",
+                "description": "A directory name. No description provided.",
+                "optional": true
+            },
+            {
+                "id": "mask",
+                "name": "Mask",
+                "type": "File",
+                "value-key": "[MASK]",
+                "description": "An existing file name. Bet binary mask file.",
+                "optional": false
+            },
+            {
+                "id": "model",
+                "name": "Model",
+                "type": "Number",
+                "value-key": "[MODEL]",
+                "command-line-flag": "-model",
+                "description": "1 or 2 or 3. Use monoexponential (1, default, required for single-shell) or multiexponential (2, multi-shell) model.",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    1,
+                    2,
+                    3
+                ]
+            },
+            {
+                "id": "n_fibres",
+                "name": "N fibres",
+                "type": "Number",
+                "minimum": 1,
+                "value-key": "[N_FIBRES]",
+                "command-line-flag": "-n",
+                "description": "A long integer >= 1. Maximum number of fibres to fit in each voxel.",
+                "optional": false,
+                "default-value": 2
+            },
+            {
+                "id": "n_jumps",
+                "name": "N jumps",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[N_JUMPS]",
+                "command-line-flag": "-j",
+                "description": "An integer (int or long). Num of jumps to be made by mcmc.",
+                "optional": true,
+                "default-value": 5000
+            },
+            {
+                "id": "no_ard",
+                "name": "No ard",
+                "type": "Flag",
+                "value-key": "[NO_ARD]",
+                "command-line-flag": "--noard",
+                "description": "A boolean. Turn ard off on all fibres.",
+                "optional": true
+            },
+            {
+                "id": "no_spat",
+                "name": "No spat",
+                "type": "Flag",
+                "value-key": "[NO_SPAT]",
+                "command-line-flag": "--nospat",
+                "description": "A boolean. Initialise with tensor, not spatially.",
+                "optional": true
+            },
+            {
+                "id": "non_linear",
+                "name": "Non linear",
+                "type": "Flag",
+                "value-key": "[NON_LINEAR]",
+                "command-line-flag": "--nonlinear",
+                "description": "A boolean. Initialise with nonlinear fitting.",
+                "optional": true
+            },
+            {
+                "id": "out_dir",
+                "name": "Out dir",
+                "type": "File",
+                "value-key": "[OUT_DIR]",
+                "description": "A directory name. Output directory.",
+                "optional": false,
+                "default-value": "bedpostx"
+            },
+            {
+                "id": "rician",
+                "name": "Rician",
+                "type": "Flag",
+                "value-key": "[RICIAN]",
+                "command-line-flag": "--rician",
+                "description": "A boolean. Use rician noise modeling.",
+                "optional": true
+            },
+            {
+                "id": "sample_every",
+                "name": "Sample every",
+                "type": "Number",
+                "minimum": 0,
+                "value-key": "[SAMPLE_EVERY]",
+                "command-line-flag": "-s",
+                "description": "A long integer >= 0. Num of jumps for each sample (mcmc).",
+                "optional": true,
+                "default-value": 1
+            },
+            {
+                "id": "seed",
+                "name": "Seed",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[SEED]",
+                "command-line-flag": "--seed",
+                "command-line-flag-separator": "=",
+                "description": "An integer (int or long). Seed for pseudo random number generator.",
+                "optional": true
+            },
+            {
+                "id": "update_proposal_every",
+                "name": "Update proposal every",
+                "type": "Number",
+                "minimum": 1,
+                "value-key": "[UPDATE_PROPOSAL_EVERY]",
+                "command-line-flag": "--updateproposalevery",
+                "command-line-flag-separator": "=",
+                "description": "A long integer >= 1. Num of jumps for each update to the proposal density std (mcmc).",
+                "optional": true,
+                "default-value": 40
+            },
+            {
+                "id": "use_gpu",
+                "name": "Use gpu",
+                "type": "Flag",
+                "value-key": "[USE_GPU]",
+                "command-line-flag": "--use_gpu",
+                "description": "A boolean. Use the gpu version of bedpostx.",
+                "optional": true
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Dyads",
+                "id": "dyads",
+                "path-template": "dyads*",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Mean of pdd distribution in vector form.",
+                "list": true
+            },
+            {
+                "name": "Dyads dispersion",
+                "id": "dyads_dispersion",
+                "path-template": "dyads*_dispersion",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Dispersion.",
+                "list": true
+            },
+            {
+                "name": "Mean s0samples",
+                "id": "mean_S0samples",
+                "path-template": "mean_S0samples",
+                "optional": true,
+                "description": "An existing file name. Mean of distribution on t2wbaseline signal intensity s0."
+            },
+            {
+                "name": "Mean dsamples",
+                "id": "mean_dsamples",
+                "path-template": "mean_dsamples",
+                "optional": true,
+                "description": "An existing file name. Mean of distribution on diffusivity d."
+            },
+            {
+                "name": "Mean fsamples",
+                "id": "mean_fsamples",
+                "path-template": "mean_f*samples",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Mean of distribution on f anisotropy.",
+                "list": true
+            },
+            {
+                "name": "Mean phsamples",
+                "id": "mean_phsamples",
+                "path-template": "mean_ph*samples",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Mean of distribution on phi.",
+                "list": true
+            },
+            {
+                "name": "Mean thsamples",
+                "id": "mean_thsamples",
+                "path-template": "mean_th*samples",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Mean of distribution on theta.",
+                "list": true
+            },
+            {
+                "name": "Merged fsamples",
+                "id": "merged_fsamples",
+                "path-template": "merged_f*samples",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Samples from the distribution on anisotropic volume fraction.",
+                "list": true
+            },
+            {
+                "name": "Merged phsamples",
+                "id": "merged_phsamples",
+                "path-template": "merged_ph*samples",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Samples from the distribution on phi.",
+                "list": true
+            },
+            {
+                "name": "Merged thsamples",
+                "id": "merged_thsamples",
+                "path-template": "merged_th*samples",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Samples from the distribution on theta.",
+                "list": true
+            }
+        ],
+        "groups": [
+            {
+                "id": "mutex_group",
+                "name": "Mutex group",
+                "members": [
+                    "no_ard",
+                    "all_ard"
+                ],
+                "mutually-exclusive": true
+            },
+            {
+                "id": "mutex_group_2",
+                "name": "Mutex group 2",
+                "members": [
+                    "non_linear",
+                    "no_spat",
+                    "cnlinear"
+                ],
+                "mutually-exclusive": true
+            },
+            {
+                "id": "mutex_group_3",
+                "name": "Mutex group 3",
+                "members": [
+                    "f0_ard",
+                    "f0_noard"
+                ],
+                "mutually-exclusive": true
+            },
+            {
+                "id": "mutex_group_4",
+                "name": "Mutex group 4",
+                "members": [
+                    "f0_ard",
+                    "f0_noard",
+                    "all_ard"
+                ],
+                "mutually-exclusive": true
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "dmri"
+            ],
+            "source": "nipype-interface"
+        },
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/dti.py"
+    },
+    {
+        "inputs": [
+            {
+                "command-line-flag": "-a",
+                "description": "An existing file name. Structural *intensity* image, typically t1. if more than one anatomical image is specified, subsequently specified images are used during the segmentation process. however, only the first image is used in the registration of priors. our suggestion would be to specify the t1 as the first image.",
+                "value-key": "[ANATOMICAL_IMAGE]",
+                "optional": false,
+                "type": "File",
+                "id": "anatomical_image",
+                "name": "Anatomical image"
+            },
+            {
+                "command-line-flag": "-v",
+                "description": "A boolean. Use b-spline syn for registrations and b-spline exponential mapping in direct.",
+                "value-key": "[B_SPLINE_SMOOTHING]",
+                "optional": true,
+                "type": "Flag",
+                "id": "b_spline_smoothing",
+                "name": "B spline smoothing"
+            },
+            {
+                "command-line-flag": "-m",
+                "description": "An existing file name. Brain probability mask in template space.",
+                "value-key": "[BRAIN_PROBABILITY_MASK]",
+                "optional": false,
+                "type": "File",
+                "id": "brain_probability_mask",
+                "name": "Brain probability mask"
+            },
+            {
+                "command-line-flag": "-e",
+                "description": "An existing file name. Anatomical *intensity* template (possibly created using a population data set with buildtemplateparallel.sh in ants). this template is  *not* skull-stripped.",
+                "value-key": "[BRAIN_TEMPLATE]",
+                "optional": false,
+                "type": "File",
+                "id": "brain_template",
+                "name": "Brain template"
+            },
+            {
+                "command-line-flag": "-r",
+                "description": "An existing file name. Cortical roi labels to use as a prior for atith.",
+                "value-key": "[CORTICAL_LABEL_IMAGE]",
+                "optional": true,
+                "type": "File",
+                "id": "cortical_label_image",
+                "name": "Cortical label image"
+            },
+            {
+                "command-line-flag": "-z 1",
+                "description": "A boolean. If > 0, runs a faster version of the script. only for testing. implies -u 0. requires single thread computation for complete reproducibility.",
+                "value-key": "[DEBUG]",
+                "optional": true,
+                "type": "Flag",
+                "id": "debug",
+                "name": "Debug"
+            },
+            {
+                "command-line-flag": "-d",
+                "description": "3 or 2. Image dimension (2 or 3).",
+                "default-value": 3,
+                "value-key": "[DIMENSION]",
+                "optional": true,
+                "value-choices": [
+                    3,
+                    2
+                ],
+                "integer": true,
+                "type": "Number",
+                "id": "dimension",
+                "name": "Dimension"
+            },
+            {
+                "command-line-flag": "-f",
+                "description": "An existing file name. Mask (defined in the template space) used during registration for brain extraction.",
+                "value-key": "[EXTRACTION_REGISTRATION_MASK]",
+                "optional": true,
+                "type": "File",
+                "id": "extraction_registration_mask",
+                "name": "Extraction registration mask"
+            },
+            {
+                "command-line-flag": "-s",
+                "description": "A unicode string. Any of standard itk formats, nii.gz is default.",
+                "default-value": "nii.gz",
+                "value-key": "[IMAGE_SUFFIX]",
+                "optional": true,
+                "type": "String",
+                "id": "image_suffix",
+                "name": "Image suffix"
+            },
+            {
+                "command-line-flag": "-k",
+                "name": "Keep temporary files",
+                "value-key": "[KEEP_TEMPORARY_FILES]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "keep_temporary_files",
+                "description": "An integer (int or long). Keep brain extraction/segmentation warps, etc (default = 0)."
+            },
+            {
+                "command-line-flag": "-l",
+                "description": "A unicode string. Incorporate a distance prior one the posterior formulation.  should be of the form 'label[lambda,boundaryprobability]' where label is a value of 1,2,3,... denoting label id.  the label probability for anything outside the current label = boundaryprobability * exp( -lambda * distancefromboundary ) intuitively, smaller lambda values will increase the spatial capture range of the distance prior.  to apply to all label values, simply omit specifying the label, i.e. -l [lambda,boundaryprobability].",
+                "value-key": "[LABEL_PROPAGATION]",
+                "optional": true,
+                "type": "String",
+                "id": "label_propagation",
+                "name": "Label propagation"
+            },
+            {
+                "command-line-flag": "-i",
+                "name": "Max iterations",
+                "value-key": "[MAX_ITERATIONS]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "max_iterations",
+                "description": "An integer (int or long). Ants registration max iterations (default = 100x100x70x20)."
+            },
+            {
+                "description": "An integer (int or long). Number of itk threads to use.",
+                "default-value": 1,
+                "value-key": "[NUM_THREADS]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "num_threads",
+                "name": "Num threads"
+            },
+            {
+                "command-line-flag": "-o",
+                "description": "A unicode string. Prefix that is prepended to all output files (default = antsct_).",
+                "default-value": "antsCT_",
+                "value-key": "[OUT_PREFIX]",
+                "optional": true,
+                "type": "String",
+                "id": "out_prefix",
+                "name": "Out prefix"
+            },
+            {
+                "command-line-flag": "-b",
+                "description": "A unicode string. Atropos posterior formulation and whether or not to use mixture model proportions. e.g 'socrates[1]' (default) or 'aristotle[1]'. choose the latter if you want use the distance priors (see also the -l option for label propagation control).",
+                "value-key": "[POSTERIOR_FORMULATION]",
+                "optional": true,
+                "type": "String",
+                "id": "posterior_formulation",
+                "name": "Posterior formulation"
+            },
+            {
+                "command-line-flag": "-w",
+                "description": "A float. Atropos spatial prior *probability* weight for the segmentation.",
+                "value-key": "[PRIOR_SEGMENTATION_WEIGHT]",
+                "optional": true,
+                "type": "Number",
+                "id": "prior_segmentation_weight",
+                "name": "Prior segmentation weight"
+            },
+            {
+                "command-line-flag": "-q 1",
+                "description": "A boolean. If = 1, use antsregistrationsynquick.sh as the basis for registration during brain extraction, brain segmentation, and (optional) normalization to a template. otherwise use antsregistrationsyn.sh (default = 0).",
+                "value-key": "[QUICK_REGISTRATION]",
+                "optional": true,
+                "type": "Flag",
+                "id": "quick_registration",
+                "name": "Quick registration"
+            },
+            {
+                "command-line-flag": "-n",
+                "name": "Segmentation iterations",
+                "value-key": "[SEGMENTATION_ITERATIONS]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "segmentation_iterations",
+                "description": "An integer (int or long). N4 -> atropos -> n4 iterations during segmentation (default = 3)."
+            },
+            {
+                "command-line-flag": "-p",
+                "name": "Segmentation priors",
+                "value-key": "[SEGMENTATION_PRIORS]",
+                "optional": false,
+                "list": true,
+                "type": "File",
+                "id": "segmentation_priors",
+                "description": "A list of items which are an existing file name. No description provided."
+            },
+            {
+                "command-line-flag": "-t",
+                "description": "An existing file name. Anatomical *intensity* template (assumed to be skull-stripped). a common case would be where this would be the same template as specified in the -e option which is not skull stripped.",
+                "value-key": "[T1_REGISTRATION_TEMPLATE]",
+                "optional": false,
+                "type": "File",
+                "id": "t1_registration_template",
+                "name": "T1 registration template"
+            },
+            {
+                "command-line-flag": "-j",
+                "description": "0 or 1. Use floating point precision in registrations (default = 0).",
+                "value-key": "[USE_FLOATINGPOINT_PRECISION]",
+                "optional": true,
+                "value-choices": [
+                    0,
+                    1
+                ],
+                "integer": true,
+                "type": "Number",
+                "id": "use_floatingpoint_precision",
+                "name": "Use floatingpoint precision"
+            },
+            {
+                "command-line-flag": "-u",
+                "description": "0 or 1. Use random number generated from system clock in atropos (default = 1).",
+                "value-key": "[USE_RANDOM_SEEDING]",
+                "optional": true,
+                "value-choices": [
+                    0,
+                    1
+                ],
+                "integer": true,
+                "type": "Number",
+                "id": "use_random_seeding",
+                "name": "Use random seeding"
+            }
+        ],
+        "description": "CorticalThickness, as implemented in Nipype (module: nipype.interfaces.ants, interface: CorticalThickness).",
+        "command-line": "${ANTSPATH}/antsCorticalThickness.sh [ANATOMICAL_IMAGE] [B_SPLINE_SMOOTHING] [BRAIN_PROBABILITY_MASK] [BRAIN_TEMPLATE] [CORTICAL_LABEL_IMAGE] [DEBUG] [DIMENSION] [EXTRACTION_REGISTRATION_MASK] [IMAGE_SUFFIX] [KEEP_TEMPORARY_FILES] [LABEL_PROPAGATION] [MAX_ITERATIONS] [NUM_THREADS] [OUT_PREFIX] [POSTERIOR_FORMULATION] [PRIOR_SEGMENTATION_WEIGHT] [QUICK_REGISTRATION] [SEGMENTATION_ITERATIONS] [SEGMENTATION_PRIORS] [T1_REGISTRATION_TEMPLATE] [USE_FLOATINGPOINT_PRECISION] [USE_RANDOM_SEEDING]",
+        "author": "Nipype (interface), Brian B. Avants et al. (tool)",
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/ants/segmentation.py",
+        "tool-version": "1.0.0",
+        "tags": {
+            "source": "nipype-interface",
+            "domain": "neuroinformatics"
+        },
+        "container-image": {
+            "index": "index.docker.io",
+            "image": "bt5e/ants:latest",
+            "type": "docker"
+        },
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[OUT_PREFIX]BrainExtractionMask.[IMAGE_SUFFIX]",
+                "description": "An existing file name. Brain extraction mask.",
+                "optional": true,
+                "name": "Brainextractionmask",
+                "id": "BrainExtractionMask"
+            },
+            {
+                "path-template": "[OUT_PREFIX]BrainSegmentation.[IMAGE_SUFFIX]",
+                "description": "An existing file name. Brain segmentaion image.",
+                "optional": true,
+                "name": "Brainsegmentation",
+                "id": "BrainSegmentation"
+            },
+            {
+                "path-template": "[OUT_PREFIX]BrainSegmentation*N4.[IMAGE_SUFFIX]",
+                "description": "An existing file name. N4 corrected image.",
+                "optional": true,
+                "name": "Brainsegmentationn4",
+                "id": "BrainSegmentationN4"
+            },
+            {
+                "description": "A list of items which are an existing file name. Posterior probability images.",
+                "list": true,
+                "id": "BrainSegmentationPosteriors",
+                "optional": true,
+                "path-template": "[OUT_PREFIX]BrainSegmentationPosteriors*.[IMAGE_SUFFIX]",
+                "name": "Brainsegmentationposteriors"
+            },
+            {
+                "path-template": "[OUT_PREFIX]brainvols.csv",
+                "description": "An existing file name. Brain volumes as text.",
+                "optional": true,
+                "name": "Brainvolumes",
+                "id": "BrainVolumes"
+            },
+            {
+                "path-template": "[OUT_PREFIX]CorticalThickness.[IMAGE_SUFFIX]",
+                "description": "An existing file name. Cortical thickness file.",
+                "optional": true,
+                "name": "Corticalthickness",
+                "id": "CorticalThickness"
+            },
+            {
+                "path-template": "[OUT_PREFIX]NormalizedCorticalThickness.[IMAGE_SUFFIX]",
+                "description": "An existing file name. Normalized cortical thickness.",
+                "optional": true,
+                "name": "Corticalthicknessnormedtotemplate",
+                "id": "CorticalThicknessNormedToTemplate"
+            },
+            {
+                "path-template": "[OUT_PREFIX]ExtractedBrain0N4.[IMAGE_SUFFIX]",
+                "description": "An existing file name. Extracted brain from n4 image.",
+                "optional": true,
+                "name": "Extractedbrainn4",
+                "id": "ExtractedBrainN4"
+            },
+            {
+                "path-template": "[OUT_PREFIX]SubjectToTemplate0GenericAffine.mat",
+                "description": "An existing file name. Template to subject inverse affine.",
+                "optional": true,
+                "name": "Subjecttotemplate0genericaffine",
+                "id": "SubjectToTemplate0GenericAffine"
+            },
+            {
+                "path-template": "[OUT_PREFIX]SubjectToTemplate1Warp.[IMAGE_SUFFIX]",
+                "description": "An existing file name. Template to subject inverse warp.",
+                "optional": true,
+                "name": "Subjecttotemplate1warp",
+                "id": "SubjectToTemplate1Warp"
+            },
+            {
+                "path-template": "[OUT_PREFIX]SubjectToTemplateLogJacobian.[IMAGE_SUFFIX]",
+                "description": "An existing file name. Template to subject log jacobian.",
+                "optional": true,
+                "name": "Subjecttotemplatelogjacobian",
+                "id": "SubjectToTemplateLogJacobian"
+            },
+            {
+                "path-template": "[OUT_PREFIX]TemplateToSubject0Warp.[IMAGE_SUFFIX]",
+                "description": "An existing file name. Template to subject warp.",
+                "optional": true,
+                "name": "Templatetosubject0warp",
+                "id": "TemplateToSubject0Warp"
+            },
+            {
+                "path-template": "[OUT_PREFIX]TemplateToSubject1GenericAffine.mat",
+                "description": "An existing file name. Template to subject affine.",
+                "optional": true,
+                "name": "Templatetosubject1genericaffine",
+                "id": "TemplateToSubject1GenericAffine"
+            }
+        ],
+        "name": "CorticalThickness"
+    },
+    {
+        "name": "LaplacianThickness",
+        "command-line": "${ANTSPATH}/LaplacianThickness [INPUT_WM] [INPUT_GM] [OUTPUT_IMAGE] [SMOOTH_PARAM] [PRIOR_THICKNESS] [DT] [SULCUS_PRIOR] [TOLERANCE]",
+        "author": "Nipype (interface), Brian B. Avants et al. (tool)",
+        "description": "LaplacianThickness, as implemented in Nipype (module: nipype.interfaces.ants, interface: LaplacianThickness).",
+        "inputs": [
+            {
+                "id": "dT",
+                "name": "Dt",
+                "type": "Number",
+                "value-key": "[DT]",
+                "description": "A float. Time delta used during integration (defaults to 0.01).",
+                "optional": true,
+                "requires-inputs": [
+                    "prior_thickness"
+                ]
+            },
+            {
+                "id": "input_gm",
+                "name": "Input gm",
+                "type": "File",
+                "value-key": "[INPUT_GM]",
+                "description": "A file name. Gray matter segmentation image.",
+                "optional": false
+            },
+            {
+                "id": "input_wm",
+                "name": "Input wm",
+                "type": "File",
+                "value-key": "[INPUT_WM]",
+                "description": "A file name. White matter segmentation image.",
+                "optional": false
+            },
+            {
+                "id": "prior_thickness",
+                "name": "Prior thickness",
+                "type": "Number",
+                "value-key": "[PRIOR_THICKNESS]",
+                "description": "A float. Prior thickness (defaults to 500).",
+                "optional": true,
+                "requires-inputs": [
+                    "smooth_param"
+                ]
+            },
+            {
+                "id": "smooth_param",
+                "name": "Smooth param",
+                "type": "Number",
+                "value-key": "[SMOOTH_PARAM]",
+                "description": "A float. Sigma of the laplacian recursive image filter (defaults to 1).",
+                "optional": true
+            },
+            {
+                "id": "sulcus_prior",
+                "name": "Sulcus prior",
+                "type": "Number",
+                "value-key": "[SULCUS_PRIOR]",
+                "description": "A float. Positive floating point number for sulcus prior. Authors said that 0.15 might be a reasonable value.",
+                "optional": true,
+                "requires-inputs": [
+                    "dT"
+                ]
+            },
+            {
+                "id": "tolerance",
+                "name": "Tolerance",
+                "type": "Number",
+                "value-key": "[TOLERANCE]",
+                "description": "A float. Tolerance to reach during optimization (defaults to 0.001).",
+                "optional": true,
+                "requires-inputs": [
+                    "sulcus_prior"
+                ]
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Output image",
+                "id": "output_image",
+                "optional": true,
+                "description": "An existing file name. Cortical thickness.",
+                "path-template": "[INPUT_WM]_thickness",
+                "value-key": "[OUTPUT_IMAGE]"
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "bt5e/ants:latest",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "tags": {
+            "domain": "neuroinformatics",
+            "source": "nipype-interface"
+        }
+    },
+    {
+        "name": "BrainExtraction",
+        "command-line": "${ANTSPATH}/antsBrainExtraction.sh [ANATOMICAL_IMAGE] [BRAIN_PROBABILITY_MASK] [BRAIN_TEMPLATE] [DEBUG] [DIMENSION] [EXTRACTION_REGISTRATION_MASK] [IMAGE_SUFFIX] [KEEP_TEMPORARY_FILES] [OUT_PREFIX] [USE_FLOATINGPOINT_PRECISION] [USE_RANDOM_SEEDING]",
+        "author": "Nipype (interface), Brian B. Avants et al. (tool)",
+        "description": "BrainExtraction, as implemented in Nipype (module: nipype.interfaces.ants, interface: BrainExtraction).",
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/ants/segmentation.py",
+        "inputs": [
+            {
+                "id": "anatomical_image",
+                "name": "Anatomical image",
+                "type": "File",
+                "value-key": "[ANATOMICAL_IMAGE]",
+                "command-line-flag": "-a",
+                "description": "An existing file name. Structural image, typically t1.  if more than one anatomical image is specified, subsequently specified images are used during the segmentation process.  however, only the first image is used in the registration of priors. our suggestion would be to specify the t1 as the first image. anatomical template created using e.g. lpba40 data set with buildtemplateparallel.sh in ants.",
+                "optional": false
+            },
+            {
+                "id": "brain_probability_mask",
+                "name": "Brain probability mask",
+                "type": "File",
+                "value-key": "[BRAIN_PROBABILITY_MASK]",
+                "command-line-flag": "-m",
+                "description": "An existing file name. Brain probability mask created using e.g. lpba40 data set which have brain masks defined, and warped to anatomical template and averaged resulting in a probability image.",
+                "optional": false
+            },
+            {
+                "id": "brain_template",
+                "name": "Brain template",
+                "type": "File",
+                "value-key": "[BRAIN_TEMPLATE]",
+                "command-line-flag": "-e",
+                "description": "An existing file name. Anatomical template created using e.g. lpba40 data set with buildtemplateparallel.sh in ants.",
+                "optional": false
+            },
+            {
+                "id": "debug",
+                "name": "Debug",
+                "type": "Flag",
+                "value-key": "[DEBUG]",
+                "command-line-flag": "-z 1",
+                "description": "A boolean. If > 0, runs a faster version of the script. only for testing. implies -u 0. requires single thread computation for complete reproducibility.",
+                "optional": true
+            },
+            {
+                "id": "dimension",
+                "name": "Dimension",
+                "type": "Number",
+                "value-key": "[DIMENSION]",
+                "command-line-flag": "-d",
+                "description": "3 or 2. Image dimension (2 or 3).",
+                "optional": true,
+                "default-value": 3,
+                "integer": true,
+                "value-choices": [
+                    3,
+                    2
+                ]
+            },
+            {
+                "id": "extraction_registration_mask",
+                "name": "Extraction registration mask",
+                "type": "File",
+                "value-key": "[EXTRACTION_REGISTRATION_MASK]",
+                "command-line-flag": "-f",
+                "description": "An existing file name. Mask (defined in the template space) used during registration for brain extraction. to limit the metric computation to a specific region.",
+                "optional": true
+            },
+            {
+                "id": "image_suffix",
+                "name": "Image suffix",
+                "type": "String",
+                "value-key": "[IMAGE_SUFFIX]",
+                "command-line-flag": "-s",
+                "description": "A unicode string. Any of standard itk formats, nii.gz is default.",
+                "optional": true,
+                "default-value": "nii.gz"
+            },
+            {
+                "id": "keep_temporary_files",
+                "name": "Keep temporary files",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[KEEP_TEMPORARY_FILES]",
+                "command-line-flag": "-k",
+                "description": "An integer (int or long). Keep brain extraction/segmentation warps, etc (default = 0).",
+                "optional": true
+            },
+            {
+                "id": "out_prefix",
+                "name": "Out prefix",
+                "type": "String",
+                "value-key": "[OUT_PREFIX]",
+                "command-line-flag": "-o",
+                "description": "A unicode string. Prefix that is prepended to all output files (default = highress001_).",
+                "optional": true,
+                "default-value": "highres001_"
+            },
+            {
+                "id": "use_floatingpoint_precision",
+                "name": "Use floatingpoint precision",
+                "type": "Number",
+                "value-key": "[USE_FLOATINGPOINT_PRECISION]",
+                "command-line-flag": "-q",
+                "description": "0 or 1. Use floating point precision in registrations (default = 0).",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "id": "use_random_seeding",
+                "name": "Use random seeding",
+                "type": "Number",
+                "value-key": "[USE_RANDOM_SEEDING]",
+                "command-line-flag": "-u",
+                "description": "0 or 1. Use random number generated from system clock in atropos (default = 1).",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ]
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Brainextractionbrain",
+                "id": "BrainExtractionBrain",
+                "path-template": "[OUT_PREFIX]BrainExtractionBrain.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. Brain extraction image."
+            },
+            {
+                "name": "Brainextractioncsf",
+                "id": "BrainExtractionCSF",
+                "path-template": "[OUT_PREFIX]BrainExtractionCSF.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. Segmentation mask with only csf."
+            },
+            {
+                "name": "Brainextractiongm",
+                "id": "BrainExtractionGM",
+                "path-template": "[OUT_PREFIX]BrainExtractionGM.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. Segmentation mask with only grey matter."
+            },
+            {
+                "name": "Brainextractioninitialaffine",
+                "id": "BrainExtractionInitialAffine",
+                "path-template": "[OUT_PREFIX]BrainExtractionInitialAffine.mat",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractioninitialaffinefixed",
+                "id": "BrainExtractionInitialAffineFixed",
+                "path-template": "[OUT_PREFIX]BrainExtractionInitialAffineFixed.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractioninitialaffinemoving",
+                "id": "BrainExtractionInitialAffineMoving",
+                "path-template": "[OUT_PREFIX]BrainExtractionInitialAffineMoving.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractionlaplacian",
+                "id": "BrainExtractionLaplacian",
+                "path-template": "[OUT_PREFIX]BrainExtractionLaplacian.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractionmask",
+                "id": "BrainExtractionMask",
+                "path-template": "[OUT_PREFIX]BrainExtractionMask.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. Brain extraction mask."
+            },
+            {
+                "name": "Brainextractionprior0genericaffine",
+                "id": "BrainExtractionPrior0GenericAffine",
+                "path-template": "[OUT_PREFIX]BrainExtractionPrior0GenericAffine.mat",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractionprior1inversewarp",
+                "id": "BrainExtractionPrior1InverseWarp",
+                "path-template": "[OUT_PREFIX]BrainExtractionPrior1InverseWarp.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractionprior1warp",
+                "id": "BrainExtractionPrior1Warp",
+                "path-template": "[OUT_PREFIX]BrainExtractionPrior1Warp.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractionpriorwarped",
+                "id": "BrainExtractionPriorWarped",
+                "path-template": "[OUT_PREFIX]BrainExtractionPriorWarped.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractionsegmentation",
+                "id": "BrainExtractionSegmentation",
+                "path-template": "[OUT_PREFIX]BrainExtractionSegmentation.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. Segmentation mask with csf, gm, and wm."
+            },
+            {
+                "name": "Brainextractiontemplatelaplacian",
+                "id": "BrainExtractionTemplateLaplacian",
+                "path-template": "[OUT_PREFIX]BrainExtractionTemplateLaplacian.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractiontmp",
+                "id": "BrainExtractionTmp",
+                "path-template": "[OUT_PREFIX]BrainExtractionTmp.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            },
+            {
+                "name": "Brainextractionwm",
+                "id": "BrainExtractionWM",
+                "path-template": "[OUT_PREFIX]BrainExtractionWM.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. Segmenration mask with only white matter."
+            },
+            {
+                "name": "N4corrected0",
+                "id": "N4Corrected0",
+                "path-template": "[OUT_PREFIX]N4Corrected0.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. N4 bias field corrected image."
+            },
+            {
+                "name": "N4truncated0",
+                "id": "N4Truncated0",
+                "path-template": "[OUT_PREFIX]N4Truncated0.[IMAGE_SUFFIX]",
+                "optional": true,
+                "description": "An existing file name. No description provided."
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "bt5e/ants:latest",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "tags": {
+            "domain": "neuroinformatics",
+            "source": "nipype-interface"
+        }
+    },
+    {
+        "tool-version": "1.0.0",
+        "description": "Concatenate multiple ANTs warping fields using ComposeMultiTransform.\n\nFor instance if you have\n- Warping field: anatomical to MNI template\n- Affine matrix: Diffusion to anatomical\nYou can obtain the transform diffusion to MNI template\n\n\nComposeMultiTransform ImageDimension output_field [-R reference_image] {[deformation_field | [-i] affine_transform_txt ]}\n  Usage has the same form as WarpImageMultiTransform\n For Example:\n\nComposeMultiTransform Dimension  outwarp.nii   -R template.nii   ExistingWarp.nii  ExistingAffine.nii\n or for an inverse mapping :\nComposeMultiTransform Dimension  outwarp.nii   -R template.nii   -i ExistingAffine.nii ExistingInverseWarp.nii\n recalling that the -i option takes the inverse of the affine mapping\n\nOr: to compose multiple affine text file into one:\nComposeMultiTransform ImageDimension output_affine_txt [-R reference_affine_txt] {[-i] affine_transform_txt}\nThis will be evoked if a text file is given as the second parameter. In this case reference_affine_txt is used to define the center of the output affine.  The default reference is the first given affine text file. This ignores all non-txt files among the following parameters.\n\n",
+        "command-line": "ComposeMultiTransform 3 [OUPUT_WARPING_FIELD] -R [REFERENCE_IMAGE] [1ST_WARPING_FIELD__OR_AFFINE_MATRIX_] [2ND_WARPING_FIELD]",
+        "author": "TONIC",
+        "container-image": {
+            "image": "bids/mrtrix3_connectome",
+            "type": "docker"
+        },
+        "inputs": [
+            {
+                "description": "Reference Image",
+                "value-key": "[REFERENCE_IMAGE]",
+                "type": "File",
+                "optional": false,
+                "id": "reference_image",
+                "name": "Reference Image"
+            },
+            {
+                "description": "1st warping field (or affine matrix)",
+                "value-key": "[1ST_WARPING_FIELD__OR_AFFINE_MATRIX_]",
+                "type": "File",
+                "optional": false,
+                "id": "1st_warping_field__or_affine_matrix_",
+                "name": "1st warping field (or affine matrix)"
+            },
+            {
+                "description": "2nd warping field",
+                "value-key": "[2ND_WARPING_FIELD]",
+                "type": "File",
+                "optional": false,
+                "id": "2nd_warping_field",
+                "name": "2nd warping field"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "description": "Ouput warping field",
+                "value-key": "[OUPUT_WARPING_FIELD]",
+                "path-template": "./",
+                "optional": false,
+                "id": "ouput_warping_field",
+                "name": "Ouput warping field"
+            }
+        ],
+        "name": "ConcatTransfo"
+    },
+    {
+        "name": "TOPUP",
+        "command-line": "topup [CONFIG] [ENCODING_FILE] [ESTMOV] [FWHM] [IN_FILE] [INTERP] [MAX_ITER] [MINMET] [NUMPREC] [OUT_BASE] [OUT_CORRECTED] [OUT_FIELD] [OUT_JAC_PREFIX] [OUT_LOGFILE] [OUT_MAT_PREFIX] [OUT_WARP_PREFIX] [REG_LAMBDA] [REGMOD] [REGRID] [SCALE] [SPLINEORDER] [SSQLAMBDA] [SUBSAMP] [WARP_RES]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "TOPUP, as implemented in Nipype (module: nipype.interfaces.fsl, interface: TOPUP).",
+        "inputs": [
+            {
+                "id": "config",
+                "name": "Config",
+                "type": "String",
+                "value-key": "[CONFIG]",
+                "command-line-flag": "--config",
+                "command-line-flag-separator": "=",
+                "description": "A string. Name of config file specifying command line arguments.",
+                "optional": true,
+                "default-value": "b02b0.cnf"
+            },
+            {
+                "id": "encoding_file",
+                "name": "Encoding file",
+                "type": "File",
+                "value-key": "[ENCODING_FILE]",
+                "command-line-flag": "--datain",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of text file with pe directions/times.",
+                "optional": false
+            },
+            {
+                "id": "estmov",
+                "name": "Estmov",
+                "type": "Number",
+                "value-key": "[ESTMOV]",
+                "command-line-flag": "--estmov",
+                "command-line-flag-separator": "=",
+                "description": "1 or 0. Estimate movements if set.",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "id": "fwhm",
+                "name": "Fwhm",
+                "type": "Number",
+                "value-key": "[FWHM]",
+                "command-line-flag": "--fwhm",
+                "command-line-flag-separator": "=",
+                "description": "A float. Fwhm (in mm) of gaussian smoothing kernel.",
+                "optional": true
+            },
+            {
+                "id": "in_file",
+                "name": "In file",
+                "type": "File",
+                "value-key": "[IN_FILE]",
+                "command-line-flag": "--imain",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of 4d file with images.",
+                "optional": false
+            },
+            {
+                "id": "interp",
+                "name": "Interp",
+                "type": "String",
+                "value-key": "[INTERP]",
+                "command-line-flag": "--interp",
+                "command-line-flag-separator": "=",
+                "description": "'spline' or 'linear'. Image interpolation model, linear or spline.",
+                "optional": true,
+                "value-choices": [
+                    "spline",
+                    "linear"
+                ]
+            },
+            {
+                "id": "max_iter",
+                "name": "Max iter",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[MAX_ITER]",
+                "command-line-flag": "--miter",
+                "command-line-flag-separator": "=",
+                "description": "An integer (int or long). Max # of non-linear iterations.",
+                "optional": true
+            },
+            {
+                "id": "minmet",
+                "name": "Minmet",
+                "type": "Number",
+                "value-key": "[MINMET]",
+                "command-line-flag": "--minmet",
+                "command-line-flag-separator": "=",
+                "description": "0 or 1. Minimisation method 0=levenberg-marquardt, 1=scaled conjugate gradient.",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "id": "numprec",
+                "name": "Numprec",
+                "type": "String",
+                "value-key": "[NUMPREC]",
+                "command-line-flag": "--numprec",
+                "command-line-flag-separator": "=",
+                "description": "'double' or 'float'. Precision for representing hessian, double or float.",
+                "optional": true,
+                "value-choices": [
+                    "double",
+                    "float"
+                ]
+            },
+            {
+                "id": "out_jac_prefix",
+                "name": "Out jac prefix",
+                "type": "String",
+                "value-key": "[OUT_JAC_PREFIX]",
+                "command-line-flag": "--jacout",
+                "command-line-flag-separator": "=",
+                "description": "A unicode string. Prefix for the warpfield images.",
+                "optional": true,
+                "default-value": "jac"
+            },
+            {
+                "id": "out_mat_prefix",
+                "name": "Out mat prefix",
+                "type": "String",
+                "value-key": "[OUT_MAT_PREFIX]",
+                "command-line-flag": "--rbmout",
+                "command-line-flag-separator": "=",
+                "description": "A unicode string. Prefix for the realignment matrices.",
+                "optional": true,
+                "default-value": "xfm"
+            },
+            {
+                "id": "out_warp_prefix",
+                "name": "Out warp prefix",
+                "type": "String",
+                "value-key": "[OUT_WARP_PREFIX]",
+                "command-line-flag": "--dfout",
+                "command-line-flag-separator": "=",
+                "description": "A unicode string. Prefix for the warpfield images (in mm).",
+                "optional": true,
+                "default-value": "warpfield"
+            },
+            {
+                "id": "reg_lambda",
+                "name": "Reg lambda",
+                "type": "Number",
+                "value-key": "[REG_LAMBDA]",
+                "command-line-flag": "--lambda",
+                "command-line-flag-separator": "=",
+                "description": "A float. Weight of regularisation, default depending on --ssqlambda and --regmod switches.",
+                "optional": true
+            },
+            {
+                "id": "regmod",
+                "name": "Regmod",
+                "type": "String",
+                "value-key": "[REGMOD]",
+                "command-line-flag": "--regmod",
+                "command-line-flag-separator": "=",
+                "description": "'bending_energy' or 'membrane_energy'. Regularisation term implementation. defaults to bending_energy. note that the two functions have vastly different scales. the membrane energy is based on the first derivatives and the bending energy on the second derivatives. the second derivatives will typically be much smaller than the first derivatives, so input lambda will have to be larger for bending_energy to yield approximately the same level of regularisation.",
+                "optional": true,
+                "value-choices": [
+                    "bending_energy",
+                    "membrane_energy"
+                ]
+            },
+            {
+                "id": "regrid",
+                "name": "Regrid",
+                "type": "Number",
+                "value-key": "[REGRID]",
+                "command-line-flag": "--regrid",
+                "command-line-flag-separator": "=",
+                "description": "1 or 0. If set (=1), the calculations are done in a different grid.",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "id": "scale",
+                "name": "Scale",
+                "type": "Number",
+                "value-key": "[SCALE]",
+                "command-line-flag": "--scale",
+                "command-line-flag-separator": "=",
+                "description": "0 or 1. If set (=1), the images are individually scaled to a common mean.",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "id": "splineorder",
+                "name": "Splineorder",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[SPLINEORDER]",
+                "command-line-flag": "--splineorder",
+                "command-line-flag-separator": "=",
+                "description": "An integer (int or long). Order of spline, 2->qadratic spline, 3->cubic spline.",
+                "optional": true
+            },
+            {
+                "id": "ssqlambda",
+                "name": "Ssqlambda",
+                "type": "Number",
+                "value-key": "[SSQLAMBDA]",
+                "command-line-flag": "--ssqlambda",
+                "command-line-flag-separator": "=",
+                "description": "1 or 0. Weight lambda by the current value of the ssd. if used (=1), the effective weight of regularisation term becomes higher for the initial iterations, therefore initial steps are a little smoother than they would without weighting. this reduces the risk of finding a local minimum.",
+                "optional": true,
+                "integer": true,
+                "value-choices": [
+                    1,
+                    0
+                ]
+            },
+            {
+                "id": "subsamp",
+                "name": "Subsamp",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[SUBSAMP]",
+                "command-line-flag": "--subsamp",
+                "command-line-flag-separator": "=",
+                "description": "An integer (int or long). Sub-sampling scheme.",
+                "optional": true
+            },
+            {
+                "id": "warp_res",
+                "name": "Warp res",
+                "type": "Number",
+                "value-key": "[WARP_RES]",
+                "command-line-flag": "--warpres",
+                "command-line-flag-separator": "=",
+                "description": "A float. (approximate) resolution (in mm) of warp basis for the different sub-sampling levels.",
+                "optional": true
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Out base",
+                "id": "out_base",
+                "optional": true,
+                "description": "A file name. Base-name of output files (spline coefficients (hz) and movement parameters).",
+                "path-template": "[IN_FILE]_base",
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ],
+                "value-key": "[OUT_BASE]",
+                "command-line-flag": "--out",
+                "command-line-flag-separator": "="
+            },
+            {
+                "name": "Out corrected",
+                "id": "out_corrected",
+                "path-template": "[IN_FILE]_corrected",
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ],
+                "optional": true,
+                "description": "A file name. Name of 4d image file with unwarped images.",
+                "value-key": "[OUT_CORRECTED]",
+                "command-line-flag": "--iout",
+                "command-line-flag-separator": "="
+            },
+            {
+                "name": "Out enc file",
+                "id": "out_enc_file",
+                "path-template": "out_enc_file",
+                "optional": true,
+                "description": "A file name. Encoding directions file output for applytopup."
+            },
+            {
+                "name": "Out field",
+                "id": "out_field",
+                "path-template": "[IN_FILE]_field",
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ],
+                "optional": true,
+                "description": "A file name. Name of image file with field (hz).",
+                "value-key": "[OUT_FIELD]",
+                "command-line-flag": "--fout",
+                "command-line-flag-separator": "="
+            },
+            {
+                "name": "Out fieldcoef",
+                "id": "out_fieldcoef",
+                "path-template": "out_fieldcoef",
+                "optional": true,
+                "description": "An existing file name. File containing the field coefficients."
+            },
+            {
+                "name": "Out jacs",
+                "id": "out_jacs",
+                "path-template": "out_jacs",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Jacobian images."
+            },
+            {
+                "name": "Out logfile",
+                "id": "out_logfile",
+                "path-template": "[IN_FILE]_topup.log",
+                "path-template-stripped-extensions": [
+                    ".nii.gz",
+                    ".nii"
+                ],
+                "optional": true,
+                "description": "A file name. Name of log-file.",
+                "value-key": "[OUT_LOGFILE]",
+                "command-line-flag": "--logout",
+                "command-line-flag-separator": "="
+            },
+            {
+                "name": "Out mats",
+                "id": "out_mats",
+                "path-template": "out_mats",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Realignment matrices."
+            },
+            {
+                "name": "Out movpar",
+                "id": "out_movpar",
+                "path-template": "out_movpar",
+                "optional": true,
+                "description": "An existing file name. Movpar.txt output file."
+            },
+            {
+                "name": "Out warps",
+                "id": "out_warps",
+                "path-template": "out_warps",
+                "optional": true,
+                "description": "A list of items which are an existing file name. Warpfield images."
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "dmri"
+            ],
+            "source": "nipype-interface"
+        },
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/epi.py"
+    },
+    {
+        "name": "ApplyTOPUP",
+        "command-line": "applytopup [DATATYPE] [ENCODING_FILE] [IN_FILES] [IN_INDEX] [IN_TOPUP_FIELDCOEF] [INTERP] [METHOD] [OUT_CORRECTED]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "ApplyTOPUP, as implemented in Nipype (module: nipype.interfaces.fsl, interface: ApplyTOPUP).",
+        "inputs": [
+            {
+                "id": "datatype",
+                "name": "Datatype",
+                "type": "String",
+                "value-key": "[DATATYPE]",
+                "command-line-flag": "--datatype",
+                "command-line-flag-separator": "=",
+                "description": "'char' or 'short' or 'int' or 'float' or 'double'. Force output data type.",
+                "optional": true,
+                "value-choices": [
+                    "char",
+                    "short",
+                    "int",
+                    "float",
+                    "double"
+                ]
+            },
+            {
+                "id": "encoding_file",
+                "name": "Encoding file",
+                "type": "File",
+                "value-key": "[ENCODING_FILE]",
+                "command-line-flag": "--datain",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Name of text file with pe directions/times.",
+                "optional": false
+            },
+            {
+                "id": "in_files",
+                "name": "In files",
+                "type": "File",
+                "list": true,
+                "list-separator": ",",
+                "value-key": "[IN_FILES]",
+                "command-line-flag": "--imain",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are an existing file name. Name of file with images.",
+                "optional": false
+            },
+            {
+                "id": "in_index",
+                "name": "In index",
+                "type": "Number",
+                "list": true,
+                "integer": true,
+                "list-separator": ",",
+                "value-key": "[IN_INDEX]",
+                "command-line-flag": "--inindex",
+                "command-line-flag-separator": "=",
+                "description": "A list of items which are an integer (int or long). Comma separated list of indices corresponding to --datain.",
+                "optional": false
+            },
+            {
+                "id": "in_topup_fieldcoef",
+                "name": "In topup fieldcoef",
+                "type": "File",
+                "value-key": "[IN_TOPUP_FIELDCOEF]",
+                "command-line-flag": "--topup",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Topup file containing the field coefficients.",
+                "optional": false
+            },
+            {
+                "id": "interp",
+                "name": "Interp",
+                "type": "String",
+                "value-key": "[INTERP]",
+                "command-line-flag": "--interp",
+                "command-line-flag-separator": "=",
+                "description": "'trilinear' or 'spline'. Interpolation method.",
+                "optional": true,
+                "value-choices": [
+                    "trilinear",
+                    "spline"
+                ]
+            },
+            {
+                "id": "method",
+                "name": "Method",
+                "type": "String",
+                "value-key": "[METHOD]",
+                "command-line-flag": "--method",
+                "command-line-flag-separator": "=",
+                "description": "'jac' or 'lsr'. Use jacobian modulation (jac) or least-squares resampling (lsr).",
+                "optional": true,
+                "value-choices": [
+                    "jac",
+                    "lsr"
+                ]
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Out corrected",
+                "id": "out_corrected",
+                "path-template": "out_corrected",
+                "optional": false,
+                "description": "An existing file name. Name of 4d image file with unwarped images.",
+                "value-key": "[OUT_CORRECTED]",
+                "command-line-flag": "--out",
+                "command-line-flag-separator": "="
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "dmri"
+            ],
+            "source": "nipype-interface"
+        },
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/epi.py"
+    },
+    {
+        "name": "CompositeTransformUtil",
+        "command-line": "${ANTSPATH}/CompositeTransformUtil [PROCESS] [OUT_FILE] [IN_FILE] [OUTPUT_PREFIX]",
+        "author": "Nipype (interface), Brian B. Avants et al. (tool)",
+        "description": "CompositeTransformUtil, as implemented in Nipype (module: nipype.interfaces.ants, interface: CompositeTransformUtil).",
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/ants/registration.py",
+        "inputs": [
+            {
+                "id": "in_file",
+                "name": "In file",
+                "type": "File",
+                "list": true,
+                "value-key": "[IN_FILE]",
+                "description": "A list of items which are an existing file name. Input transform file(s).",
+                "optional": false
+            },
+            {
+                "id": "out_file",
+                "name": "Out file",
+                "type": "File",
+                "value-key": "[OUT_FILE]",
+                "description": "A file name. Output file path (only used for assembly).",
+                "optional": true
+            },
+            {
+                "id": "output_prefix",
+                "name": "Output prefix",
+                "type": "String",
+                "value-key": "[OUTPUT_PREFIX]",
+                "description": "A unicode string. A prefix that is prepended to all output files (only used for disassembly).",
+                "optional": true,
+                "default-value": "transform"
+            },
+            {
+                "id": "process",
+                "name": "Process",
+                "type": "String",
+                "value-key": "[PROCESS]",
+                "command-line-flag": "--",
+                "command-line-flag-separator": "",
+                "description": "'assemble' or 'disassemble'. What to do with the transform inputs (assemble or disassemble).",
+                "optional": true,
+                "default-value": "assemble",
+                "value-choices": [
+                    "assemble",
+                    "disassemble"
+                ],
+                "value-disables": {
+                    "assemble": [
+                        "output_prefix"
+                    ],
+                    "disassemble": [
+                        "out_file"
+                    ]
+                }
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Affine transform",
+                "id": "affine_transform",
+                "path-template": "00_[OUTPUT_PREFIX]_AffineTransform.mat",
+                "optional": true,
+                "description": "A file name. Affine transform component."
+            },
+            {
+                "name": "Displacement field",
+                "id": "displacement_field",
+                "path-template": "01_[OUTPUT_PREFIX]_DisplacementFieldTransform.nii.gz",
+                "optional": true,
+                "description": "A file name. Displacement field component."
+            },
+            {
+                "name": "Out file",
+                "id": "out_file_outfile",
+                "path-template": "[OUT_FILE]",
+                "optional": true,
+                "description": "A file name. Compound transformation file."
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "bt5e/ants:latest",
+            "index": "index.docker.io",
+            "type": "docker"
+        },
+        "tags": {
+            "domain": "neuroinformatics",
+            "source": "nipype-interface"
+        }
+    },
+    {
+        "error-codes": [
+            {
+                "code": 1,
+                "description": "failed"
+            }
+        ],
+        "tool-version": "v1",
+        "tests": [
+            {
+                "invocation": {
+                    "5c0c0020f0a53c004bd7ae7c_M": "mean",
+                    "5c0a8a9df0a53c004bd79c82_lmax": null,
+                    "5bfebb5d80ce40002a62cdfc_eddyCorrect": "1",
+                    "5c0a8a9df0a53c004bd79c82_fibers": 500000,
+                    "5bfebb5d80ce40002a62cdfc_resolution": "default",
+                    "5c0bea9cf0a53c004bd7ae07_useinterhemisphericsplit": false,
+                    "5c0c0020f0a53c004bd7ae7c_maxlen": 4,
+                    "5bfebb5d80ce40002a62cdfc_phaseEncodeDir": "2",
+                    "5c0a8a9df0a53c004bd79c82_fibers_max": 1000000,
+                    "5bfebb5d80ce40002a62cdfc_noDwiAlignment": false,
+                    "5bfebb5d80ce40002a62cdfc_rotateBvecsWithCanXform": true,
+                    "5c0c0020f0a53c004bd7ae7c_numnodes": 100,
+                    "5bfebb5d80ce40002a62cdfc_rotateBvecsWithRx": true,
+                    "5c0c0020f0a53c004bd7ae7c_maxdist": 4,
+                    "5c0c0020f0a53c004bd7ae7c_maxiter": 5
+                },
+                "name": "test1",
+                "assertions": {
+                    "output-files": [
+                        {
+                            "id": "output"
+                        }
+                    ],
+                    "exit-code": 0
+                }
+            }
+        ],
+        "description": "from acpc_aligned t1 and singleshell b2000 dwi, generate afq output",
+        "command-line": "bash run.sh",
+        "author": "Soichi Hayashi",
+        "tags": {
+            "source": "brainlife",
+            "dataset_id": "5c0c06e6f6f108004b490e2a"
+        },
+        "inputs": [
+            {
+                "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n phaseEncodeDir",
+                "default-value": "2",
+                "value-key": "[task.5bfebb5d80ce40002a62cdfc.phaseEncodeDir]",
+                "optional": true,
+                "type": "String",
+                "id": "5bfebb5d80ce40002a62cdfc_phaseEncodeDir"
+            },
+            {
+                "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n resolution",
+                "default-value": "default",
+                "value-key": "[task.5bfebb5d80ce40002a62cdfc.resolution]",
+                "optional": true,
+                "type": "String",
+                "id": "5bfebb5d80ce40002a62cdfc_resolution"
+            },
+            {
+                "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n rotateBvecsWithCanXform",
+                "default-value": "true",
+                "value-key": "[task.5bfebb5d80ce40002a62cdfc.rotateBvecsWithCanXform]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "5bfebb5d80ce40002a62cdfc_rotateBvecsWithCanXform"
+            },
+            {
+                "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n rotateBvecsWithRx",
+                "default-value": "true",
+                "value-key": "[task.5bfebb5d80ce40002a62cdfc.rotateBvecsWithRx]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "5bfebb5d80ce40002a62cdfc_rotateBvecsWithRx"
+            },
+            {
+                "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n eddyCorrect",
+                "default-value": "1",
+                "value-key": "[task.5bfebb5d80ce40002a62cdfc.eddyCorrect]",
+                "optional": true,
+                "type": "String",
+                "id": "5bfebb5d80ce40002a62cdfc_eddyCorrect"
+            },
+            {
+                "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n noDwiAlignment",
+                "default-value": "false",
+                "value-key": "[task.5bfebb5d80ce40002a62cdfc.noDwiAlignment]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "5bfebb5d80ce40002a62cdfc_noDwiAlignment"
+            },
+            {
+                "name": "brain-life/app-tracking(1.5)\nlmax:(null)\nfibers:500000\nfibers_max:1000000\n lmax",
+                "default-value": null,
+                "value-key": "[task.5c0a8a9df0a53c004bd79c82.lmax]",
+                "optional": true,
+                "type": "Number",
+                "id": "5c0a8a9df0a53c004bd79c82_lmax"
+            },
+            {
+                "name": "brain-life/app-tracking(1.5)\nlmax:(null)\nfibers:500000\nfibers_max:1000000\n fibers",
+                "default-value": 500000,
+                "value-key": "[task.5c0a8a9df0a53c004bd79c82.fibers]",
+                "type": "Number",
+                "optional": true,
+                "id": "5c0a8a9df0a53c004bd79c82_fibers"
+            },
+            {
+                "name": "brain-life/app-tracking(1.5)\nlmax:(null)\nfibers:500000\nfibers_max:1000000\n fibers_max",
+                "default-value": 1000000,
+                "value-key": "[task.5c0a8a9df0a53c004bd79c82.fibers_max]",
+                "optional": true,
+                "type": "Number",
+                "id": "5c0a8a9df0a53c004bd79c82_fibers_max"
+            },
+            {
+                "name": "brain-life/app-tractclassification(1.2)\nuseinterhemisphericsplit:(null)\n useinterhemisphericsplit",
+                "default-value": "false",
+                "value-key": "[task.5c0bea9cf0a53c004bd7ae07.useinterhemisphericsplit]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "5c0bea9cf0a53c004bd7ae07_useinterhemisphericsplit"
+            },
+            {
+                "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n maxiter",
+                "default-value": 5,
+                "value-key": "[task.5c0c0020f0a53c004bd7ae7c.maxiter]",
+                "optional": true,
+                "type": "Number",
+                "id": "5c0c0020f0a53c004bd7ae7c_maxiter"
+            },
+            {
+                "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n numnodes",
+                "default-value": 100,
+                "value-key": "[task.5c0c0020f0a53c004bd7ae7c.numnodes]",
+                "optional": true,
+                "type": "Number",
+                "id": "5c0c0020f0a53c004bd7ae7c_numnodes"
+            },
+            {
+                "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n maxlen",
+                "default-value": 4,
+                "value-key": "[task.5c0c0020f0a53c004bd7ae7c.maxlen]",
+                "optional": true,
+                "type": "Number",
+                "id": "5c0c0020f0a53c004bd7ae7c_maxlen"
+            },
+            {
+                "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n maxdist",
+                "default-value": 4,
+                "value-key": "[task.5c0c0020f0a53c004bd7ae7c.maxdist]",
+                "optional": true,
+                "type": "Number",
+                "id": "5c0c0020f0a53c004bd7ae7c_maxdist"
+            },
+            {
+                "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n M",
+                "default-value": "mean",
+                "value-key": "[task.5c0c0020f0a53c004bd7ae7c.M]",
+                "optional": true,
+                "type": "String",
+                "id": "5c0c0020f0a53c004bd7ae7c_M"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "task.5a05e7ad2767f30030bcf433/config.json",
+                "file-template": [
+                    "{    \"t1\": \"../5a05e7a82767f30030bcf431/5a050966eec2b300611abff2/t1.nii.gz\"}"
+                ],
+                "id": "5a05e7ad2767f30030bcf433_config",
+                "name": "config.json for brain-life/app-freesurfer\n"
+            },
+            {
+                "path-template": "task.5bfebb5d80ce40002a62cdfc/config.json",
+                "file-template": [
+                    "{    \"phaseEncodeDir\": \"[task.5bfebb5d80ce40002a62cdfc.phaseEncodeDir]\",    \"resolution\": \"[task.5bfebb5d80ce40002a62cdfc.resolution]\",    \"rotateBvecsWithCanXform\": [task.5bfebb5d80ce40002a62cdfc.rotateBvecsWithCanXform],    \"rotateBvecsWithRx\": [task.5bfebb5d80ce40002a62cdfc.rotateBvecsWithRx],    \"eddyCorrect\": \"[task.5bfebb5d80ce40002a62cdfc.eddyCorrect]\",    \"noDwiAlignment\": [task.5bfebb5d80ce40002a62cdfc.noDwiAlignment],    \"dwi\": \"../5bfebb5d80ce40002a62cdfa/5a050a00eec2b300611abff3/dwi.nii.gz\",    \"bvecs\": \"../5bfebb5d80ce40002a62cdfa/5a050a00eec2b300611abff3/dwi.bvecs\",    \"bvals\": \"../5bfebb5d80ce40002a62cdfa/5a050a00eec2b300611abff3/dwi.bvals\",    \"t1\": \"../5bfebb5d80ce40002a62cdfa/5a050966eec2b300611abff2/t1.nii.gz\"}"
+                ],
+                "id": "5bfebb5d80ce40002a62cdfc_config",
+                "name": "config.json for brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n"
+            },
+            {
+                "path-template": "task.5c0a8a9df0a53c004bd79c82/config.json",
+                "file-template": [
+                    "{    \"lmax\": \"[task.5c0a8a9df0a53c004bd79c82.lmax]\",    \"fibers\": \"[task.5c0a8a9df0a53c004bd79c82.fibers]\",    \"fibers_max\": \"[task.5c0a8a9df0a53c004bd79c82.fibers_max]\",    \"dwi\": \"../5c098457f0a53c004bd79131/5bfee5acc203920043d43ddd/dwi.nii.gz\",    \"bvecs\": \"../5c098457f0a53c004bd79131/5bfee5acc203920043d43ddd/dwi.bvecs\",    \"bvals\": \"../5c098457f0a53c004bd79131/5bfee5acc203920043d43ddd/dwi.bvals\",    \"freesurfer\": \"../5c098457f0a53c004bd79131/5a065cc75ab38300be518f51/output\"}"
+                ],
+                "id": "5c0a8a9df0a53c004bd79c82_config",
+                "name": "config.json for brain-life/app-tracking(1.5)\nlmax:(null)\nfibers:500000\nfibers_max:1000000\n"
+            },
+            {
+                "path-template": "task.5c0bea9cf0a53c004bd7ae07/config.json",
+                "file-template": [
+                    "{    \"useinterhemisphericsplit\": [task.5c0bea9cf0a53c004bd7ae07.useinterhemisphericsplit],    \"track\": \"../5c0a8a9df0a53c004bd79c82/output.DT_STREAM.tck\",    \"dtiinit\": \"../5c093a2af0a53c004bd78b69/5bfee5abc203920043d43ddc/.\"}"
+                ],
+                "id": "5c0bea9cf0a53c004bd7ae07_config",
+                "name": "config.json for brain-life/app-tractclassification(1.2)\nuseinterhemisphericsplit:(null)\n"
+            },
+            {
+                "path-template": "task.5c0c0020f0a53c004bd7ae7c/config.json",
+                "file-template": [
+                    "{    \"maxiter\": \"[task.5c0c0020f0a53c004bd7ae7c.maxiter]\",    \"numnodes\": \"[task.5c0c0020f0a53c004bd7ae7c.numnodes]\",    \"maxlen\": \"[task.5c0c0020f0a53c004bd7ae7c.maxlen]\",    \"maxdist\": \"[task.5c0c0020f0a53c004bd7ae7c.maxdist]\",    \"M\": \"[task.5c0c0020f0a53c004bd7ae7c.M]\",    \"afq_fg\": \"../5c0bea9cf0a53c004bd7ae07/output.mat\"}"
+                ],
+                "id": "5c0c0020f0a53c004bd7ae7c_config",
+                "name": "config.json for brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n"
+            },
+            {
+                "path-template": "run.sh",
+                "file-template": [
+                    "#!/bin/bash",
+                    "echo \"staging task.5a05e7ad2767f30030bcf433 (brain-life/app-freesurfer)\"",
+                    "[ ! -d task.5a05e7ad2767f30030bcf433 ] && curl -L https://github.com/brain-life/app-freesurfer/archive/undefined.zip > task.5a05e7ad2767f30030bcf433.zip && unzip task.5a05e7ad2767f30030bcf433.zip && mv *undefined task.5a05e7ad2767f30030bcf433 && rm task.5a05e7ad2767f30030bcf433.zip",
+                    "",
+                    "echo \"running task task.5a05e7ad2767f30030bcf433 (brain-life/app-freesurfer)\"",
+                    "(",
+                    "\tcd task.5a05e7ad2767f30030bcf433",
+                    "\ttime ./main",
+                    ")",
+                    "",
+                    "echo \"staging task.5bfebb5d80ce40002a62cdfc (brain-life/app-dtiinit)\"",
+                    "[ ! -d task.5bfebb5d80ce40002a62cdfc ] && curl -L https://github.com/brain-life/app-dtiinit/archive/c4dcc5667c51e31f032e5148b72b236b3ff81900.zip > task.5bfebb5d80ce40002a62cdfc.zip && unzip task.5bfebb5d80ce40002a62cdfc.zip && mv *c4dcc5667c51e31f032e5148b72b236b3ff81900 task.5bfebb5d80ce40002a62cdfc && rm task.5bfebb5d80ce40002a62cdfc.zip",
+                    "",
+                    "echo \"running task task.5bfebb5d80ce40002a62cdfc (brain-life/app-dtiinit)\"",
+                    "(",
+                    "\tcd task.5bfebb5d80ce40002a62cdfc",
+                    "\ttime ./main",
+                    ")",
+                    "",
+                    "echo \"staging task.5c0a8a9df0a53c004bd79c82 (brain-life/app-tracking)\"",
+                    "[ ! -d task.5c0a8a9df0a53c004bd79c82 ] && curl -L https://github.com/brain-life/app-tracking/archive/44ff601ee2f2fd35c2a2bdb95426d828143692c6.zip > task.5c0a8a9df0a53c004bd79c82.zip && unzip task.5c0a8a9df0a53c004bd79c82.zip && mv *44ff601ee2f2fd35c2a2bdb95426d828143692c6 task.5c0a8a9df0a53c004bd79c82 && rm task.5c0a8a9df0a53c004bd79c82.zip",
+                    "",
+                    "echo \"running task task.5c0a8a9df0a53c004bd79c82 (brain-life/app-tracking)\"",
+                    "(",
+                    "\tcd task.5c0a8a9df0a53c004bd79c82",
+                    "\ttime ./main",
+                    ")",
+                    "",
+                    "echo \"staging task.5c0bea9cf0a53c004bd7ae07 (brain-life/app-tractclassification)\"",
+                    "[ ! -d task.5c0bea9cf0a53c004bd7ae07 ] && curl -L https://github.com/brain-life/app-tractclassification/archive/1ee98655908ee4a815f5da6970e18ea73bae6490.zip > task.5c0bea9cf0a53c004bd7ae07.zip && unzip task.5c0bea9cf0a53c004bd7ae07.zip && mv *1ee98655908ee4a815f5da6970e18ea73bae6490 task.5c0bea9cf0a53c004bd7ae07 && rm task.5c0bea9cf0a53c004bd7ae07.zip",
+                    "",
+                    "echo \"running task task.5c0bea9cf0a53c004bd7ae07 (brain-life/app-tractclassification)\"",
+                    "(",
+                    "\tcd task.5c0bea9cf0a53c004bd7ae07",
+                    "\ttime ./main",
+                    ")",
+                    "",
+                    "echo \"staging task.5c0c0020f0a53c004bd7ae7c (brain-life/app-AFQclean)\"",
+                    "[ ! -d task.5c0c0020f0a53c004bd7ae7c ] && curl -L https://github.com/brain-life/app-AFQclean/archive/6eb386469d5274df073ee2629d4f04e8a2d22fb2.zip > task.5c0c0020f0a53c004bd7ae7c.zip && unzip task.5c0c0020f0a53c004bd7ae7c.zip && mv *6eb386469d5274df073ee2629d4f04e8a2d22fb2 task.5c0c0020f0a53c004bd7ae7c && rm task.5c0c0020f0a53c004bd7ae7c.zip",
+                    "",
+                    "echo \"running task task.5c0c0020f0a53c004bd7ae7c (brain-life/app-AFQclean)\"",
+                    "(",
+                    "\tcd task.5c0c0020f0a53c004bd7ae7c",
+                    "\ttime ./main",
+                    ")",
+                    "",
+                    ""
+                ],
+                "id": "run",
+                "name": "run.sh"
+            },
+            {
+                "path-template": "task.5c0c0020f0a53c004bd7ae7c",
+                "id": "output",
+                "name": "Dataset output5c0c06e6f6f108004b490e2a"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 120,
+            "ram": 16,
+            "cpu-cores": 8
+        },
+        "name": "workflow generated from dataset:5c0c06e6f6f108004b490e2a"
+    },
+    {
+        "name": "DistanceMap",
+        "command-line": "distancemap  [DISTANCE_MAP] [IN_FILE] [INVERT_INPUT] [LOCAL_MAX_FILE] [MASK_FILE]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "DistanceMap, as implemented in Nipype (module: nipype.interfaces.fsl, interface: DistanceMap).",
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/dti.py",
+        "inputs": [
+            {
+                "id": "distance_map",
+                "name": "Distance map",
+                "type": "File",
+                "value-key": "[DISTANCE_MAP]",
+                "command-line-flag": "--out",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Distance map to write.",
+                "optional": false
+            },
+            {
+                "id": "in_file",
+                "name": "In file",
+                "type": "File",
+                "value-key": "[IN_FILE]",
+                "command-line-flag": "--in",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Image to calculate distance values for.",
+                "optional": false
+            },
+            {
+                "id": "invert_input",
+                "name": "Invert input",
+                "type": "Flag",
+                "value-key": "[INVERT_INPUT]",
+                "command-line-flag": "--invert",
+                "description": "A boolean. Invert input image.",
+                "optional": true
+            },
+            {
+                "id": "local_max_file",
+                "name": "Local max file",
+                "type": "File",
+                "value-key": "[LOCAL_MAX_FILE]",
+                "command-line-flag": "--localmax",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Write an image of the local maxima.",
+                "optional": true
+            },
+            {
+                "id": "mask_file",
+                "name": "Mask file",
+                "type": "File",
+                "value-key": "[MASK_FILE]",
+                "command-line-flag": "--mask",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Binary mask to contrain calculations.",
+                "optional": true
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Distance map",
+                "id": "distance_map_outfile",
+                "path-template": "[DISTANCE_MAP]",
+                "optional": true,
+                "description": "An existing file name. Value is distance to nearest nonzero voxels."
+            },
+            {
+                "name": "Local max file",
+                "id": "local_max_file_outfile",
+                "path-template": "[LOCAL_MAX_FILE]",
+                "optional": true,
+                "description": "A file name. Image of local maxima."
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ],
+            "source": "nipype-interface"
+        }
+    },
+    {
+        "name": "ApplyWarp",
+        "command-line": "applywarp [INTERP] [IN_FILE] [REF_FILE] [OUT_FILE] [RELWARP] [ABSWARP] [DATATYPE] [FIELD_FILE] [MASK_FILE] [POSTMAT] [PREMAT] [SUPERLEVEL] [SUPERSAMPLE]",
+        "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+        "description": "ApplyWarp, as implemented in Nipype (module: nipype.interfaces.fsl, interface: ApplyWarp).",
+        "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/preprocess.py",
+        "inputs": [
+            {
+                "id": "abswarp",
+                "name": "Abswarp",
+                "type": "Flag",
+                "value-key": "[ABSWARP]",
+                "command-line-flag": "--abs",
+                "description": "A boolean. Treat warp field as absolute: x' = w(x).",
+                "optional": true
+            },
+            {
+                "id": "datatype",
+                "name": "Datatype",
+                "type": "String",
+                "value-key": "[DATATYPE]",
+                "command-line-flag": "--datatype",
+                "command-line-flag-separator": "=",
+                "description": "'char' or 'short' or 'int' or 'float' or 'double'. Force output data type [char short int float double].",
+                "optional": true,
+                "value-choices": [
+                    "char",
+                    "short",
+                    "int",
+                    "float",
+                    "double"
+                ]
+            },
+            {
+                "id": "field_file",
+                "name": "Field file",
+                "type": "File",
+                "value-key": "[FIELD_FILE]",
+                "command-line-flag": "--warp",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. File containing warp field.",
+                "optional": true
+            },
+            {
+                "id": "in_file",
+                "name": "In file",
+                "type": "File",
+                "value-key": "[IN_FILE]",
+                "command-line-flag": "--in",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Image to be warped.",
+                "optional": false
+            },
+            {
+                "id": "interp",
+                "name": "Interp",
+                "type": "String",
+                "value-key": "[INTERP]",
+                "command-line-flag": "--interp",
+                "command-line-flag-separator": "=",
+                "description": "'nn' or 'trilinear' or 'sinc' or 'spline'. Interpolation method.",
+                "optional": true,
+                "value-choices": [
+                    "nn",
+                    "trilinear",
+                    "sinc",
+                    "spline"
+                ]
+            },
+            {
+                "id": "mask_file",
+                "name": "Mask file",
+                "type": "File",
+                "value-key": "[MASK_FILE]",
+                "command-line-flag": "--mask",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Filename for mask image (in reference space).",
+                "optional": true
+            },
+            {
+                "id": "out_file",
+                "name": "Out file",
+                "type": "File",
+                "value-key": "[OUT_FILE]",
+                "command-line-flag": "--out",
+                "command-line-flag-separator": "=",
+                "description": "A file name. Output filename.",
+                "optional": false
+            },
+            {
+                "id": "postmat",
+                "name": "Postmat",
+                "type": "File",
+                "value-key": "[POSTMAT]",
+                "command-line-flag": "--postmat",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Filename for post-transform (affine matrix).",
+                "optional": true
+            },
+            {
+                "id": "premat",
+                "name": "Premat",
+                "type": "File",
+                "value-key": "[PREMAT]",
+                "command-line-flag": "--premat",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Filename for pre-transform (affine matrix).",
+                "optional": true
+            },
+            {
+                "id": "ref_file",
+                "name": "Ref file",
+                "type": "File",
+                "value-key": "[REF_FILE]",
+                "command-line-flag": "--ref",
+                "command-line-flag-separator": "=",
+                "description": "An existing file name. Reference image.",
+                "optional": false
+            },
+            {
+                "id": "relwarp",
+                "name": "Relwarp",
+                "type": "Flag",
+                "value-key": "[RELWARP]",
+                "command-line-flag": "--rel",
+                "description": "A boolean. Treat warp field as relative: x' = x + w(x).",
+                "optional": true
+            },
+            {
+                "id": "superlevel",
+                "name": "Superlevel",
+                "type": "String",
+                "value-key": "[SUPERLEVEL]",
+                "command-line-flag": "--superlevel",
+                "command-line-flag-separator": "=",
+                "description": "'a' or an integer (int or long). Level of intermediary supersampling, a for 'automatic' or integer level. default = 2.",
+                "optional": true,
+                "value-choices": [
+                    "a"
+                ]
+            },
+            {
+                "id": "superlevel_int",
+                "name": "Superlevel",
+                "type": "Number",
+                "integer": true,
+                "value-key": "[SUPERLEVEL]",
+                "command-line-flag": "--superlevel",
+                "command-line-flag-separator": "=",
+                "description": "'a' or an integer (int or long). Level of intermediary supersampling, a for 'automatic' or integer level. default = 2.",
+                "optional": true
+            },
+            {
+                "id": "supersample",
+                "name": "Supersample",
+                "type": "Flag",
+                "value-key": "[SUPERSAMPLE]",
+                "command-line-flag": "--super",
+                "description": "A boolean. Intermediary supersampling of output, default is off.",
+                "optional": true
+            }
+        ],
+        "output-files": [
+            {
+                "name": "Out file",
+                "id": "out_file_outfile",
+                "path-template": "[OUT_FILE]",
+                "optional": true,
+                "description": "An existing file name. Warped output file."
+            }
+        ],
+        "groups": [
+            {
+                "id": "superlevel_group",
+                "name": "Superlevel group",
+                "members": [
+                    "superlevel",
+                    "superlevel_int"
+                ],
+                "mutually-exclusive": true
+            },
+            {
+                "id": "mutex_group",
+                "name": "Mutex group",
+                "members": [
+                    "relwarp",
+                    "abswarp"
+                ],
+                "mutually-exclusive": true
+            }
+        ],
+        "tool-version": "1.0.0",
+        "schema-version": "0.5",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker",
+            "index": "index.docker.io"
+        },
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ],
+            "source": "nipype-interface"
+        }
+    },
+    {
+        "tool-version": "mcin/docker-fsl:latest",
+        "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+        "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_stats.json",
+        "command-line": "fslstats [t] [INPUT_FILE] [l] [u] [r] [R] [e] [E] [v] [V] [m] [M] [s] [S] [w] [x] [X] [c] [C] [p] [P] [a] [n] [k] [d] [h] [H] > [OUTPUT_FILE]",
+        "container-image": {
+            "image": "mcin/docker-fsl:latest",
+            "type": "docker"
+        },
+        "description": "Descriptor of fslstats from the FSL toolbox. Computes various statistics on nifti images.",
+        "inputs": [
+            {
+                "id": "t",
+                "name": "t",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[t]",
+                "description": "give a separate output line for each 3D volume of a 4D timeseries",
+                "command-line-flag": "-t"
+            },
+            {
+                "id": "input_file",
+                "name": "Input file",
+                "optional": false,
+                "type": "File",
+                "value-key": "[INPUT_FILE]"
+            },
+            {
+                "id": "l",
+                "name": "lower threshold",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[l]",
+                "description": "set lower threshold",
+                "command-line-flag": "-l"
+            },
+            {
+                "id": "u",
+                "name": "upper threshold",
+                "optional": true,
+                "type": "Number",
+                "value-key": "[u]",
+                "description": "set upper threshold",
+                "command-line-flag": "-u"
+            },
+            {
+                "id": "r",
+                "name": "r",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[r]",
+                "description": " output <robust min intensity> <robust max intensity>",
+                "command-line-flag": "-r"
+            },
+            {
+                "id": "R",
+                "name": "R",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[R]",
+                "description": " output <min intensity> <max intensity>",
+                "command-line-flag": "-R"
+            },
+            {
+                "id": "e",
+                "name": "e",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[e]",
+                "description": " output mean entropy ; mean(-i*ln(i))",
+                "command-line-flag": "-e"
+            },
+            {
+                "id": "E",
+                "name": "E",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[E]",
+                "description": " output mean entropy (of nonzero voxels)",
+                "command-line-flag": "-E"
+            },
+            {
+                "id": "v",
+                "name": "v",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[v]",
+                "description": " output <voxels> <volume>",
+                "command-line-flag": "-v"
+            },
+            {
+                "id": "V",
+                "name": "V",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[V]",
+                "description": " output <voxels> <volume> (for nonzero voxels)",
+                "command-line-flag": "-V"
+            },
+            {
+                "id": "m",
+                "name": "m",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[m]",
+                "description": " output mean",
+                "command-line-flag": "-m"
+            },
+            {
+                "id": "M",
+                "name": "M",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[M]",
+                "description": " output mean (for nonzero voxels)",
+                "command-line-flag": "-M"
+            },
+            {
+                "id": "s",
+                "name": "s",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[s]",
+                "description": " output standard deviation",
+                "command-line-flag": "-s"
+            },
+            {
+                "id": "S",
+                "name": "S",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[S]",
+                "description": " output standard deviation (for nonzero voxels)",
+                "command-line-flag": "-S"
+            },
+            {
+                "id": "w",
+                "name": "w",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[w]",
+                "description": " output smallest ROI <xmin> <xsize> <ymin> <ysize> <zmin> <zsize> <tmin> <tsize> containing nonzero voxels",
+                "command-line-flag": "-w"
+            },
+            {
+                "id": "x",
+                "name": "x",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[x]",
+                "description": " output co-ordinates of maximum voxel",
+                "command-line-flag": "-x"
+            },
+            {
+                "id": "X",
+                "name": "X",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[X]",
+                "description": " output co-ordinates of minimum voxel",
+                "command-line-flag": "-X"
+            },
+            {
+                "id": "c",
+                "name": "c",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[c]",
+                "description": " output centre-of-gravity (cog) in mm coordinates",
+                "command-line-flag": "-c"
+            },
+            {
+                "id": "C",
+                "name": "C",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[C]",
+                "description": " output centre-of-gravity (cog) in voxel coordinates",
+                "command-line-flag": "-C"
+            },
+            {
+                "id": "p",
+                "name": "p",
+                "optional": true,
+                "type": "Number",
+                "integer": true,
+                "minimum": 0,
+                "maximum": 100,
+                "value-key": "[p]",
+                "description": " output nth percentile (n between 0 and 100)",
+                "command-line-flag": "-p"
+            },
+            {
+                "id": "P",
+                "name": "P",
+                "optional": true,
+                "type": "Number",
+                "integer": true,
+                "minimum": 0,
+                "maximum": 100,
+                "value-key": "[P]",
+                "description": " output nth percentile (for nonzero voxels)",
+                "command-line-flag": "-P"
+            },
+            {
+                "id": "a",
+                "name": "a",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[a]",
+                "description": " use absolute values of all image intensities",
+                "command-line-flag": "-a"
+            },
+            {
+                "id": "n",
+                "name": "n",
+                "optional": true,
+                "type": "Flag",
+                "value-key": "[n]",
+                "description": " treat NaN or Inf as zero for subsequent stats",
+                "command-line-flag": "-n"
+            },
+            {
+                "id": "k",
+                "name": "k",
+                "optional": true,
+                "type": "File",
+                "value-key": "[k]",
+                "description": " use the specified image (filename) for masking - overrides lower and upper thresholds",
+                "command-line-flag": "-k"
+            },
+            {
+                "id": "d",
+                "name": "d",
+                "optional": true,
+                "type": "File",
+                "value-key": "[d]",
+                "description": " take the difference between the base image and the image specified here",
+                "command-line-flag": "-d"
+            },
+            {
+                "id": "h",
+                "name": "h",
+                "optional": true,
+                "type": "Number",
+                "integer": true,
+                "value-key": "[h]",
+                "description": " output a histogram (for the thresholded/masked voxels only) with nbins",
+                "command-line-flag": "-h"
+            },
+            {
+                "id": "H",
+                "name": "H",
+                "optional": true,
+                "type": "Number",
+                "list": true,
+                "min-list-entries": 3,
+                "max-list-entries": 3,
+                "list-separator": " ",
+                "value-key": "[H]",
+                "description": " output a histogram (for the thresholded/masked voxels only) with nbins and histogram limits of min and max",
+                "command-line-flag": "-H"
+            }
+        ],
+        "groups": [
+            {
+                "one-is-required": true,
+                "id": "output_type",
+                "name": "output type",
+                "members": [
+                    "r",
+                    "R",
+                    "e",
+                    "E",
+                    "v",
+                    "V",
+                    "m",
+                    "M",
+                    "s",
+                    "S",
+                    "w",
+                    "x",
+                    "X",
+                    "c",
+                    "C",
+                    "p",
+                    "P",
+                    "h",
+                    "H"
+                ]
+            }
+        ],
+        "name": "fslstats",
+        "output-files": [
+            {
+                "id": "output",
+                "name": "Output",
+                "optional": false,
+                "path-template": "output.txt",
+                "value-key": "[OUTPUT_FILE]"
+            }
+        ],
+        "schema-version": "0.5",
+        "tags": {
+            "domain": [
+                "neuroinformatics",
+                "mri"
+            ],
+            "toolbox": "FSL"
+        }
+    },
+    {
+        "tool-version": "v2.7.1",
+        "tests": [
+            {
+                "invocation": {
+                    "outfmt": "5",
+                    "evalue": 0.001,
+                    "db": "uniprotmini.fasta",
+                    "query": "test1_query.fasta",
+                    "max_target_seqs": 10,
+                    "out": "blastp.out"
+                },
+                "name": "test1",
+                "assertions": {
+                    "output-files": [
+                        {
+                            "id": "output",
+                            "md5-reference": "049ea2f2b7e3fbe9a0c7d36a8e1c749c"
+                        }
+                    ],
+                    "exit-code": 0
+                }
+            }
+        ],
+        "description": "Protein-Protein BLAST 2.7.1+",
+        "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ cp -R [DB_DIR]/* . 2> /dev/null \\; /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/blastp [IMPORT_SEARCH_STRATEGY] [EXPORT_SEARCH_STRATEGY] [TASK] [DB] [DBSIZE] [GILIST] [SEQIDLIST] [NEGATIVE_GILIST] [NEGATIVE_SEQIDLIST] [ENTREZ_QUERY] [DB_SOFT_MASK] [DB_HARD_MASK] [SUBJECT] [SUBJECT_LOC] [QUERY] [OUT] [EVALUE] [WORD_SIZE] [GAPOPEN] [GAPEXTEND] [QCOV_HSP_PERC] [MAX_HSPS] [XDROP_UNGAP] [XDROP_GAP] [XDROP_GAP_FINAL] [SEARCHSP] [SUM_STATS] [SEG] [SOFT_MASKING] [MATRIX] [THRESHOLD] [CULLING_LIMIT] [BEST_HIT_OVERHANG] [BEST_HIT_SCORE_EDGE] [WINDOW_SIZE] [fLCASE_MASKING] [QUERY_LOC] [fPARSE_DEFLINES] [OUTFMT] [fSHOW_GIS] [NUM_DESCRIPTIONS] [NUM_ALIGNMENTS] [LINE_LENGTH] [fHTML] [MAX_TARGET_SEQS] [NUM_THREADS] [fUNGAPPED] [fREMOTE] [COMP_BASED_STATS] [fUSE_SW_TBACK]",
+        "author": "Altschul et al.",
+        "tags": {
+            "domain": [
+                "bioinformatics",
+                "blast"
+            ]
+        },
+        "container-image": {
+            "index": "docker://",
+            "image": "c3genomics/genpipes",
+            "type": "singularity"
+        },
+        "inputs": [
+            {
+                "command-line-flag": "-db",
+                "description": "BLAST database name",
+                "disables-inputs": [
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[DB]",
+                "type": "String",
+                "id": "db",
+                "name": "BLAST database name"
+            },
+            {
+                "description": "directory containing BLAST Archive format in ASN.1 (i.e.: output format 11) and all needed db files",
+                "default-value": ".",
+                "value-key": "[DB_DIR]",
+                "optional": true,
+                "requires-inputs": [
+                    "db"
+                ],
+                "type": "File",
+                "id": "archive_dir",
+                "name": "Blast Database Directory"
+            },
+            {
+                "command-line-flag": "-query_loc",
+                "description": "Location on the query sequence in 1-based offsets (Format: start-stop)",
+                "value-key": "[QUERY_LOC]",
+                "optional": true,
+                "type": "String",
+                "id": "query_loc",
+                "name": "query location"
+            },
+            {
+                "command-line-flag": "-subject_loc",
+                "description": "Location on the query sequence in 1-based offsets (Format: start-stop)",
+                "disables-inputs": [
+                    "db",
+                    "gilist",
+                    "seqidlist",
+                    "negative_gilist",
+                    "negative_seqidlist",
+                    "db_soft_mask",
+                    "db_hard_mask"
+                ],
+                "optional": true,
+                "value-key": "[SUBJECT_LOC]",
+                "type": "String",
+                "id": "subject_loc",
+                "name": "Subject Sequence Location"
+            },
+            {
+                "command-line-flag": "-task",
+                "description": "Task to execute",
+                "value-key": "[TASK]",
+                "optional": true,
+                "value-choices": [
+                    "blastp",
+                    "blastp-fast",
+                    "blastp-short"
+                ],
+                "type": "String",
+                "id": "task",
+                "name": "Task Name"
+            },
+            {
+                "command-line-flag": "-matrix",
+                "description": "Scoring matrix name (normally BLOSUM62)",
+                "value-key": "[MATRIX]",
+                "optional": true,
+                "type": "String",
+                "id": "matrix",
+                "name": "Scoring matrix name"
+            },
+            {
+                "command-line-flag": "-comp_based_stats",
+                "description": "Use composition-based statistics:\n       D or d: default (equivalent to 2 )\n       0 or F or f: No composition-based statistics\n       1: Composition-based statistics as in NAR 29:2994-3005, 2001\n       2 or T or t : Composition-based score adjustment as in Bioinformatics\n   21:902-911, 2005, conditioned on sequence properties\n       3: Composition-based score adjustment as in Bioinformatics 21:902-911,\n 2005, unconditionally\nDefault = `2'",
+                "value-key": "[COMP_BASED_STATS]",
+                "optional": true,
+                "value-choices": [
+                    "D",
+                    "d",
+                    "0",
+                    "F",
+                    "f",
+                    "1",
+                    "2",
+                    "T",
+                    "t",
+                    "3"
+                ],
+                "type": "String",
+                "id": "comp_based_stats",
+                "name": "Composition-based statistics mode"
+            },
+            {
+                "command-line-flag": "-seg",
+                "description": "Filter query sequence with SEG",
+                "value-key": "[SEG]",
+                "optional": true,
+                "value-choices": [
+                    "yes",
+                    "window locut hicut",
+                    "no"
+                ],
+                "type": "String",
+                "id": "seg",
+                "name": "SEG Options"
+            },
+            {
+                "command-line-flag": "-gilist",
+                "description": "Restrict search of database to list of GI's",
+                "disables-inputs": [
+                    "negative_gilist",
+                    "seqidlist",
+                    "negative_seqidlist",
+                    "remote",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[GILIST]",
+                "type": "String",
+                "id": "gilist",
+                "name": "Restrictive GI List"
+            },
+            {
+                "command-line-flag": "-seqidlist",
+                "description": "Restrict search of database to list of SeqId's",
+                "disables-inputs": [
+                    "gilist",
+                    "negative_gilist",
+                    "negative_seqidlist",
+                    "remote",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[SEQIDLIST]",
+                "type": "String",
+                "id": "seqidlist",
+                "name": "Restrictive Sequence Id List"
+            },
+            {
+                "command-line-flag": "-negative_gilist",
+                "description": "Restrict search of database to everything except the listed GIs",
+                "disables-inputs": [
+                    "gilist",
+                    "seqidlist",
+                    "remote",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[NEGATIVE_GILIST]",
+                "type": "String",
+                "id": "negative_gilist",
+                "name": "Exclusive GI List"
+            },
+            {
+                "command-line-flag": "-negative_seqidlist",
+                "description": "Restrict search of database to everything except the listed SeqIDs",
+                "disables-inputs": [
+                    "gilist",
+                    "seqidlist",
+                    "remote",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[NEGATIVE_SEQIDLIST]",
+                "type": "String",
+                "id": "negative_seqidlist",
+                "name": "Exclusive Sequence Id List"
+            },
+            {
+                "command-line-flag": "-entrez_query",
+                "description": "Restrict search with the given Entrez query",
+                "value-key": "[ENTREZ_QUERY]",
+                "optional": true,
+                "requires-inputs": [
+                    "remote"
+                ],
+                "type": "String",
+                "id": "entrez_query",
+                "name": "Exclusive Sequence Id List"
+            },
+            {
+                "command-line-flag": "-db_soft_mask",
+                "description": "Filtering algorithm ID to apply to the BLAST database as soft masking",
+                "disables-inputs": [
+                    "db_hard_mask",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[DB_SOFT_MASK]",
+                "type": "String",
+                "id": "db_soft_mask",
+                "name": "Soft Mask ID"
+            },
+            {
+                "command-line-flag": "-db_hard_mask",
+                "description": "Filtering algorithm ID to apply to the BLAST database as hard masking",
+                "disables-inputs": [
+                    "db_soft_mask",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[DB_HARD_MASK]",
+                "type": "String",
+                "id": "db_hard_mask",
+                "name": "Hard Mask ID"
+            },
+            {
+                "command-line-flag": "-lcase_masking",
+                "description": "Use lower case filtering in query and subject sequence(s)?",
+                "value-key": "[fLCASE_MASKING]",
+                "optional": true,
+                "type": "Flag",
+                "id": "lcase_masking",
+                "name": "Lowercase Filtering"
+            },
+            {
+                "command-line-flag": "-ungapped",
+                "description": "Perform ungapped alignment only?",
+                "value-key": "[fUNGAPPED]",
+                "optional": true,
+                "type": "Flag",
+                "id": "ungapped",
+                "name": "Ungapped Alignment"
+            },
+            {
+                "command-line-flag": "-parse_deflines",
+                "description": "Should the query and subject defline(s) be parsed?",
+                "value-key": "[fPARSE_DEFLINES]",
+                "optional": true,
+                "type": "Flag",
+                "id": "parse_deflines",
+                "name": "Parse Deflines"
+            },
+            {
+                "command-line-flag": "-remote",
+                "description": "Execute search remotely?",
+                "disables-inputs": [
+                    "gilist",
+                    "seqidlist",
+                    "negative_gilist",
+                    "negative_seqidlist",
+                    "subject_loc",
+                    "num_threads"
+                ],
+                "optional": true,
+                "value-key": "[fREMOTE]",
+                "type": "Flag",
+                "id": "remote",
+                "name": "Remote Search"
+            },
+            {
+                "command-line-flag": "-use_sw_tback",
+                "description": "Compute locally optimal Smith-Waterman alignments?",
+                "value-key": "[fUSE_SW_TBACK]",
+                "optional": true,
+                "type": "Flag",
+                "id": "use_sw_tback",
+                "name": "Locally Optimal Smith-Waterman Alignments"
+            },
+            {
+                "command-line-flag": "-soft_masking",
+                "description": "Apply filtering locations as soft masks",
+                "value-key": "[SOFT_MASKING]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "soft_masking",
+                "name": "Filtering Locations As Soft Masks"
+            },
+            {
+                "command-line-flag": "-sum_stats",
+                "description": "Use sum statistics",
+                "value-key": "[SUM_STATS]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "sum_stats",
+                "name": "Sum Statistics"
+            },
+            {
+                "command-line-flag": "-word_size",
+                "description": "Word size for wordfinder algorithm",
+                "value-key": "[WORD_SIZE]",
+                "optional": true,
+                "minimum": 2,
+                "integer": true,
+                "type": "Number",
+                "id": "word_size",
+                "name": "Word Size"
+            },
+            {
+                "command-line-flag": "-gapopen",
+                "description": "Cost to open a gap",
+                "value-key": "[GAPOPEN]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "gapopen",
+                "name": "Gap Open Penalty"
+            },
+            {
+                "command-line-flag": "-gapextend",
+                "description": "Cost to extend a gap",
+                "value-key": "[GAPEXTEND]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "gapextend",
+                "name": "Gap Extend Penalty"
+            },
+            {
+                "command-line-flag": "-max_hsps",
+                "description": "Set maximum number of HSPs per subject sequence to save for each query",
+                "value-key": "[MAX_HSPS]",
+                "optional": true,
+                "minimum": 1,
+                "integer": true,
+                "type": "Number",
+                "id": "max_hsps",
+                "name": "Max HSPs Per Subject"
+            },
+            {
+                "command-line-flag": "-culling_limit",
+                "description": "   If the query range of a hit is enveloped by that of at least this many\n   higher-scoring hits, delete the hit",
+                "value-key": "[CULLING_LIMIT]",
+                "optional": true,
+                "disables-inputs": [
+                    "best_hit_overhang",
+                    "best_hit_score_edge"
+                ],
+                "minimum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "culling_limit",
+                "name": "Higher Scoring Hit Culling Limit"
+            },
+            {
+                "command-line-flag": "-max_target_seqs",
+                "description": "   Maximum number of aligned sequences to keep\n   Not applicable for outfmt <= 4\n   Default = `500'",
+                "value-key": "[MAX_TARGET_SEQS]",
+                "optional": true,
+                "disables-inputs": [
+                    "num_descriptions",
+                    "num_alignments"
+                ],
+                "minimum": 1,
+                "integer": true,
+                "type": "Number",
+                "id": "max_target_seqs",
+                "name": "Maximum Target Sequence"
+            },
+            {
+                "command-line-flag": "-dbsize",
+                "description": "Effective length of the database",
+                "value-key": "[DBSIZE]",
+                "optional": true,
+                "maximum": 255,
+                "integer": true,
+                "type": "Number",
+                "id": "dbsize",
+                "name": "Database Size"
+            },
+            {
+                "command-line-flag": "-searchsp",
+                "description": "Effective length of the search space",
+                "value-key": "[SEARCHSP]",
+                "optional": true,
+                "maximum": 255,
+                "minimum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "searchsp",
+                "name": "Search Space Length"
+            },
+            {
+                "command-line-flag": "-window_size",
+                "description": "Multiple hits window size, use 0 to specify 1-hit algorithm",
+                "value-key": "[WINDOW_SIZE]",
+                "optional": true,
+                "minimum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "window_size",
+                "name": "Multiple Hits Window Size"
+            },
+            {
+                "command-line-flag": "-num_threads",
+                "description": "   Number of threads (CPUs) to use in the BLAST search\n   Default = `1'",
+                "value-key": "[NUM_THREADS]",
+                "optional": true,
+                "maximum": 12,
+                "disables-inputs": [
+                    "remote"
+                ],
+                "minimum": 1,
+                "integer": true,
+                "type": "Number",
+                "id": "num_threads",
+                "name": "Maximum Target Sequence"
+            },
+            {
+                "command-line-flag": "-evalue",
+                "description": "  Expectation value (E) threshold for saving hits\n  Default = `10'",
+                "value-key": "[EVALUE]",
+                "optional": true,
+                "type": "Number",
+                "id": "evalue",
+                "name": "Expectation Value"
+            },
+            {
+                "command-line-flag": "-threshold",
+                "description": "Minimum word score such that the word is added to the BLAST lookup table",
+                "value-key": "[THRESHOLD]",
+                "optional": true,
+                "minimum": 0,
+                "type": "Number",
+                "id": "threshold",
+                "name": "Minimum word score threshold"
+            },
+            {
+                "command-line-flag": "-qcov_hsp_perc",
+                "description": "Percent query coverage per hsp",
+                "value-key": "[QCOV_HSP_PERC]",
+                "optional": true,
+                "maximum": 100,
+                "minimum": 0,
+                "type": "Number",
+                "id": "qcov_hsp_perc",
+                "name": "Percentage Query Coverage"
+            },
+            {
+                "command-line-flag": "-best_hit_overhang",
+                "description": "Best Hit algorithm overhang value (recommended value: 0.1)",
+                "value-key": "[BEST_HIT_OVERHANG]",
+                "optional": true,
+                "exclusive-maximum": true,
+                "maximum": 0.5,
+                "disables-inputs": [
+                    "culling_limit"
+                ],
+                "minimum": 0,
+                "exclusive-minimum": true,
+                "type": "Number",
+                "id": "best_hit_overhang",
+                "name": "Best Hit Algorithm Overhang"
+            },
+            {
+                "command-line-flag": "-best_hit_score_edge",
+                "description": "Best Hit algorithm score edge value (recommended value: 0.1)",
+                "value-key": "[BEST_HIT_SCORE_EDGE]",
+                "optional": true,
+                "exclusive-maximum": true,
+                "maximum": 0.5,
+                "disables-inputs": [
+                    "culling_limit"
+                ],
+                "minimum": 0,
+                "exclusive-minimum": true,
+                "type": "Number",
+                "id": "best_hit_score_edge",
+                "name": "Best Hit Algorithm Score Edge Value"
+            },
+            {
+                "command-line-flag": "-xdrop_ungap",
+                "description": "X-dropoff value (in bits) for ungapped extensions",
+                "value-key": "[XDROP_UNGAP]",
+                "optional": true,
+                "type": "Number",
+                "id": "xdrop_ungap",
+                "name": "Ungapped Extensions X-dropoff Value"
+            },
+            {
+                "command-line-flag": "-xdrop_gap",
+                "description": "X-dropoff value (in bits) for preliminary gapped extensions",
+                "value-key": "[XDROP_GAP]",
+                "optional": true,
+                "type": "Number",
+                "id": "xdrop_gap",
+                "name": "Preiliminary Gapped Extensions X-dropoff Value"
+            },
+            {
+                "command-line-flag": "-xdrop_gap_final",
+                "description": "X-dropoff value (in bits) for final gapped alignment",
+                "value-key": "[XDROP_GAP_FINAL]",
+                "optional": true,
+                "type": "Number",
+                "id": "xdrop_gap_final",
+                "name": "Final Gapped Extensions X-dropoff Value"
+            },
+            {
+                "command-line-flag": "-query",
+                "description": "Input file name",
+                "value-key": "[QUERY]",
+                "optional": false,
+                "type": "File",
+                "id": "query",
+                "name": "Query"
+            },
+            {
+                "command-line-flag": "-subject",
+                "description": "Subject sequence(s) to search",
+                "value-key": "[SUBJECT]",
+                "optional": true,
+                "disables-inputs": [
+                    "db",
+                    "gilist",
+                    "seqidlist",
+                    "negative_gilist",
+                    "negative_seqidlist",
+                    "db_soft_mask",
+                    "db_hard_mask"
+                ],
+                "type": "File",
+                "id": "subject",
+                "name": "Subject"
+            },
+            {
+                "command-line-flag": "-import_search_strategy",
+                "description": "Search strategy to use",
+                "value-key": "[IMPORT_SEARCH_STRATEGY]",
+                "optional": true,
+                "disables-inputs": [
+                    "export_search_strategy"
+                ],
+                "type": "File",
+                "id": "import_search_strategy",
+                "name": "Search Strategy File"
+            },
+            {
+                "command-line-flag": "-export_search_strategy",
+                "description": "File name to record the search strategy used",
+                "value-key": "[EXPORT_SEARCH_STRATEGY]",
+                "optional": true,
+                "disables-inputs": [
+                    "import_search_strategy"
+                ],
+                "type": "File",
+                "id": "export_search_strategy",
+                "name": "Search Strategy Record Filename"
+            },
+            {
+                "command-line-flag": "-show_gis",
+                "description": "Show NCBI GIs in deflines?",
+                "value-key": "[fSHOW_GIS]",
+                "optional": true,
+                "type": "Flag",
+                "id": "show_gis",
+                "name": "Show NCBI GIs"
+            },
+            {
+                "command-line-flag": "-html",
+                "description": "Produce HTML Output",
+                "value-key": "[fHTML]",
+                "optional": true,
+                "type": "Flag",
+                "id": "html",
+                "name": "Show HTML"
+            },
+            {
+                "command-line-flag": "-outfmt",
+                "description": "   alignment view options:\n     0 = Pairwise,\n     1 = Query-anchored showing identities,\n     2 = Query-anchored no identities,\n     3 = Flat query-anchored showing identities,\n     4 = Flat query-anchored no identities,\n     5 = BLAST XML,\n     6 = Tabular,\n     7 = Tabular with comment lines,\n     8 = Seqalign (Text ASN.1),\n     9 = Seqalign (Binary ASN.1),\n    10 = Comma-separated values,\n    11 = BLAST archive (ASN.1),\n    12 = Seqalign (JSON),\n    13 = Multiple-file BLAST JSON,\n    14 = Multiple-file BLAST XML2,\n    15 = Single-file BLAST JSON,\n    16 = Single-file BLAST XML2,\n    17 = Sequence Alignment/Map (SAM),\n    18 = Organism Report\n\n   Options 6, 7, 10 and 17 can be additionally configured to produce\n   a custom format specified by space delimited format specifiers.\n   The supported format specifiers for options 6, 7 and 10 are:\n            qseqid means Query Seq-id\n               qgi means Query GI\n              qacc means Query accesion\n           qaccver means Query accesion.version\n              qlen means Query sequence length\n            sseqid means Subject Seq-id\n         sallseqid means All subject Seq-id(s), separated by a ';'\n               sgi means Subject GI\n            sallgi means All subject GIs\n              sacc means Subject accession\n           saccver means Subject accession.version\n           sallacc means All subject accessions\n              slen means Subject sequence length\n            qstart means Start of alignment in query\n              qend means End of alignment in query\n            sstart means Start of alignment in subject\n              send means End of alignment in subject\n              qseq means Aligned part of query sequence\n              sseq means Aligned part of subject sequence\n            evalue means Expect value\n          bitscore means Bit score\n             score means Raw score\n            length means Alignment length\n            pident means Percentage of identical matches\n            nident means Number of identical matches\n          mismatch means Number of mismatches\n          positive means Number of positive-scoring matches\n           gapopen means Number of gap openings\n              gaps means Total number of gaps\n              ppos means Percentage of positive-scoring matches\n            frames means Query and subject frames separated by a '/'\n            qframe means Query frame\n            sframe means Subject frame\n              btop means Blast traceback operations (BTOP)\n            staxid means Subject Taxonomy ID\n          ssciname means Subject Scientific Name\n          scomname means Subject Common Name\n        sblastname means Subject Blast Name\n         sskingdom means Subject Super Kingdom\n           staxids means unique Subject Taxonomy ID(s), separated by a ';'\n                         (in numerical order)\n         sscinames means unique Subject Scientific Name(s), separated by a ';'\n         scomnames means unique Subject Common Name(s), separated by a ';'\n        sblastnames means unique Subject Blast Name(s), separated by a ';'\n                         (in alphabetical order)\n        sskingdoms means unique Subject Super Kingdom(s), separated by a ';'\n                         (in alphabetical order)\n            stitle means Subject Title\n        salltitles means All Subject Title(s), separated by a '<>'\n           sstrand means Subject Strand\n             qcovs means Query Coverage Per Subject\n           qcovhsp means Query Coverage Per HSP\n            qcovus means Query Coverage Per Unique Subject (blastn only)\n   When not provided, the default value is:\n   'qaccver saccver pident length mismatch gapopen qstart qend sstart send\n   evalue bitscore', which is equivalent to the keyword 'std'\n   The supported format specifier for option 17 is:\n                SQ means Include Sequence Data\n                SR means Subject as Reference Seq\n  Default = `0'",
+                "value-key": "[OUTFMT]",
+                "optional": true,
+                "type": "String",
+                "id": "outfmt",
+                "name": "Alignment View Options"
+            },
+            {
+                "command-line-flag": "-num_descriptions",
+                "description": "   Number of database sequences to show one-line descriptions for\n   Not applicable for outfmt > 4\n   Default = `500'",
+                "value-key": "[NUM_DESCRIPTIONS]",
+                "optional": true,
+                "disables-inputs": [
+                    "max_target_seqs"
+                ],
+                "minimum": 0,
+                "type": "Number",
+                "id": "num_descriptions",
+                "name": "Number of Sequence Descriptions to Show"
+            },
+            {
+                "command-line-flag": "-num_alignments",
+                "description": "   Number of database sequences to show alignments for\n   Default = `250'",
+                "value-key": "[NUM_ALIGNMENTS]",
+                "optional": true,
+                "disables-inputs": [
+                    "max_target_seqs"
+                ],
+                "minimum": 0,
+                "type": "Number",
+                "id": "num_alignments",
+                "name": "Number of Sequence Alignments to Show"
+            },
+            {
+                "command-line-flag": "-line_length",
+                "description": "   Line length for formatting alignments\n   Not applicable for outfmt > 4\n   Default = `60'",
+                "value-key": "[LINE_LENGTH]",
+                "optional": true,
+                "minimum": 1,
+                "type": "Number",
+                "id": "line_length",
+                "name": "Line Length"
+            },
+            {
+                "command-line-flag": "-out",
+                "description": "   Output file name",
+                "value-key": "[OUT]",
+                "optional": true,
+                "type": "String",
+                "id": "out",
+                "name": "Output file name"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[OUT]",
+                "optional": false,
+                "id": "output",
+                "name": "Output File"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 60,
+            "ram": 1,
+            "cpu-cores": 1
+        },
+        "name": "blastp"
+    },
+    {
+        "tool-version": "v2.7.1",
+        "tests": [
+            {
+                "invocation": {
+                    "query": "test1_query.fasta",
+                    "outfmt": "5",
+                    "db": "sample",
+                    "max_target_seqs": 5,
+                    "out": "blastn.out"
+                },
+                "name": "test1",
+                "assertions": {
+                    "output-files": [
+                        {
+                            "id": "output",
+                            "md5-reference": "eb917a2e0723ee9cca9d86db85e83b69"
+                        }
+                    ],
+                    "exit-code": 0
+                }
+            }
+        ],
+        "description": "Nucleotide-Nucleotide BLAST 2.7.1+",
+        "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ cp -R [DB_DIR]/* . 2> /dev/null \\;  /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/blastn [IMPORT_SEARCH_STRATEGY] [EXPORT_SEARCH_STRATEGY] [TASK] [DB] [DBSIZE] [GILIST] [SEQIDLIST] [NEGATIVE_GILIST] [NEGATIVE_SEQIDLIST] [ENTREZ_QUERY] [DB_SOFT_MASK] [DB_HARD_MASK] [SUBJECT] [SUBJECT_LOC] [QUERY] [OUT] [EVALUE] [WORD_SIZE] [GAPOPEN] [GAPEXTEND] [PERC_IDENTITY] [QCOV_HSP_PERC] [MAX_HSPS] [XDROP_UNGAP] [XDROP_GAP] [XDROP_GAP_FINAL] [SEARCHSP] [SUM_STATS] [PENALTY] [REWARD] [fNO_GREEDY] [MIN_RAW_GAPPED_SCORE] [TEMPLATE_TYPE] [TEMPLATE_LENGTH] [DUST] [FILTERING_DB] [WINDOW_MASKER_TAXID] [WINDOW_MASKER_DB] [SOFT_MASKING] [fUNGAPPED] [CULLING_LIMIT] [BEST_HIT_OVERHANG] [BEST_HIT_SCORE_EDGE] [WINDOW_SIZE] [OFF_DIAGONAL_RANGE] [USE_INDEX] [INDEX_NAME] [fLCASE_MASKING] [QUERY_LOC] [STRAND] [fPARSE_DEFLINES] [OUTFMT] [fSHOW_GIS] [NUM_DESCRIPTIONS] [NUM_ALIGNMENTS] [LINE_LENGTH] [fHTML] [MAX_TARGET_SEQS] [NUM_THREADS] [fREMOTE]",
+        "author": "Altschul et al.",
+        "tags": {
+            "domain": [
+                "bioinformatics",
+                "blast"
+            ]
+        },
+        "container-image": {
+            "index": "docker://",
+            "image": "c3genomics/genpipes",
+            "type": "singularity"
+        },
+        "inputs": [
+            {
+                "command-line-flag": "-db",
+                "description": "BLAST database name",
+                "disables-inputs": [
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[DB]",
+                "type": "String",
+                "id": "db",
+                "name": "BLAST database name"
+            },
+            {
+                "description": "directory containing BLAST Archive format in ASN.1 (i.e.: output format 11) and all needed db files",
+                "default-value": ".",
+                "value-key": "[DB_DIR]",
+                "optional": true,
+                "requires-inputs": [
+                    "db"
+                ],
+                "type": "File",
+                "id": "archive_dir",
+                "name": "Blast Database Directory"
+            },
+            {
+                "command-line-flag": "-query_loc",
+                "description": "Location on the query sequence in 1-based offsets (Format: start-stop)",
+                "value-key": "[QUERY_LOC]",
+                "optional": true,
+                "type": "String",
+                "id": "query_loc",
+                "name": "query location"
+            },
+            {
+                "command-line-flag": "-strand",
+                "description": "   Query strand(s) to search against database/subject\n   Default = `both'",
+                "value-key": "[STRAND]",
+                "optional": true,
+                "value-choices": [
+                    "both",
+                    "minus",
+                    "plus"
+                ],
+                "type": "String",
+                "id": "strand",
+                "name": "Query Strand to Search"
+            },
+            {
+                "command-line-flag": "-subject_loc",
+                "description": "Location on the query sequence in 1-based offsets (Format: start-stop)",
+                "disables-inputs": [
+                    "db",
+                    "gilist",
+                    "seqidlist",
+                    "negative_gilist",
+                    "negative_seqidlist",
+                    "db_soft_mask",
+                    "db_hard_mask"
+                ],
+                "optional": true,
+                "value-key": "[SUBJECT_LOC]",
+                "type": "String",
+                "id": "subject_loc",
+                "name": "Subject Sequence Location"
+            },
+            {
+                "command-line-flag": "-task",
+                "description": "Task to execute",
+                "value-key": "[TASK]",
+                "optional": true,
+                "value-choices": [
+                    "blastn",
+                    "blastn-short",
+                    "dc-megablast",
+                    "megablast",
+                    "rmblastn"
+                ],
+                "type": "String",
+                "id": "task",
+                "name": "Task Name"
+            },
+            {
+                "command-line-flag": "-dust",
+                "description": "Filter query sequence with DUST\n  (Format: 'yes', 'level window linker', or   'no' to disable)\n   Default = '20 64 1')",
+                "value-key": "[DUST]",
+                "optional": true,
+                "type": "String",
+                "id": "dust",
+                "name": "DUST Options"
+            },
+            {
+                "command-line-flag": "-gilist",
+                "description": "Restrict search of database to list of GI's",
+                "disables-inputs": [
+                    "negative_gilist",
+                    "seqidlist",
+                    "negative_seqidlist",
+                    "remote",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[GILIST]",
+                "type": "String",
+                "id": "gilist",
+                "name": "Restrictive GI List"
+            },
+            {
+                "command-line-flag": "-seqidlist",
+                "description": "Restrict search of database to list of SeqId's",
+                "disables-inputs": [
+                    "gilist",
+                    "negative_gilist",
+                    "negative_seqidlist",
+                    "remote",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[SEQIDLIST]",
+                "type": "String",
+                "id": "seqidlist",
+                "name": "Restrictive Sequence Id List"
+            },
+            {
+                "command-line-flag": "-negative_gilist",
+                "description": "Restrict search of database to everything except the listed GIs",
+                "disables-inputs": [
+                    "gilist",
+                    "seqidlist",
+                    "remote",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[NEGATIVE_GILIST]",
+                "type": "String",
+                "id": "negative_gilist",
+                "name": "Exclusive GI List"
+            },
+            {
+                "command-line-flag": "-negative_seqidlist",
+                "description": "Restrict search of database to everything except the listed SeqIDs",
+                "disables-inputs": [
+                    "gilist",
+                    "seqidlist",
+                    "remote",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[NEGATIVE_SEQIDLIST]",
+                "type": "String",
+                "id": "negative_seqidlist",
+                "name": "Exclusive Sequence Id List"
+            },
+            {
+                "command-line-flag": "-entrez_query",
+                "description": "Restrict search with the given Entrez query",
+                "value-key": "[ENTREZ_QUERY]",
+                "optional": true,
+                "requires-inputs": [
+                    "remote"
+                ],
+                "type": "String",
+                "id": "entrez_query",
+                "name": "Exclusive Sequence Id List"
+            },
+            {
+                "command-line-flag": "-db_soft_mask",
+                "description": "Filtering algorithm ID to apply to the BLAST database as soft masking",
+                "disables-inputs": [
+                    "db_hard_mask",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[DB_SOFT_MASK]",
+                "type": "String",
+                "id": "db_soft_mask",
+                "name": "Soft Mask ID"
+            },
+            {
+                "command-line-flag": "-db_hard_mask",
+                "description": "Filtering algorithm ID to apply to the BLAST database as hard masking",
+                "disables-inputs": [
+                    "db_soft_mask",
+                    "subject",
+                    "subject_loc"
+                ],
+                "optional": true,
+                "value-key": "[DB_HARD_MASK]",
+                "type": "String",
+                "id": "db_hard_mask",
+                "name": "Hard Mask ID"
+            },
+            {
+                "command-line-flag": "-index_name",
+                "description": "MegaBLAST database index name (deprecated; use only for old style indices)",
+                "value-key": "[INDEX_NAME]",
+                "optional": true,
+                "type": "String",
+                "id": "index_name",
+                "name": "MegaBLAST database index name"
+            },
+            {
+                "command-line-flag": "-filtering_db",
+                "description": "BLAST database containing filtering elements (i.e.: repeats)",
+                "value-key": "[FILTERING_DB]",
+                "optional": true,
+                "type": "String",
+                "id": "filtering_db",
+                "name": "BLAST filtering database"
+            },
+            {
+                "command-line-flag": "-window_masker_db",
+                "description": "Enable WindowMasker filtering using this repeats database.",
+                "value-key": "[WINDOW_MASKER_DB]",
+                "optional": true,
+                "type": "String",
+                "id": "window_masker_db",
+                "name": "Window Masker DB"
+            },
+            {
+                "command-line-flag": "-template_type",
+                "description": "Discontiguous MegaBLAST template type",
+                "value-key": "[TEMPLATE_TYPE]",
+                "optional": true,
+                "requires-inputs": [
+                    "template_length"
+                ],
+                "value-choices": [
+                    "coding",
+                    "coding_and_optimal",
+                    "optimal"
+                ],
+                "type": "String",
+                "id": "template_type",
+                "name": "Discontiguous MegaBLAST template type"
+            },
+            {
+                "command-line-flag": "-lcase_masking",
+                "description": "Use lower case filtering in query and subject sequence(s)?",
+                "value-key": "[fLCASE_MASKING]",
+                "optional": true,
+                "type": "Flag",
+                "id": "lcase_masking",
+                "name": "Lowercase Filtering"
+            },
+            {
+                "command-line-flag": "-ungapped",
+                "description": "Perform ungapped alignment only?",
+                "value-key": "[fUNGAPPED]",
+                "optional": true,
+                "type": "Flag",
+                "id": "ungapped",
+                "name": "Ungapped Alignment"
+            },
+            {
+                "command-line-flag": "-parse_deflines",
+                "description": "Should the query and subject defline(s) be parsed?",
+                "value-key": "[fPARSE_DEFLINES]",
+                "optional": true,
+                "type": "Flag",
+                "id": "parse_deflines",
+                "name": "Parse Deflines"
+            },
+            {
+                "command-line-flag": "-remote",
+                "description": "Execute search remotely?",
+                "disables-inputs": [
+                    "gilist",
+                    "seqidlist",
+                    "negative_gilist",
+                    "negative_seqidlist",
+                    "subject_loc",
+                    "num_threads"
+                ],
+                "optional": true,
+                "value-key": "[fREMOTE]",
+                "type": "Flag",
+                "id": "remote",
+                "name": "Remote Search"
+            },
+            {
+                "command-line-flag": "-no_greedy",
+                "description": "Use non-greedy dynamic programming extension",
+                "value-key": "[fNO_GREEDY]",
+                "optional": true,
+                "type": "Flag",
+                "id": "no_greedy",
+                "name": "Non-Greedy Dynamic Programming Extension"
+            },
+            {
+                "command-line-flag": "-use_index",
+                "description": "Use MegaBLAST database index\n  Default 'false'",
+                "value-key": "[USE_INDEX]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "use_index",
+                "name": "MegaBLAST Database Index Usage"
+            },
+            {
+                "command-line-flag": "-soft_masking",
+                "description": "Apply filtering locations as soft masks\n  Default 'true'",
+                "value-key": "[SOFT_MASKING]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "soft_masking",
+                "name": "Filtering Locations As Soft Masks"
+            },
+            {
+                "command-line-flag": "-sum_stats",
+                "description": "Use sum statistics",
+                "value-key": "[SUM_STATS]",
+                "optional": true,
+                "value-choices": [
+                    "true",
+                    "false"
+                ],
+                "type": "String",
+                "id": "sum_stats",
+                "name": "Sum Statistics"
+            },
+            {
+                "command-line-flag": "-word_size",
+                "description": "Word size for wordfinder algorithm (length of best perfect match)",
+                "value-key": "[WORD_SIZE]",
+                "optional": true,
+                "minimum": 4,
+                "integer": true,
+                "type": "Number",
+                "id": "word_size",
+                "name": "Word Size"
+            },
+            {
+                "command-line-flag": "-gapopen",
+                "description": "Cost to open a gap",
+                "value-key": "[GAPOPEN]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "gapopen",
+                "name": "Gap Open Penalty"
+            },
+            {
+                "command-line-flag": "-gapextend",
+                "description": "Cost to extend a gap",
+                "value-key": "[GAPEXTEND]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "gapextend",
+                "name": "Gap Extend Penalty"
+            },
+            {
+                "command-line-flag": "-max_hsps",
+                "description": "Set maximum number of HSPs per subject sequence to save for each query",
+                "value-key": "[MAX_HSPS]",
+                "optional": true,
+                "minimum": 1,
+                "integer": true,
+                "type": "Number",
+                "id": "max_hsps",
+                "name": "Max HSPs Per Subject"
+            },
+            {
+                "command-line-flag": "-culling_limit",
+                "description": "   If the query range of a hit is enveloped by that of at least this many\n   higher-scoring hits, delete the hit",
+                "value-key": "[CULLING_LIMIT]",
+                "optional": true,
+                "disables-inputs": [
+                    "best_hit_overhang",
+                    "best_hit_score_edge"
+                ],
+                "minimum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "culling_limit",
+                "name": "Higher Scoring Hit Culling Limit"
+            },
+            {
+                "command-line-flag": "-max_target_seqs",
+                "description": "   Maximum number of aligned sequences to keep\n   Not applicable for outfmt <= 4\n   Default = `500'",
+                "value-key": "[MAX_TARGET_SEQS]",
+                "optional": true,
+                "disables-inputs": [
+                    "num_descriptions",
+                    "num_alignments"
+                ],
+                "minimum": 1,
+                "integer": true,
+                "type": "Number",
+                "id": "max_target_seqs",
+                "name": "Maximum Target Sequence"
+            },
+            {
+                "command-line-flag": "-dbsize",
+                "description": "Effective length of the database",
+                "value-key": "[DBSIZE]",
+                "optional": true,
+                "maximum": 255,
+                "integer": true,
+                "type": "Number",
+                "id": "dbsize",
+                "name": "Database Size"
+            },
+            {
+                "command-line-flag": "-searchsp",
+                "description": "Effective length of the search space",
+                "value-key": "[SEARCHSP]",
+                "optional": true,
+                "maximum": 255,
+                "minimum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "searchsp",
+                "name": "Search Space Length"
+            },
+            {
+                "command-line-flag": "-window_size",
+                "description": "Multiple hits window size, use 0 to specify 1-hit algorithm",
+                "value-key": "[WINDOW_SIZE]",
+                "optional": true,
+                "minimum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "window_size",
+                "name": "Multiple Hits Window Size"
+            },
+            {
+                "command-line-flag": "-num_threads",
+                "description": "   Number of threads (CPUs) to use in the BLAST search\n   Default = `1'",
+                "value-key": "[NUM_THREADS]",
+                "optional": true,
+                "maximum": 12,
+                "disables-inputs": [
+                    "remote"
+                ],
+                "minimum": 1,
+                "integer": true,
+                "type": "Number",
+                "id": "num_threads",
+                "name": "Maximum Target Sequence"
+            },
+            {
+                "command-line-flag": "-penalty",
+                "description": "Penalty for a nucleotide mismatch",
+                "value-key": "[PENALTY]",
+                "optional": true,
+                "maximum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "penalty",
+                "name": "Nucleotide Mismatch Penalty"
+            },
+            {
+                "command-line-flag": "-reward",
+                "description": "Reward for a nucleotide match",
+                "value-key": "[REWARD]",
+                "optional": true,
+                "minimum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "reward",
+                "name": "Nucleotide Match Reward"
+            },
+            {
+                "command-line-flag": "-window_masker_taxid",
+                "description": "Enable WindowMasker filtering using a Taxonomic ID",
+                "value-key": "[WINDOW_MASKER_TAXID]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "window_masker_taxid",
+                "name": "Taxonomic ID for WindowMasker Filtering"
+            },
+            {
+                "command-line-flag": "-template_length",
+                "description": "Discontiguous MegaBLAST template length",
+                "value-key": "[TEMPLATE_LENGTH]",
+                "optional": true,
+                "requires-inputs": [
+                    "template_type"
+                ],
+                "value-choices": [
+                    16,
+                    18,
+                    21
+                ],
+                "integer": true,
+                "type": "Number",
+                "id": "template_length",
+                "name": "Discontiguous MegaBLAST Template Length"
+            },
+            {
+                "command-line-flag": "-min_raw_gapped_score",
+                "description": "Minimum raw gapped score to keep an alignment in the preliminary gapped and traceback stages",
+                "value-key": "[MIN_RAW_GAPPED_SCORE]",
+                "optional": true,
+                "integer": true,
+                "type": "Number",
+                "id": "min_raw_gapped_score",
+                "name": "Minumum Raw Gapped Score"
+            },
+            {
+                "command-line-flag": "-off_diagonal_range",
+                "description": "   Number of off-diagonals to search for the 2nd hit, use 0 to turn off\n   Default = `0'",
+                "value-key": "[OFF_DIAGONAL_RANGE]",
+                "optional": true,
+                "minimum": 0,
+                "integer": true,
+                "type": "Number",
+                "id": "off_diagonal_range",
+                "name": "Off-Diagonal Range"
+            },
+            {
+                "command-line-flag": "-evalue",
+                "description": "  Expectation value (E) threshold for saving hits\n  Default = `10'",
+                "value-key": "[EVALUE]",
+                "optional": true,
+                "type": "Number",
+                "id": "evalue",
+                "name": "Expectation Value"
+            },
+            {
+                "command-line-flag": "-perc_identity",
+                "description": "Percent identity",
+                "value-key": "[PERC_IDENTITY]",
+                "optional": true,
+                "maximum": 100,
+                "minimum": 0,
+                "type": "Number",
+                "id": "perc_identity",
+                "name": "Percent identity"
+            },
+            {
+                "command-line-flag": "-qcov_hsp_perc",
+                "description": "Percent query coverage per hsp",
+                "value-key": "[QCOV_HSP_PERC]",
+                "optional": true,
+                "maximum": 100,
+                "minimum": 0,
+                "type": "Number",
+                "id": "qcov_hsp_perc",
+                "name": "Percentage Query Coverage"
+            },
+            {
+                "command-line-flag": "-best_hit_overhang",
+                "description": "Best Hit algorithm overhang value (recommended value: 0.1)",
+                "value-key": "[BEST_HIT_OVERHANG]",
+                "optional": true,
+                "exclusive-maximum": true,
+                "maximum": 0.5,
+                "disables-inputs": [
+                    "culling_limit"
+                ],
+                "minimum": 0,
+                "exclusive-minimum": true,
+                "type": "Number",
+                "id": "best_hit_overhang",
+                "name": "Best Hit Algorithm Overhang"
+            },
+            {
+                "command-line-flag": "-best_hit_score_edge",
+                "description": "Best Hit algorithm score edge value (recommended value: 0.1)",
+                "value-key": "[BEST_HIT_SCORE_EDGE]",
+                "optional": true,
+                "exclusive-maximum": true,
+                "maximum": 0.5,
+                "disables-inputs": [
+                    "culling_limit"
+                ],
+                "minimum": 0,
+                "exclusive-minimum": true,
+                "type": "Number",
+                "id": "best_hit_score_edge",
+                "name": "Best Hit Algorithm Score Edge Value"
+            },
+            {
+                "command-line-flag": "-xdrop_ungap",
+                "description": "X-dropoff value (in bits) for ungapped extensions",
+                "value-key": "[XDROP_UNGAP]",
+                "optional": true,
+                "type": "Number",
+                "id": "xdrop_ungap",
+                "name": "Ungapped Extensions X-dropoff Value"
+            },
+            {
+                "command-line-flag": "-xdrop_gap",
+                "description": "X-dropoff value (in bits) for preliminary gapped extensions",
+                "value-key": "[XDROP_GAP]",
+                "optional": true,
+                "type": "Number",
+                "id": "xdrop_gap",
+                "name": "Preiliminary Gapped Extensions X-dropoff Value"
+            },
+            {
+                "command-line-flag": "-xdrop_gap_final",
+                "description": "X-dropoff value (in bits) for final gapped alignment",
+                "value-key": "[XDROP_GAP_FINAL]",
+                "optional": true,
+                "type": "Number",
+                "id": "xdrop_gap_final",
+                "name": "Final Gapped Extensions X-dropoff Value"
+            },
+            {
+                "command-line-flag": "-query",
+                "description": "Input file name",
+                "value-key": "[QUERY]",
+                "optional": false,
+                "type": "File",
+                "id": "query",
+                "name": "Query"
+            },
+            {
+                "command-line-flag": "-subject",
+                "description": "Subject sequence(s) to search",
+                "value-key": "[SUBJECT]",
+                "optional": true,
+                "disables-inputs": [
+                    "db",
+                    "gilist",
+                    "seqidlist",
+                    "negative_gilist",
+                    "negative_seqidlist",
+                    "db_soft_mask",
+                    "db_hard_mask"
+                ],
+                "type": "File",
+                "id": "subject",
+                "name": "Subject"
+            },
+            {
+                "command-line-flag": "-import_search_strategy",
+                "description": "Search strategy to use",
+                "value-key": "[IMPORT_SEARCH_STRATEGY]",
+                "optional": true,
+                "disables-inputs": [
+                    "export_search_strategy"
+                ],
+                "type": "File",
+                "id": "import_search_strategy",
+                "name": "Search Strategy File"
+            },
+            {
+                "command-line-flag": "-export_search_strategy",
+                "description": "File name to record the search strategy used",
+                "value-key": "[EXPORT_SEARCH_STRATEGY]",
+                "optional": true,
+                "disables-inputs": [
+                    "import_search_strategy"
+                ],
+                "type": "File",
+                "id": "export_search_strategy",
+                "name": "Search Strategy Record Filename"
+            },
+            {
+                "command-line-flag": "-show_gis",
+                "description": "Show NCBI GIs in deflines?",
+                "value-key": "[fSHOW_GIS]",
+                "optional": true,
+                "type": "Flag",
+                "id": "show_gis",
+                "name": "Show NCBI GIs"
+            },
+            {
+                "command-line-flag": "-html",
+                "description": "Produce HTML Output",
+                "value-key": "[fHTML]",
+                "optional": true,
+                "type": "Flag",
+                "id": "html",
+                "name": "Show HTML"
+            },
+            {
+                "command-line-flag": "-outfmt",
+                "description": "   alignment view options:\n     0 = Pairwise,\n     1 = Query-anchored showing identities,\n     2 = Query-anchored no identities,\n     3 = Flat query-anchored showing identities,\n     4 = Flat query-anchored no identities,\n     5 = BLAST XML,\n     6 = Tabular,\n     7 = Tabular with comment lines,\n     8 = Seqalign (Text ASN.1),\n     9 = Seqalign (Binary ASN.1),\n    10 = Comma-separated values,\n    11 = BLAST archive (ASN.1),\n    12 = Seqalign (JSON),\n    13 = Multiple-file BLAST JSON,\n    14 = Multiple-file BLAST XML2,\n    15 = Single-file BLAST JSON,\n    16 = Single-file BLAST XML2,\n    17 = Sequence Alignment/Map (SAM),\n    18 = Organism Report\n\n   Options 6, 7, 10 and 17 can be additionally configured to produce\n   a custom format specified by space delimited format specifiers.\n   The supported format specifiers for options 6, 7 and 10 are:\n            qseqid means Query Seq-id\n               qgi means Query GI\n              qacc means Query accesion\n           qaccver means Query accesion.version\n              qlen means Query sequence length\n            sseqid means Subject Seq-id\n         sallseqid means All subject Seq-id(s), separated by a ';'\n               sgi means Subject GI\n            sallgi means All subject GIs\n              sacc means Subject accession\n           saccver means Subject accession.version\n           sallacc means All subject accessions\n              slen means Subject sequence length\n            qstart means Start of alignment in query\n              qend means End of alignment in query\n            sstart means Start of alignment in subject\n              send means End of alignment in subject\n              qseq means Aligned part of query sequence\n              sseq means Aligned part of subject sequence\n            evalue means Expect value\n          bitscore means Bit score\n             score means Raw score\n            length means Alignment length\n            pident means Percentage of identical matches\n            nident means Number of identical matches\n          mismatch means Number of mismatches\n          positive means Number of positive-scoring matches\n           gapopen means Number of gap openings\n              gaps means Total number of gaps\n              ppos means Percentage of positive-scoring matches\n            frames means Query and subject frames separated by a '/'\n            qframe means Query frame\n            sframe means Subject frame\n              btop means Blast traceback operations (BTOP)\n            staxid means Subject Taxonomy ID\n          ssciname means Subject Scientific Name\n          scomname means Subject Common Name\n        sblastname means Subject Blast Name\n         sskingdom means Subject Super Kingdom\n           staxids means unique Subject Taxonomy ID(s), separated by a ';'\n                         (in numerical order)\n         sscinames means unique Subject Scientific Name(s), separated by a ';'\n         scomnames means unique Subject Common Name(s), separated by a ';'\n        sblastnames means unique Subject Blast Name(s), separated by a ';'\n                         (in alphabetical order)\n        sskingdoms means unique Subject Super Kingdom(s), separated by a ';'\n                         (in alphabetical order)\n            stitle means Subject Title\n        salltitles means All Subject Title(s), separated by a '<>'\n           sstrand means Subject Strand\n             qcovs means Query Coverage Per Subject\n           qcovhsp means Query Coverage Per HSP\n            qcovus means Query Coverage Per Unique Subject (blastn only)\n   When not provided, the default value is:\n   'qaccver saccver pident length mismatch gapopen qstart qend sstart send\n   evalue bitscore', which is equivalent to the keyword 'std'\n   The supported format specifier for option 17 is:\n                SQ means Include Sequence Data\n                SR means Subject as Reference Seq\n  Default = `0'",
+                "value-key": "[OUTFMT]",
+                "optional": true,
+                "type": "String",
+                "id": "outfmt",
+                "name": "Alignment View Options"
+            },
+            {
+                "command-line-flag": "-num_descriptions",
+                "description": "   Number of database sequences to show one-line descriptions for\n   Not applicable for outfmt > 4\n   Default = `500'",
+                "value-key": "[NUM_DESCRIPTIONS]",
+                "optional": true,
+                "disables-inputs": [
+                    "max_target_seqs"
+                ],
+                "minimum": 0,
+                "type": "Number",
+                "id": "num_descriptions",
+                "name": "Number of Sequence Descriptions to Show"
+            },
+            {
+                "command-line-flag": "-num_alignments",
+                "description": "   Number of database sequences to show alignments for\n   Default = `250'",
+                "value-key": "[NUM_ALIGNMENTS]",
+                "optional": true,
+                "disables-inputs": [
+                    "max_target_seqs"
+                ],
+                "minimum": 0,
+                "type": "Number",
+                "id": "num_alignments",
+                "name": "Number of Sequence Alignments to Show"
+            },
+            {
+                "command-line-flag": "-line_length",
+                "description": "   Line length for formatting alignments\n   Not applicable for outfmt > 4\n   Default = `60'",
+                "value-key": "[LINE_LENGTH]",
+                "optional": true,
+                "minimum": 1,
+                "type": "Number",
+                "id": "line_length",
+                "name": "Line Length"
+            },
+            {
+                "command-line-flag": "-out",
+                "description": "   Output file name",
+                "value-key": "[OUT]",
+                "optional": true,
+                "type": "String",
+                "id": "out",
+                "name": "Output file name"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[OUT]",
+                "optional": false,
+                "id": "output",
+                "name": "Output File"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 60,
+            "ram": 1,
+            "cpu-cores": 1
+        },
+        "name": "blastn"
+    },
+    {
+        "tool-version": "v1.1",
+        "tests": [
+            {
+                "invocation": {
+                    "input": "uniprotminier.fasta"
+                },
+                "name": "test1",
+                "assertions": {
+                    "output-files": [
+                        {
+                            "id": "outmafft_rascal",
+                            "md5-reference": "4b003bebd3fb9722152f65ab5d17c434"
+                        }
+                    ],
+                    "exit-code": 0
+                }
+            }
+        ],
+        "description": "automatic quality improvment for multiple sequence alignment.",
+        "command-line": "AQUA.tcl [INPUT] [OUTPUT_DIR]",
+        "author": "Muller J, Creevey CJ, Thompson JD, Arendt D, Bork P.",
+        "tags": {
+            "domain": [
+                "bioinformatics",
+                "AQUA"
+            ]
+        },
+        "container-image": {
+            "index": "shub://",
+            "image": "bioinformatics-group/aqua-singularity-recipe",
+            "type": "singularity"
+        },
+        "inputs": [
+            {
+                "description": "A file containing the input sequence in fasta format",
+                "value-key": "[INPUT]",
+                "optional": false,
+                "type": "File",
+                "id": "input",
+                "name": "Input Sequence"
+            },
+            {
+                "description": "The directory where the results are stored. The default location is the same directory as the input sequence.",
+                "default-value": ".",
+                "value-key": "[OUTPUT_DIR]",
+                "optional": false,
+                "type": "File",
+                "id": "output_dir",
+                "name": "Output Directory"
+            }
+        ],
+        "schema-version": "0.5",
+        "output-files": [
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].muscle",
+                "optional": false,
+                "id": "outmuscle",
+                "name": "Output of muscle results"
+            },
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].mafft",
+                "optional": false,
+                "id": "outmafft",
+                "name": "Output of mafft results"
+            },
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].muscle.rascal",
+                "optional": false,
+                "id": "outmuscle_rascal",
+                "name": "Output of muscle and rascal results"
+            },
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].mafft.rascal",
+                "optional": false,
+                "id": "outmafft_rascal",
+                "name": "Output of mafft and rascal results"
+            },
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].muscle.normd",
+                "optional": false,
+                "id": "outmuscle_normd",
+                "name": "Output of muscle and normd results"
+            },
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].mafft.normd",
+                "optional": false,
+                "id": "outmafft_normd",
+                "name": "Output of mafft and normd results"
+            },
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].muscle.rascal.normd",
+                "optional": false,
+                "id": "outmuscle_rascal_normd",
+                "name": "Output of muscle, rascal and normd results"
+            },
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].mafft.rascal.normd",
+                "optional": false,
+                "id": "outmafft_rascal_normd",
+                "name": "Output of mafft, rascal and normd results"
+            },
+            {
+                "path-template": "[OUTPUT_DIR]/[INPUT].best",
+                "optional": false,
+                "id": "outbest",
+                "name": "Output of best results"
+            }
+        ],
+        "suggested-resources": {
+            "walltime-estimate": 60,
+            "ram": 1,
+            "cpu-cores": 1
+        },
+        "name": "AQUA"
+    },
+    {
+        "name": "spark",
+        "schema-version": "0.5",
+        "tool-version": "v1.2.1",
+        "tags": {
+            "domain": "neuroinformatics"
+        },
+        "author": "Kangjoo Lee, Jean-Marc Lina, Jean Gotman, Christophe Grova",
+        "description": "SParsity-based Analysis of Reliable K-hubness (SPARK) for brain fMRI functional connectivity",
+        "container-image": {
+            "type": "singularity",
+            "image": "multifunkimlab/spark:1.2.1"
+        },
+        "command-line": "octave --no-gui --no-init-file -q $SPARK_ROOT/SPARK.m [FMRI_DATA] [MASK] [OUT_DIR] [NB_RESAMPLING] [NETWORK_SCALES] [NB_ITERATIONS] [P_VALUE] [RESAMPLING_METHOD] [BLOCK_WINDOW_LENGTH] [DICT_INIT_METHOD] [SPARSE_CODING_METHOD] [PRESERVE_DC_ATOM] [MAX_PARALLEL_JOBS]",
+        "groups": [
+            {
+                "id": "bootstrap_resampling",
+                "name": "Bootstrap resampling",
+                "members": [
+                    "nb_resampling",
+                    "resampling_method",
+                    "block_window_length"
+                ]
+            },
+            {
+                "id": "sparse_dict_learning",
+                "name": "Sparse dictionary learning",
+                "members": [
+                    "network_scales",
+                    "nb_iterations",
+                    "dict_init_method",
+                    "sparse_coding_method",
+                    "preserve_dc_atom"
+                ]
+            },
+            {
+                "id": "k_hubness_map_generation",
+                "name": "k-hubness map generation",
+                "members": [
+                    "p_value"
+                ]
+            }
+        ],
+        "output-files": [
+            {
+                "id": "result",
+                "name": "Results directory",
+                "description": "Results directory containing:  k-hubness maps, atom maps and intermediate files. (file formats: MINC, NIfTI)",
+                "path-template": "[OUT_DIR]",
+                "optional": false
+            }
+        ],
+        "inputs": [
+            {
+                "id": "fmri_data",
+                "name": "fMRI data",
+                "description": "The fMRI data to analyze. (file formats: MINC, NIfTI)",
+                "type": "File",
+                "optional": false,
+                "command-line-flag": "--fmri-data",
+                "value-key": "[FMRI_DATA]"
+            },
+            {
+                "id": "mask",
+                "name": "Grey-matter mask",
+                "description": "Path to the grey-matter mask. (file formats: MINC, NIfTI)",
+                "type": "File",
+                "optional": false,
+                "command-line-flag": "--mask",
+                "value-key": "[MASK]"
+            },
+            {
+                "id": "out_dir",
+                "name": "Output name",
+                "description": "The name of the output directory.",
+                "type": "String",
+                "optional": false,
+                "command-line-flag": "--out-dir",
+                "value-key": "[OUT_DIR]"
+            },
+            {
+                "id": "nb_resampling",
+                "name": "Number of resampling",
+                "description": "Number of bootstrap resampling at the individual level. (recommended: 100)",
+                "type": "Number",
+                "optional": false,
+                "integer": true,
+                "minimum": 2,
+                "command-line-flag": "--nb-resampling",
+                "value-key": "[NB_RESAMPLING]"
+            },
+            {
+                "id": "network_scales",
+                "name": "Network scales",
+                "description": "Three numbers, respectively: [begin] [step] [end], used to create a regularly-spaced vector. In order to specify a single number, for instance '15', enter the same number for [begin] and [end], as: 15 1 15. This vector of numbers corresponds to the range of network scales to be tested. An optimal network scale is estimated from the specified set of numbers. (recommended: 10 2 30)",
+                "type": "Number",
+                "optional": false,
+                "list": true,
+                "integer": true,
+                "min-list-entries": 3,
+                "max-list-entries": 3,
+                "minimum": 1,
+                "command-line-flag": "--network-scales",
+                "value-key": "[NETWORK_SCALES]"
+            },
+            {
+                "id": "nb_iterations",
+                "name": "Number of iterations",
+                "description": "Number of iterations for the sparse dictionary learning.  (recommended: 20)",
+                "type": "Number",
+                "optional": false,
+                "integer": true,
+                "minimum": 2,
+                "command-line-flag": "--nb-iterations",
+                "value-key": "[NB_ITERATIONS]"
+            },
+            {
+                "id": "p_value",
+                "name": "P-Value",
+                "description": "Significance level, using a Z-test, for removing inconsistent elements in the average sparse coefficients (considered as the Gaussian noise) after spatial clustering (using a threshold).",
+                "type": "Number",
+                "optional": false,
+                "minimum": 0,
+                "maximum": 1,
+                "command-line-flag": "--p-value",
+                "value-key": "[P_VALUE]"
+            },
+            {
+                "id": "resampling_method",
+                "name": "Resampling method",
+                "description": "Method (from NIAK) used to resample the data under the null hypothesis. Note: If 'CBB' is selected, the option --block-window-length is used. [CBB]: Circular-block-bootstrap sample of multiple time series. [AR1B]: Bootstrap sample of multiple time series based on a semiparametric scheme mixing an auto-regressive temporal model and i.i.d. bootstrap of the 'innovations'. [AR1G]: (Bootstrap sample of multiple time series based on a parametric model of Gaussian data with arbitrary spatial correlations and first-order auto-regressive temporal correlations.",
+                "type": "String",
+                "optional": true,
+                "value-choices": [
+                    "CBB",
+                    "AR1B",
+                    "AR1G"
+                ],
+                "value-disables": {
+                    "CBB": [],
+                    "AR1B": [
+                        "block_window_length"
+                    ],
+                    "AR1G": [
+                        "block_window_length"
+                    ]
+                },
+                "value-requires": {
+                    "CBB": [
+                        "block_window_length"
+                    ],
+                    "AR1B": [],
+                    "AR1G": []
+                },
+                "default-value": "CBB",
+                "command-line-flag": "--resampling-method",
+                "value-key": "[RESAMPLING_METHOD]"
+            },
+            {
+                "id": "block_window_length",
+                "name": "Block window length",
+                "description": "Three numbers, respectively: [begin] [step] [end], used to create a regularly-spaced vector. In order to specify a single number, for instance '15', enter the same number for [begin] and [end], as: 15 1 15. A number in this vector corresponds to a window length used in the circular block bootstrap. The unit of the window length is \u2018time-point\u2019 with each time-point indicating a 3D scan at each TR. If multiple numbers are specified, then a number is randomly selected from the list at each resampling. It is recommended to use a minimum of sqrt(T), where T is the total number of time points in the fMRI time-course. It is also recommended to randomize the window length to reduce a bias by window size.",
+                "type": "Number",
+                "optional": true,
+                "list": true,
+                "integer": true,
+                "min-list-entries": 3,
+                "max-list-entries": 3,
+                "minimum": 1,
+                "default-value": [
+                    10,
+                    1,
+                    30
+                ],
+                "command-line-flag": "--block-window-length",
+                "value-key": "[BLOCK_WINDOW_LENGTH]"
+            },
+            {
+                "id": "dict_init_method",
+                "name": "Dictionary initialization method",
+                "description": "If 'GivenMatrix' is selected, then the dictionary will be initialized by a random permutation of the raw data obtained in step 1. If 'DataElements' is selected, then the dictionary will be initialized by the first N (number of atoms) columns in the raw data obtained in step 1.",
+                "type": "String",
+                "optional": true,
+                "value-choices": [
+                    "GivenMatrix",
+                    "DataElements"
+                ],
+                "default-value": "GivenMatrix",
+                "command-line-flag": "--dict-init-method",
+                "value-key": "[DICT_INIT_METHOD]"
+            },
+            {
+                "id": "sparse_coding_method",
+                "name": "Sparse coding method",
+                "description": "Sparse coding method for the sparse dictionary learning.",
+                "type": "String",
+                "optional": true,
+                "value-choices": [
+                    "OMP",
+                    "Thresholding"
+                ],
+                "default-value": "Thresholding",
+                "command-line-flag": "--sparse-coding-method",
+                "value-key": "[SPARSE_CODING_METHOD]"
+            },
+            {
+                "id": "preserve_dc_atom",
+                "name": "Perserve first atom",
+                "description": "If set, then the first atom will be set to a constant and will never change, while all the other atoms will be trained and updated.",
+                "type": "Flag",
+                "optional": true,
+                "command-line-flag": "--preserve-dc-atom",
+                "value-key": "[PRESERVE_DC_ATOM]"
+            },
+            {
+                "id": "max_parallel_jobs",
+                "name": "Number of parallel jobs",
+                "description": "Maximum number of jobs to run in parallel.",
+                "type": "Number",
+                "optional": true,
+                "default-value": 12,
+                "command-line-flag": "--max-parallel-jobs",
+                "value-key": "[MAX_PARALLEL_JOBS]"
+            }
+        ],
+        "suggested-resources": {
+            "cpu-cores": 2,
+            "ram": 12,
+            "walltime-estimate": 100000
+        }
+    }
+]

--- a/app/static/pipelines/zenodo-1445789.json
+++ b/app/static/pipelines/zenodo-1445789.json
@@ -1,0 +1,209 @@
+{
+    "tool-version": "0.3.1", 
+    "name": "ICA_AROMA", 
+    "author": "Maarten Mennes",
+    "command-line": "python /ICA-AROMA/ica-aroma-wrapper.py [OUTPUT_DIR] [INPUT_FILE] [AFFINE_FILE] [WARP_FILE] [REALIGNMENT_FILE] [MASK_FILE] [MELODIC_DIR] [FEAT_DIR] [TR_NUM] [DIMS_NUM] [DENOISING_STRATEGY]", 
+    "inputs": [
+        {
+            "command-line-flag": "-out", 
+            "description": "Output directory name.", 
+            "default-value": "AROMA_output", 
+            "value-key": "[OUTPUT_DIR]", 
+            "type": "String", 
+            "list": false, 
+            "optional": false, 
+            "id": "outdir", 
+            "name": "Output directory"
+        }, 
+        {
+            "command-line-flag": "-in", 
+            "description": "Input file name of fMRI data (.nii.gz).", 
+            "value-key": "[INPUT_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "realignment_file", 
+                "affine_file", 
+                "warp_file"
+            ], 
+            "optional": true, 
+            "id": "infile", 
+            "name": "Input file"
+        }, 
+        {
+            "command-line-flag": "-affmat", 
+            "description": "File name of the mat-file describing the affine registration (e.g. FSL FLIRT) of the functional data to structural space (.mat file).", 
+            "value-key": "[AFFINE_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "infile"
+            ], 
+            "optional": true, 
+            "id": "affine_file", 
+            "name": "Affine registration file"
+        }, 
+        {
+            "command-line-flag": "-warp", 
+            "description": "File name of the warp-file describing the non-linear registration (e.g. FSL FNIRT) of the structural data to MNI152 space (.nii.gz format).", 
+            "value-key": "[WARP_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "infile"
+            ], 
+            "optional": true, 
+            "id": "warp_file", 
+            "name": "Non-linear registration warp file"
+        }, 
+        {
+            "command-line-flag": "-mc", 
+            "description": "File name of the text file containing the six (column-wise) realignment parameters time-courses derived from volume-realignment (e.g. MCFLIRT). (Usually .par format).", 
+            "value-key": "[REALIGNMENT_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "infile"
+            ], 
+            "optional": true, 
+            "id": "realignment_file", 
+            "name": "Realignment file"
+        }, 
+        {
+            "command-line-flag": "-mask", 
+            "description": "Input fMRI data should be masked (i.e. brain-extracted) or a specific mask has to be specified (-m, -mask) when running ICA-AROMA. Note the mask determined by FEAT is not recommended to be used; rather, a mask can be created via the Brain Extraction Tool of FSL (e.g. bet input output -f 0.3 -n -m -R). Not strictly required in generic mode. (Usually .nii.gz format.)", 
+            "value-key": "[MASK_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "infile"
+            ], 
+            "optional": true, 
+            "id": "mask_file", 
+            "name": "Mask file"
+        }, 
+        {
+            "command-line-flag": "-md", 
+            "description": "When you have already run MELODIC you can specify the melodic directory as additional input to avoid running MELODIC again. Note that MELODIC should have been run on the fMRI data prior to temporal filtering and after spatial smoothing. Further, unless you have a good reason for doing otherwise, we advise to run MELODIC as part of ICA-AROMA so that it runs with optimal settings. (Usually .ica extension.)", 
+            "value-key": "[MELODIC_DIR]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "melodic_dir", 
+            "name": "Melodic directory"
+        }, 
+        {
+            "command-line-flag": "-feat", 
+            "description": "Runs ICA-AROMA in post-FEAT mode. In this case, only the FEAT directory has to be specified, as well as an output directory. ICA-AROMA will automatically define the appropriate files, create an appropriate mask (see ICA-AROMA manual, section 4.1) and use the melodic.ica directory if available, in case \u2018MELODIC ICA data exploration\u2019 was checked in FEAT. (.feat extension.)", 
+            "value-key": "[FEAT_DIR]", 
+            "type": "File", 
+            "list": false, 
+            "disables-inputs": [
+                "realignment_file", 
+                "affine_file", 
+                "warp_file", 
+                "mask_file"
+            ], 
+            "optional": true, 
+            "id": "feat_dir", 
+            "name": "FEAT directory"
+        }, 
+        {
+            "command-line-flag": "-tr", 
+            "description": "TR in seconds. If this is not specified the TR will be extracted from the header of the fMRI file using \u2018fslinfo\u2019. In that case, make sure the TR in the header is correct!", 
+            "value-key": "[TR_NUM]", 
+            "type": "Number", 
+            "list": false, 
+            "minimum": 0, 
+            "optional": true, 
+            "id": "tr_num", 
+            "name": "TR"
+        }, 
+        {
+            "command-line-flag": "-dim", 
+            "description": "Dimensionality reduction into a defined number of dimensions when running MELODIC (default is 0; automatic estimation).", 
+            "value-key": "[DIMS_NUM]", 
+            "type": "Number", 
+            "list": false, 
+            "minimum": 0, 
+            "integer": true, 
+            "optional": true, 
+            "id": "dims_num", 
+            "name": "Dimensionality reduction level"
+        }, 
+        {
+            "command-line-flag": "-den", 
+            "description": "Type of denoising strategy (default is nonaggr). Can be \"no\" (only classification, no denoising), \"nonaggr\" (non-aggressive denoising, i.e. partial component regression; default), \"aggr\" (aggressive denoising, i.e. full component regression), \"both\" (both aggressive and non-aggressive denoising, two outputs).", 
+            "value-key": "[DENOISING_STRATEGY]", 
+            "optional": true, 
+            "list": false, 
+            "value-choices": [
+                "no", 
+                "nonaggr", 
+                "aggr", 
+                "both"
+            ], 
+            "type": "String", 
+            "id": "denoising_strategy", 
+            "name": "Denoising strategy"
+        }
+    ], 
+    "container-image": {
+        "index": "index.docker.io", 
+        "image": "mcin/ica-aroma:latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "groups": [
+        {
+            "description": "Either input a .nii.gz file or a Feat directory. The former allows running ICA-AROMA in generic mode; the latter runs it in Feat mode.", 
+            "one-is-required": true, 
+            "mutually-exclusive": true, 
+            "members": [
+                "infile", 
+                "feat_dir"
+            ], 
+            "id": "input_data_group", 
+            "name": "Input Data"
+        }, 
+        {
+            "description": "Input files used in generic mode. The realignment, affine registration, and warp files are required in this mode.", 
+            "id": "generic_mode_group", 
+            "members": [
+                "realignment_file", 
+                "affine_file", 
+                "warp_file", 
+                "mask_file"
+            ], 
+            "name": "Generic Mode Parameters"
+        }, 
+        {
+            "description": "Optional parameters that can be specified in either mode of ICA-AROMA.", 
+            "id": "optional_args_group", 
+            "members": [
+                "tr_num", 
+                "denoising_strategy", 
+                "dims_num", 
+                "melodic_dir"
+            ], 
+            "name": "Optional Parameters"
+        }
+    ], 
+    "output-files": [
+        {
+            "description": "A folder containing the output files for ICA-AROMA (see ICA-AROMA manual, sec. 6). Should include a denoised fMRI data file (.nii.gz), text files indicating classification and feature results, and Melodic-related files (spatial maps in .nii.gz, a mask in .nii.gz, and the .ica output directory).", 
+            "list": false, 
+            "id": "folder_out", 
+            "optional": false, 
+            "path-template": "[OUTPUT_DIR]", 
+            "name": "Output folder"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 5000
+    }, 
+    "description": "ICA-AROMA (i.e. Independent Component Analyis-based Automatic Removal Of Motion Artifacts) is a data-driven method to identify and remove motion-related independent components from fMRI data.",
+    "tags": {
+        "domain": "fmri"
+    }
+}

--- a/app/static/pipelines/zenodo-1450991.json
+++ b/app/static/pipelines/zenodo-1450991.json
@@ -1,0 +1,149 @@
+{
+    "tool-version": "1.0.0", 
+    "name": "fsl_probtrackx2",
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_probtrackx2.json", 
+    "command-line": "cp -rL [INPUT_DIR] [OUTPUT_DIR]; probtrackx2 -s [OUTPUT_DIR]/[BASENAME] -m [OUTPUT_DIR]/[MASKNAME] -x [SEEDFILE] --dir=[OUTPUT_DIR]/[FINALDIR] [FORCEDIR] [OPD] [PD] [OS2T] --targetmasks=[TARGETMASKS] --xfm=[OUTPUT_DIR]/[XFM] --invxfm=[OUTPUT_DIR]/[INVXFM]", 
+    "inputs": [
+        {
+            "description": "A bedpostX directory", 
+            "value-key": "[INPUT_DIR]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "inputdir", 
+            "name": "Input Directory"
+        }, 
+        {
+            "description": "Basename for samples files - e.g. 'merged'", 
+            "value-key": "[BASENAME]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "basename", 
+            "name": "Base name"
+        }, 
+        {
+            "description": "Bet binary mask file in diffusion space", 
+            "value-key": "[MASKNAME]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "maskname", 
+            "name": "Mask name"
+        }, 
+        {
+            "description": "Seed volume or list (ascii text file) of volumes and/or surfaces", 
+            "value-key": "[SEEDFILE]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "seedfile", 
+            "name": "Seed file"
+        }, 
+        {
+            "description": "Directory to put the final volumes in - code makes this directory - default='logdir'", 
+            "value-key": "[FINALDIR]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "finaldir", 
+            "name": "Directory to put the final volumes in"
+        }, 
+        {
+            "command-line-flag": "--forcedir", 
+            "description": "Use the actual directory name given - i.e. don't add + to make a new directory", 
+            "default-value": true, 
+            "value-key": "[FORCEDIR]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "forcedir", 
+            "name": "Use the actual directory name given"
+        }, 
+        {
+            "command-line-flag": "--opd", 
+            "description": "Output path distribution", 
+            "default-value": true, 
+            "value-key": "[OPD]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "outputpath", 
+            "name": "Output path"
+        }, 
+        {
+            "command-line-flag": "--pd", 
+            "description": "Correct path distribution for the length of the pathways", 
+            "default-value": true, 
+            "value-key": "[PD]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "pathdistribution", 
+            "name": "Correct path distribution"
+        }, 
+        {
+            "command-line-flag": "--os2t", 
+            "description": "Output seeds to targets", 
+            "default-value": true, 
+            "value-key": "[OS2T]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "outseeds", 
+            "name": "Output seeds"
+        }, 
+        {
+            "description": "File containing a list of target masks - for seeds_to_targets classification", 
+            "value-key": "[TARGETMASKS]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "targetmasks", 
+            "name": "File containing a list of target masks"
+        }, 
+        {
+            "description": "Transform taking seed space to DTI space (either FLIRT matrix or FNIRT warpfield) - default is identity", 
+            "value-key": "[XFM]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "xfm", 
+            "name": "Transform taking seed space to DTI space"
+        }, 
+        {
+            "description": "Transform taking DTI space to seed space (compulsory when using a warpfield for seeds_to_dti)", 
+            "value-key": "[INVXFM]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "infxfm", 
+            "name": "Transform taking DTI space to seed space"
+        }, 
+        {
+            "description": "Output directory name.", 
+            "default-value": "probtrackx2_output", 
+            "value-key": "[OUTPUT_DIR]", 
+            "type": "String", 
+            "list": false, 
+            "optional": false, 
+            "id": "outdir", 
+            "name": "Output directory"
+        }
+    ], 
+    "container-image": {
+        "index": "index.docker.io", 
+        "image": "mcin/docker-fsl:latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "description": "A folder containing the output result.", 
+            "list": false, 
+            "id": "folder_out", 
+            "optional": false, 
+            "path-template": "[OUTPUT_DIR]", 
+            "name": "Output folder"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 331200
+    }, 
+    "description": "probabilistic tracking with crossing fibres",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "dmri"
+        ]
+    }
+}

--- a/app/static/pipelines/zenodo-1450993.json
+++ b/app/static/pipelines/zenodo-1450993.json
@@ -1,0 +1,59 @@
+{
+    "tool-version": "3.19.0-centos7", 
+    "name": "PostFreeSurferPipelineBatch-CentOS7",
+    "author": "Washington University",
+    "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/postfreesurfer-exec-centos7.json", 
+    "command-line": "postfreesurfer-command-line-script.sh [SUBJECT_FOLDER] [NAME] [LICENSE]", 
+    "inputs": [
+        {
+            "description": "HCP subject folder, downloaded from http://www.humanconnectome.org/documentation/S500.", 
+            "value-key": "[SUBJECT_FOLDER]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "subject_folder", 
+            "name": "HCP subject folder"
+        }, 
+        {
+            "description": "Use this parameter to give a name to the execution. Example: \"Exec-CentOS5-PostFreeSurfer\". The results will be written in a folder named [SUBJECT]-[EXECUTION-NAME] (a unique identifier will be appended in case a file with the same name already exists).", 
+            "default-value": "Exec-CentOS-[X]-PostFreeSurfer", 
+            "value-key": "[NAME]", 
+            "optional": false, 
+            "type": "String", 
+            "id": "execution_name", 
+            "name": "Execution name"
+        }, 
+        {
+            "description": "Use this parameter to add the content of the license file in the freesurfer directory", 
+            "default-value": "", 
+            "value-key": "[LICENSE]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "freesurfer_license", 
+            "name": "FreeSurfer License"
+        }
+    ], 
+    "container-image": {
+        "image": "bigdatalabteam/hcp-prefreesurfer:exec-centos7.freesurferbuild-centos4-latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[SUBJECT_FOLDER]-[NAME]", 
+            "description": "This directory will contain 3 directories (T1w, T2w and MNINonLinear), a monitoring file (monitor.txt) and the input data.", 
+            "optional": false, 
+            "id": "results", 
+            "name": "Results"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 25200
+    }, 
+    "description": "PostFreeSurferPipelineBatch HCP pipeline",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    }
+}

--- a/app/static/pipelines/zenodo-1450995.json
+++ b/app/static/pipelines/zenodo-1450995.json
@@ -1,0 +1,50 @@
+{
+    "tool-version": "3.19.0-centos7", 
+    "name": "PreFreeSurferPipelineBatch", 
+    "author": "Washington University", 
+    "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/prefreesurfer-exec-centos7-fslbuild-centos5.json",
+    "command-line": "command-line-script.sh [SUBJECT_FOLDER] [NAME]", 
+    "inputs": [
+        {
+            "description": "HCP subject folder, downloaded from http://www.humanconnectome.org/documentation/S500.", 
+            "value-key": "[SUBJECT_FOLDER]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "subject_folder", 
+            "name": "HCP subject folder"
+        }, 
+        {
+            "description": "Use this parameter to give a name to the execution. Example: \"Exec-CentOS5-FSLbuild-CentOS5\". The results will be written in a folder named [SUBJECT]-[EXECUTION-NAME] (a unique identifier will be appended in case a file with the same name already exists).", 
+            "default-value": "Exec-CentOS-[X]-FSLbuild-CentOS-[Y]", 
+            "value-key": "[NAME]", 
+            "optional": false, 
+            "type": "String", 
+            "id": "execution_name", 
+            "name": "Execution name"
+        }
+    ], 
+    "container-image": {
+        "image": "bigdatalabteam/hcp-prefreesurfer:exec-centos7-fslbuild-centos5-latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[SUBJECT_FOLDER]-[NAME]", 
+            "description": "This directory will contain 3 directories (T1w, T2w and MNINonLinear), a monitoring file (monitor.txt) and the input data.", 
+            "optional": false, 
+            "id": "results", 
+            "name": "Results"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 25200
+    }, 
+    "description": "PreFreeSurferPipelineBatch HCP pipeline",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    }
+}

--- a/app/static/pipelines/zenodo-1450997.json
+++ b/app/static/pipelines/zenodo-1450997.json
@@ -1,0 +1,59 @@
+{
+    "tool-version": "3.19.0-centos7", 
+    "name": "FreeSurferPipelineBatch-CentOS7", 
+    "author": "Washington University", 
+    "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/freesurfer-exec-centos7-freesurferbuild-centos4.json",
+    "command-line": "freesurfer-command-line-script.sh [SUBJECT_FOLDER] [NAME] [LICENSE]", 
+    "inputs": [
+        {
+            "description": "HCP subject folder, downloaded from http://www.humanconnectome.org/documentation/S500.", 
+            "value-key": "[SUBJECT_FOLDER]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "subject_folder", 
+            "name": "HCP subject folder"
+        }, 
+        {
+            "description": "Use this parameter to give a name to the execution. Example: \"Exec-CentOS7-FreeSurferbuild-CentOS4\". The results will be written in a folder named [SUBJECT]-[EXECUTION-NAME] (a unique identifier will be appended in case a file with the same name already exists).", 
+            "default-value": "Exec-CentOS-[X]-FreeSurferbuild-CentOS-[Y]", 
+            "value-key": "[NAME]", 
+            "optional": false, 
+            "type": "String", 
+            "id": "execution_name", 
+            "name": "Execution name"
+        }, 
+        {
+            "description": "Use this parameter to add the content of the license file in the freesurfer directory", 
+            "default-value": "", 
+            "value-key": "[LICENSE]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "freesurfer_license", 
+            "name": "FreeSurfer License"
+        }
+    ], 
+    "container-image": {
+        "image": "bigdatalabteam/hcp-prefreesurfer:exec-centos7.freesurferbuild-centos4-latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[SUBJECT_FOLDER]-[NAME]", 
+            "description": "This directory will contain 3 directories (T1w, T2w and MNINonLinear), a monitoring file (monitor.txt) and the input data.", 
+            "optional": false, 
+            "id": "results", 
+            "name": "Results"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 25200
+    }, 
+    "description": "FreeSurferPipelineBatch HCP pipeline",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    }
+}

--- a/app/static/pipelines/zenodo-1450999.json
+++ b/app/static/pipelines/zenodo-1450999.json
@@ -1,0 +1,255 @@
+{
+    "tool-version": "v0.1.0", 
+    "name": "ndmg", 
+    "author": "Greg Kiar", 
+    "descriptor-url": "https://github.com/neurodata/boutiques-tools/blob/8d5274754e2d5b3b146f2b3cc581400b96bb6081/cbrain_task_descriptors/ndmg-docker.json", 
+    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN]", 
+    "inputs": [
+        {
+            "value-key": "[DTI]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "dti_file", 
+            "name": "Diffusion Tensor Image"
+        }, 
+        {
+            "value-key": "[BVAL]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "bval_file", 
+            "name": "B-values file"
+        }, 
+        {
+            "value-key": "[BVEC]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "bvec_file", 
+            "name": "Gradient vectors file"
+        }, 
+        {
+            "value-key": "[MPRAGE]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "mprage_file", 
+            "name": "Structural scan file"
+        }, 
+        {
+            "name": "Atlas image (MNI152)", 
+            "value-key": "[ATLAS]", 
+            "type": "String", 
+            "value-choices": [
+                "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
+            ], 
+            "optional": false, 
+            "id": "atlas"
+        }, 
+        {
+            "name": "Atlas brain mask", 
+            "value-key": "[MASK]", 
+            "type": "String", 
+            "value-choices": [
+                "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
+            ], 
+            "optional": false, 
+            "id": "mask"
+        }, 
+        {
+            "value-key": "[OUTDIR]", 
+            "optional": false, 
+            "type": "String", 
+            "id": "outdir", 
+            "name": "Output directory"
+        }, 
+        {
+            "name": "Desikan parcellation", 
+            "value-key": "[DESIKAN]", 
+            "type": "String", 
+            "value-choices": [
+                "/ndmg_atlases/labels/desikan.nii.gz"
+            ], 
+            "optional": true, 
+            "id": "desikan"
+        }, 
+        {
+            "name": "JHU parcellation", 
+            "value-key": "[JHU]", 
+            "type": "String", 
+            "value-choices": [
+                "/ndmg_atlases/labels/JHU.nii.gz"
+            ], 
+            "optional": true, 
+            "id": "jhu"
+        }, 
+        {
+            "name": "Talairach parcellation", 
+            "value-key": "[TALAIRACH]", 
+            "type": "String", 
+            "value-choices": [
+                "/ndmg_atlases/labels/Talairach.nii.gz"
+            ], 
+            "optional": true, 
+            "id": "talairach"
+        }, 
+        {
+            "name": "AAL parcellation", 
+            "value-key": "[AAL]", 
+            "type": "String", 
+            "value-choices": [
+                "/ndmg_atlases/labels/AAL.nii.gz"
+            ], 
+            "optional": true, 
+            "id": "aal"
+        }, 
+        {
+            "name": "Harvard-Oxford parcellation", 
+            "value-key": "[HARVARDOXFORD]", 
+            "type": "String", 
+            "value-choices": [
+                "/ndmg_atlases/labels/HarvardOxford.nii.gz"
+            ], 
+            "optional": true, 
+            "id": "harvardoxford"
+        }, 
+        {
+            "name": "CPAC200 parcellation", 
+            "value-key": "[CPAC200]", 
+            "type": "String", 
+            "value-choices": [
+                "/ndmg_atlases/labels/CPAC200.nii.gz"
+            ], 
+            "optional": true, 
+            "id": "cpac200"
+        }, 
+        {
+            "command-line-flag": "-c", 
+            "name": "Clean-up flag", 
+            "value-key": "[CLEAN]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "clean"
+        }
+    ], 
+    "container-image": {
+        "index": "index.docker.io", 
+        "image": "neurodata/ndmg:v0.1.0", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "groups": [
+        {
+            "one-is-required": true, 
+            "id": "parcellation_group", 
+            "members": [
+                "desikan", 
+                "jhu", 
+                "talairach", 
+                "aal", 
+                "harvardoxford", 
+                "cpac200"
+            ], 
+            "name": "Group of all used parcellations"
+        }
+    ], 
+    "output-files": [
+        {
+            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz", 
+            "optional": true, 
+            "id": "aligned_dti", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "Aligned DTI volume"
+        }, 
+        {
+            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz", 
+            "optional": true, 
+            "id": "tensors", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "Tensor maps"
+        }, 
+        {
+            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz", 
+            "optional": true, 
+            "id": "fibers", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "Fiber streamlines"
+        }, 
+        {
+            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle", 
+            "optional": true, 
+            "id": "desikan_graph", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "Desikan graph"
+        }, 
+        {
+            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle", 
+            "optional": true, 
+            "id": "jhu_graph", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "JHU graph"
+        }, 
+        {
+            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle", 
+            "optional": true, 
+            "id": "talairach_graph", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "Talairach graph"
+        }, 
+        {
+            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle", 
+            "optional": true, 
+            "id": "aal_graph", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "AAL graph"
+        }, 
+        {
+            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle", 
+            "optional": true, 
+            "id": "harvardoxford_graph", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "Harvard-Oxford graph"
+        }, 
+        {
+            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle", 
+            "optional": true, 
+            "id": "cpac200_graph", 
+            "path-template-stripped-extensions": [
+                ".nii", 
+                ".nii.gz"
+            ], 
+            "name": "CPAC200 graph"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 7400
+    }, 
+    "description": "dwi connectome estimation pipeline",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "dmri"
+        ]
+    }
+}

--- a/app/static/pipelines/zenodo-1451001.json
+++ b/app/static/pipelines/zenodo-1451001.json
@@ -1,0 +1,171 @@
+{
+    "author": "chrisfilo and others",
+    "command-line": "mkdir -p OUTPUT_DIR; /run.py BIDS_DIR OUTPUT_DIR ANALYSIS_LEVEL PARTICIPANT_LABEL SESSION_LABEL",
+    "container-image": {
+        "image": "bids/example",
+        "type": "docker"
+    },
+    "description": "See https://github.com/BIDS-Apps/example",
+    "descriptor-url": "https://github.com/BIDS-Apps/example/blob/master/boutiques/bids-app-example.json", 
+    "groups": [
+        {
+            "description": "For a participants analysis, an output directory name must be specified. For a group analysis, a directory containing the output of participant-level analyses must be selected. ",
+            "id": "output_directory",
+            "members": [
+                "output_dir_name",
+                "participant_level_analysis_dir"
+            ],
+            "mutually-exclusive": true,
+            "name": "Output Directory",
+            "one-is-required": true
+        }
+    ],
+    "inputs": [
+        {
+            "description": "The directory with the input dataset formatted according to the BIDS standard.",
+            "id": "bids_dir",
+            "name": "BIDS directory",
+            "optional": false,
+            "type": "File",
+            "value-key": "BIDS_DIR"
+        },
+        {
+            "description": "The directory where the output files should be stored. If you are running a group level analysis, this folder should be prepopulated with the results of the participant level analysis.",
+            "id": "output_dir_name",
+            "name": "Output directory name",
+            "optional": true,
+            "type": "String",
+            "value-key": "OUTPUT_DIR"
+        },
+        {
+            "description": "Directory containing the output of the participants analysis.",
+            "id": "participant_level_analysis_dir",
+            "name": "Participants dir",
+            "optional": true,
+            "type": "File",
+            "value-key": "OUTPUT_DIR"
+        },
+        {
+            "description": "Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel).",
+            "id": "analysis_level",
+            "name": "Analysis level",
+            "type": "String",
+            "value-choices": [
+                "participant",
+                "group"
+            ],
+            "value-key": "ANALYSIS_LEVEL"
+        },
+        {
+            "command-line-flag": "--participant_label",
+            "description": "The label(s) of the participant(s) that should be analyzed. The label corresponds to sub-<participant_label> from the BIDS spec (so it does not include \"sub-\"). If this parameter is not provided all subjects will be analyzed. Multiple participants can be specified with a space separated list.",
+            "id": "participant_label",
+            "list": true,
+            "name": "Participant label",
+            "optional": true,
+            "type": "String",
+            "value-key": "PARTICIPANT_LABEL"
+        },
+        {
+            "command-line-flag": "--session_label",
+            "description": "The label(s) of the session(s) that should be analyzed. The label corresponds to ses-<session_label>, an extension of the BIDS spec (so it does not include \"ses-\"). If this parameter is not provided all sessions will be analyzed. Multiple sessions can be specified with a space separated list.",
+            "id": "session_label",
+            "list": true,
+            "name": "Session label",
+            "optional": true,
+            "type": "String",
+            "value-key": "SESSION_LABEL"
+        }
+    ],
+    "invocation-schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "additionalProperties": false,
+        "allOf": [
+            {
+                "anyOf": [
+                    {
+                        "required": [
+                            "output_dir_name"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "participant_level_analysis_dir"
+                        ]
+                    }
+                ]
+            }
+        ],
+        "dependencies": {
+            "output_dir_name": {
+                "properties": {
+                    "participant_level_analysis_dir": {
+                        "not": {}
+                    }
+                }
+            },
+            "participant_level_analysis_dir": {
+                "properties": {
+                    "output_dir_name": {
+                        "not": {}
+                    }
+                }
+            }
+        },
+        "description": "Invocation schema for example.",
+        "properties": {
+            "analysis_level": {
+                "enum": [
+                    "participant",
+                    "group",
+                    "session"
+                ]
+            },
+            "bids_dir": {
+                "type": "string"
+            },
+            "output_dir_name": {
+                "type": "string"
+            },
+            "participant_label": {
+                "items": {
+                    "type": "string"
+                },
+                "type": "array"
+            },
+            "participant_level_analysis_dir": {
+                "type": "string"
+            },
+            "session_label": {
+                "items": {
+                    "type": "string"
+                },
+                "type": "array"
+            }
+        },
+        "required": [
+            "bids_dir",
+            "analysis_level"
+        ],
+        "title": "example.invocationSchema",
+        "type": "object"
+    },
+    "name": "BIDS app example",
+    "output-files": [
+        {
+            "description": "The directory where the output files should be stored. If you are running a group level analysis, this folder should be prepopulated with the results of the participant level analysis.",
+            "id": "output_dir",
+            "name": "Output directory",
+            "optional": false,
+            "path-template": "OUTPUT_DIR"
+        }
+    ],
+    "schema-version": "0.5",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "testing"
+        ]
+    },
+    "tool-version": "dev"
+}

--- a/app/static/pipelines/zenodo-1451003.json
+++ b/app/static/pipelines/zenodo-1451003.json
@@ -1,0 +1,241 @@
+{
+    "tool-version": "undefined", 
+    "name": "qeeg", 
+    "author": "Neuroinformatics Collaboratory", 
+    "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-eeg/blob/master/cbrain_task_descriptors/qeeg.json", 
+    "command-line": "qeegt.sh --input [input_directory]/[basename] --state [state] --lwin [lwin] --fmin [fmin] --freqres [freqres] --fmax [fmax] --wbands [wbands] [brain] [pg_apply] [bbsm] [nbsm] [spectra] [bbsmz] [nbsmz] [ssz] [corr] [cohe] [phdiff] [fcorr] [storexyz] --output \"results\" ", 
+    "inputs": [
+        {
+            "description": "Directory containing the files to process.", 
+            "value-key": "[input_directory]", 
+            "optional": false, 
+            "list": false, 
+            "type": "File", 
+            "id": "input_directory", 
+            "name": "Input directory"
+        }, 
+        {
+            "description": "Basename of the file to process in the input directory.", 
+            "value-key": "[basename]", 
+            "optional": false, 
+            "list": false, 
+            "type": "String", 
+            "id": "basename", 
+            "name": "Basename"
+        }, 
+        {
+            "description": "Example: \"A\". EEG state to be analyzed. The program will look for existing analysis windows labelled as state 'A' (Eyes Closed).", 
+            "default-value": "A", 
+            "value-key": "[state]", 
+            "optional": false, 
+            "list": false, 
+            "type": "String", 
+            "id": "state", 
+            "name": "State"
+        }, 
+        {
+            "description": "Length of the analysis window in seconds.", 
+            "default-value": 2.56, 
+            "value-key": "[lwin]", 
+            "optional": false, 
+            "list": false, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "lwin", 
+            "name": "Window length"
+        }, 
+        {
+            "description": "Low cut frequency for analysis. Example: \"0.390625\".", 
+            "default-value": 0.390625, 
+            "value-key": "[fmin]", 
+            "optional": false, 
+            "list": false, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "fmin", 
+            "name": "fmin"
+        }, 
+        {
+            "description": "Fequency resolution for analysis. Example: \"0.390625\". The analysis will use a frequency band like this: fmin:freqres:fmax. The program will compare this interval with the interval that is obtained for the real frequency parameters of the signal and will match both of them.", 
+            "default-value": 0.390625, 
+            "value-key": "[freqres]", 
+            "optional": false, 
+            "list": false, 
+            "type": "Number", 
+            "id": "freqres", 
+            "name": "freqres"
+        }, 
+        {
+            "description": "High cut frequency for analysis. Example: \"19.11\".", 
+            "default-value": 19.11, 
+            "value-key": "[fmax]", 
+            "optional": false, 
+            "list": false, 
+            "type": "Number", 
+            "id": "fmax", 
+            "name": "fmax"
+        }, 
+        {
+            "description": "Broad Bands definition. A string representing a 5x2 matrix of real numbers, where rows are separated by ';' and columns by spaces. Example: \"1.56 3.51; 3.9 7.41; 7.8 12.48; 12.87 19.11; 1.56 19.11\".", 
+            "default-value": "1.56 3.51; 3.9 7.41; 7.8 12.48; 12.87 19.11; 1.56 19.11", 
+            "value-key": "[wbands]", 
+            "optional": false, 
+            "list": false, 
+            "type": "String", 
+            "id": "wbands", 
+            "name": "wbands"
+        }, 
+        {
+            "command-line-flag": "--brain", 
+            "description": "Restricts the inverse solution to only gray matter. Otherwise, deep structure (basal ganglia) will be included in the grid.", 
+            "default-value": true, 
+            "value-key": "[brain]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "brain", 
+            "name": "Brain"
+        }, 
+        {
+            "command-line-flag": "--pg_apply", 
+            "description": "Substracts the Global Scale Factor (Geometric Power) from the EEG signal.", 
+            "default-value": true, 
+            "value-key": "[pg_apply]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "pg_apply", 
+            "name": "PG Apply"
+        }, 
+        {
+            "command-line-flag": "--bbsm", 
+            "description": "Calculates the Broad Band Spectral Model.", 
+            "default-value": true, 
+            "value-key": "[bbsm]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "bbsm", 
+            "name": "Broad Band Spectral Model"
+        }, 
+        {
+            "command-line-flag": "--nbsm", 
+            "description": "Calculates the Narrow Band Spectral Model.", 
+            "default-value": true, 
+            "value-key": "[nbsm]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "nbsm", 
+            "name": "Narrow Band Spectral Model"
+        }, 
+        {
+            "command-line-flag": "--spectra", 
+            "description": "Calculates the Spectra at the EEG sources.", 
+            "default-value": true, 
+            "value-key": "[spectra]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "spectra", 
+            "name": "Spectra"
+        }, 
+        {
+            "command-line-flag": "--bbsmz", 
+            "description": "Calculates the Broad Band Spectral Model Z values.", 
+            "default-value": true, 
+            "value-key": "[bbsmz]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "bbsmz", 
+            "name": "Broad Band Spectral Model Z values"
+        }, 
+        {
+            "command-line-flag": "--nbsmz", 
+            "description": "Calculates the Narrow Band Spectral Model Z values.", 
+            "default-value": true, 
+            "value-key": "[nbsmz]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "nbsmz", 
+            "name": "Narrow Band Spectral Model Z values"
+        }, 
+        {
+            "command-line-flag": "--ssz", 
+            "description": "Calculates the Sources Spectra Z values.", 
+            "default-value": true, 
+            "value-key": "[ssz]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "ssz", 
+            "name": "Source Spectra Z"
+        }, 
+        {
+            "command-line-flag": "--corr", 
+            "description": "Calculates the correlations matrix bewteen all pairs of channels for each epoch.", 
+            "default-value": true, 
+            "value-key": "[corr]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "corr", 
+            "name": "Correlations matrix"
+        }, 
+        {
+            "command-line-flag": "--cohe", 
+            "description": "Calculates the coherence matrix bewteen all pairs of channels for each frequency.", 
+            "default-value": true, 
+            "value-key": "[cohe]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "cohe", 
+            "name": "Coherence matrix"
+        }, 
+        {
+            "command-line-flag": "--phdiff", 
+            "description": "Calculates the phase difference matrix bewteen all pairs of channels for each frequency.", 
+            "default-value": true, 
+            "value-key": "[phdiff]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "phdiff", 
+            "name": "Phase difference matrix"
+        }, 
+        {
+            "command-line-flag": "--fcorr", 
+            "description": "Calculates  the frequency domain correlations bewteen all pairs of channels for each frequency and each epoch.", 
+            "default-value": true, 
+            "value-key": "[fcorr]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "fcorr", 
+            "name": "Frequency domain correlations"
+        }, 
+        {
+            "command-line-flag": "--storexyz", 
+            "description": "Stores the XYZ components of the solutions at the sources.", 
+            "default-value": true, 
+            "value-key": "[storexyz]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "storexyz", 
+            "name": "XYZ components"
+        }
+    ], 
+    "container-image": {
+        "image": "mcin/qeeg:latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "description": "A folder containing the output files.", 
+            "list": false, 
+            "id": "folder_out", 
+            "optional": false, 
+            "path-template": "results", 
+            "name": "Output folder"
+        }
+    ], 
+    "description": "qeeg application",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "eeg"
+        ]
+    }
+}

--- a/app/static/pipelines/zenodo-1482743.json
+++ b/app/static/pipelines/zenodo-1482743.json
@@ -1,0 +1,386 @@
+{
+    "tool-version": "1.0.0", 
+    "name": "fsl_bet", 
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_bet.json",
+    "command-line": "bet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [CENTER_OF_GRAVITY] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [VTK_VIEW_FLAG] [HEAD_RADIUS] [THRESHOLDING_FLAG] [ROBUST_ITERS_FLAG] [RES_OPTIC_CLEANUP_FLAG] [REDUCE_BIAS_FLAG] [SLICE_PADDING_FLAG] [MASK_WHOLE_SET_FLAG] [ADD_SURFACES_FLAG] [ADD_SURFACES_T2] [VERBOSE_FLAG] [DEBUG_FLAG]", 
+    "container-image": {
+        "image": "mcin/docker-fsl:latest", 
+        "index": "index.docker.io", 
+        "type": "docker"
+    }, 
+    "inputs": [
+        {
+            "description": "Input image (e.g. img.nii.gz)", 
+            "value-key": "[INPUT_FILE]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "infile", 
+            "name": "Input file"
+        }, 
+        {
+            "description": "Output brain mask (e.g. img_bet.nii.gz)", 
+            "value-key": "[MASK]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "maskfile", 
+            "name": "Mask file"
+        }, 
+        {
+            "command-line-flag": "-f", 
+            "description": "Fractional intensity threshold (0->1); default=0.5; smaller values give larger brain outline estimates", 
+            "value-key": "[FRACTIONAL_INTENSITY]", 
+            "type": "Number", 
+            "maximum": 1, 
+            "minimum": 0, 
+            "integer": false, 
+            "optional": true, 
+            "id": "fractional_intensity", 
+            "name": "Fractional intensity threshold"
+        }, 
+        {
+            "command-line-flag": "-g", 
+            "description": "Vertical gradient in fractional intensity threshold (-1->1); default=0; positive values give larger brain outline at bottom, smaller at top", 
+            "value-key": "[VERTICAL_GRADIENT]", 
+            "type": "Number", 
+            "maximum": 1, 
+            "minimum": -1, 
+            "integer": false, 
+            "optional": true, 
+            "id": "vg_fractional_intensity", 
+            "name": "Vertical gradient fractional intensity threshold"
+        }, 
+        {
+            "command-line-flag": "-c", 
+            "description": "The xyz coordinates of the center of gravity (voxels, not mm) of initial mesh surface. Must have exactly three numerical entries in the list (3-vector).", 
+            "value-key": "[CENTER_OF_GRAVITY]", 
+            "type": "Number", 
+            "list": true, 
+            "max-list-entries": 3, 
+            "optional": true, 
+            "id": "center_of_gravity", 
+            "min-list-entries": 3, 
+            "name": "Center of gravity vector"
+        }, 
+        {
+            "command-line-flag": "-o", 
+            "description": "Generate brain surface outline overlaid onto original image", 
+            "value-key": "[OVERLAY_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "overlay_flag", 
+            "name": "Overlay flag"
+        }, 
+        {
+            "command-line-flag": "-m", 
+            "description": "Generate binary brain mask", 
+            "value-key": "[BINARY_MASK_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "binary_mask_flag", 
+            "name": "Binary mask flag"
+        }, 
+        {
+            "command-line-flag": "-s", 
+            "description": "Generate rough skull image (not as clean as betsurf)", 
+            "value-key": "[APPROX_SKULL_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "approx_skull_flag", 
+            "name": "Approximate skull flag"
+        }, 
+        {
+            "command-line-flag": "-n", 
+            "description": "Don't generate segmented brain image output", 
+            "value-key": "[NO_SEG_OUTPUT_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "no_seg_output_flag", 
+            "name": "No segmented brain image flag"
+        }, 
+        {
+            "command-line-flag": "-e", 
+            "description": "Generate brain surface as mesh in .vtk format", 
+            "value-key": "[VTK_VIEW_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "vtk_mesh", 
+            "name": "VTK format brain surface mesh flag"
+        }, 
+        {
+            "command-line-flag": "-r", 
+            "description": "head radius (mm not voxels); initial surface sphere is set to half of this", 
+            "value-key": "[HEAD_RADIUS]", 
+            "type": "Number", 
+            "optional": true, 
+            "id": "head_radius", 
+            "name": "Head Radius"
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "Apply thresholding to segmented brain image and mask", 
+            "value-key": "[THRESHOLDING_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "thresholding_flag", 
+            "name": "Threshold segmented image flag"
+        }, 
+        {
+            "command-line-flag": "-R", 
+            "description": "More robust brain center estimation, by iterating BET with a changing center-of-gravity.", 
+            "value-key": "[ROBUST_ITERS_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "robust_iters_flag", 
+            "name": "Robust iterations flag"
+        }, 
+        {
+            "command-line-flag": "-S", 
+            "description": "This attempts to cleanup residual eye and optic nerve voxels which bet2 can sometimes leave behind. This can be useful when running SIENA or SIENAX, for example. Various stages involving standard-space masking, morphpological operations and thresholdings are combined to produce a result which can often give better results than just running bet2.", 
+            "value-key": "[RES_OPTIC_CLEANUP_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "residual_optic_cleanup_flag", 
+            "name": "Residual optic cleanup flag"
+        }, 
+        {
+            "command-line-flag": "-B", 
+            "description": "This attempts to reduce image bias, and residual neck voxels. This can be useful when running SIENA or SIENAX, for example. Various stages involving FAST segmentation-based bias field removal and standard-space masking are combined to produce a result which can often give better results than just running bet2.", 
+            "value-key": "[REDUCE_BIAS_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "reduce_bias_flag", 
+            "name": "Bias reduction flag"
+        }, 
+        {
+            "command-line-flag": "-Z", 
+            "description": "This can improve the brain extraction if only a few slices are present in the data (i.e., a small field of view in the Z direction). This is achieved by padding the end slices in both directions, copying the end slices several times, running bet2 and then removing the added slices.", 
+            "value-key": "[SLICE_PADDING_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "slice_padding_flag", 
+            "name": "Slice padding flag"
+        }, 
+        {
+            "command-line-flag": "-F", 
+            "description": "This option uses bet2 to determine a brain mask on the basis of the first volume in a 4D data set, and applies this to the whole data set. This is principally intended for use on FMRI data, for example to remove eyeballs. Because it is normally important (in this application) that masking be liberal (ie that there be little risk of cutting out valid brain voxels) the -f threshold is reduced to 0.3, and also the brain mask is \"dilated\" slightly before being used.", 
+            "value-key": "[MASK_WHOLE_SET_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "whole_set_mask_flag", 
+            "name": "Mask-whole-set flag"
+        }, 
+        {
+            "command-line-flag": "-A", 
+            "description": "This runs both bet2 and betsurf programs in order to get the additional skull and scalp surfaces created by betsurf. This involves registering to standard space in order to allow betsurf to find the standard space masks it needs.", 
+            "value-key": "[ADD_SURFACES_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "additional_surfaces_flag", 
+            "name": "Additional surfaces flag"
+        }, 
+        {
+            "command-line-flag": "-A2", 
+            "description": "This is the same as -A except that a T2 image is also input, to further improve the estimated skull and scalp surfaces. As well as carrying out the standard space registration this also registers the T2 to the T1 input image.", 
+            "value-key": "[ADD_SURFACES_T2]", 
+            "type": "File", 
+            "optional": true, 
+            "id": "additional_surfaces_t2", 
+            "name": "Additional surfaces with T2"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "description": "Switch on diagnostic messages", 
+            "value-key": "[VERBOSE_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "verbose_flag", 
+            "name": "Verbose Flag"
+        }, 
+        {
+            "command-line-flag": "-d", 
+            "description": "Don't delete temporary intermediate images", 
+            "value-key": "[DEBUG_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "debug_flag", 
+            "name": "Debug Flag"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "groups": [
+        {
+            "description": "Specify parameters that alter the default BET functionality", 
+            "id": "optional_params_group", 
+            "members": [
+                "fractional_intensity", 
+                "vg_fractional_intensity", 
+                "center_of_gravity", 
+                "overlay_flag", 
+                "binary_mask_flag", 
+                "approx_skull_flag", 
+                "no_seg_output_flag", 
+                "vtk_mesh", 
+                "head_radius", 
+                "thresholding_flag"
+            ], 
+            "name": "Main Program Parameters"
+        }, 
+        {
+            "description": "Mutually exclusive options that specify variations on how BET should be run.", 
+            "mutually-exclusive": true, 
+            "id": "variational_params_group", 
+            "members": [
+                "robust_iters_flag", 
+                "residual_optic_cleanup_flag", 
+                "reduce_bias_flag", 
+                "slice_padding_flag", 
+                "whole_set_mask_flag", 
+                "additional_surfaces_flag", 
+                "additional_surfaces_t2"
+            ], 
+            "name": "Variations on Default Functionality"
+        }, 
+        {
+            "description": "Optional miscellaneous parameters when running BET", 
+            "id": "miscellaneous_params_group", 
+            "members": [
+                "verbose_flag", 
+                "debug_flag"
+            ], 
+            "name": "Miscellaneous Parameters"
+        }
+    ], 
+    "output-files": [
+        {
+            "path-template": "[MASK].nii.gz", 
+            "description": "Main default mask output of BET", 
+            "optional": true, 
+            "id": "outfile", 
+            "name": "Output mask file"
+        }, 
+        {
+            "path-template": "[MASK]_mask.nii.gz", 
+            "description": "Binary mask file (from -m option)", 
+            "optional": true, 
+            "id": "binary_mask", 
+            "name": "Output binary mask file"
+        }, 
+        {
+            "path-template": "[MASK]_overlay.nii.gz", 
+            "description": "Overlaid brain surface onto original image", 
+            "optional": true, 
+            "id": "overlay_file", 
+            "name": "Surface overlay file"
+        }, 
+        {
+            "path-template": "[MASK]_skull.nii.gz", 
+            "description": "Approximate skull image file", 
+            "optional": true, 
+            "id": "approx_skull_img", 
+            "name": "Approximate skull file"
+        }, 
+        {
+            "path-template": "[MASK]_mesh.vtk", 
+            "description": "Mesh in VTK format", 
+            "optional": true, 
+            "id": "output_vtk_mesh", 
+            "name": "VTK mesh"
+        }, 
+        {
+            "path-template": "[MASK]_skull_mask.nii.gz", 
+            "description": "Output mask for skull image", 
+            "optional": true, 
+            "id": "skull_mask", 
+            "name": "Skull mask image"
+        }, 
+        {
+            "path-template": "[MASK]_inskull_mask.nii.gz", 
+            "description": "The in-skull mask file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_inskull_mask", 
+            "name": "Output in-skull mask file"
+        }, 
+        {
+            "path-template": "[MASK]_inskull_mesh.nii.gz", 
+            "description": "The in-skull mesh file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_inskull_mesh", 
+            "name": "Output in-skull mesh file"
+        }, 
+        {
+            "path-template": "[MASK]_inskull_mesh.off", 
+            "description": "The in-skull mesh .off file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_inskull_off", 
+            "name": "Output in-skull mesh off file"
+        }, 
+        {
+            "path-template": "[MASK]_outskin_mask.nii.gz", 
+            "description": "The out-skin mask file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskin_mask", 
+            "name": "Output out-skin mask file"
+        }, 
+        {
+            "path-template": "[MASK]_outskin_mesh.nii.gz", 
+            "description": "The out-skin mesh file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskin_mesh", 
+            "name": "Output out-skin mesh file"
+        }, 
+        {
+            "path-template": "[MASK]_outskin_mesh.off", 
+            "description": "The out-skin mesh .off file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskin_off", 
+            "name": "Output out-skin mesh off file"
+        }, 
+        {
+            "path-template": "[MASK]_outskull_mask.nii.gz", 
+            "description": "The out-skull mask file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskull_mask", 
+            "name": "Output out-skull mask file"
+        }, 
+        {
+            "path-template": "[MASK]_outskull_mesh.nii.gz", 
+            "description": "The out-skull mesh file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskull_mesh", 
+            "name": "Output out-skull mesh file"
+        }, 
+        {
+            "path-template": "[MASK]_outskull_mesh.off", 
+            "description": "The out-skull mesh .off file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskull_off", 
+            "name": "Output out-skull mesh off file"
+        }
+    ], 
+     "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    },
+    "tests": [
+            {
+             "name": "fsl_bet_test",
+             "invocation": {
+                    "infile": "sub-01_T1w.nii.gz",
+                    "maskfile": "img_bet"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "outfile",
+                            "md5-reference": "053507dd8605d62f5ba71dbecece17f8"
+                        }
+                    ]
+                }
+        }
+    ],
+    "description": "Automated brain extraction tool for FSL"
+}

--- a/app/static/pipelines/zenodo-1484547.json
+++ b/app/static/pipelines/zenodo-1484547.json
@@ -1,0 +1,483 @@
+{
+    "author": "Shawn T. Brown, McGill University <stbrown@mcin.ca>", 
+    "command-line": "mkdir -p [OUTPUT_DIR] ; /run.py [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [PARTICIPANT_LABEL] [SESSION_LABEL] [N_CPUS] [STAGES] [STEPS] [TEMPLATE_NAME] [LICENSE_FILE] [ACQUISITION_LABEL] [REFINE_PIAL_ACQUISITION_LABEL] [MULTIPLE_SESSIONS] [REFINE_PIAL] [HIRES_MODE] [PARCELLATIONS] [MEASUREMENTS] [VERSION] [BIDS_VALIDATOR_CONFIG] [SKIP_BIDS_VALIDATOR] [3T]", 
+    "container-image": {
+        "image": "shots47s/bids-freesurfer-6.0", 
+        "type": "singularity"
+    }, 
+    "description": "BIDS App version of freesurfer 6.0, from https://github.com/BIDS-Apps/freesurfer, see the readme there for more details, note it needs a license file to run", 
+    "groups": [
+        {
+            "description": "For a participants analysis, an output directory name must be specified. For a group analysis, a directory containing the output of participant-level analyses must be selected. ", 
+            "id": "output_directory", 
+            "members": [
+                "output_dir", 
+                "participant_level_analysis_dir"
+            ], 
+            "mutually-exclusive": true, 
+            "name": "Output Directory", 
+            "one-is-required": true
+        }
+    ], 
+    "inputs": [
+        {
+            "description": "The directory with the input dataset formatted according to the BIDS standard.", 
+            "id": "bids_dir", 
+            "name": "bids_dir", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[BIDS_DIR]"
+        }, 
+        {
+            "description": "The directory where the output files should be stored. If you are running group level analysis this folder should be prepopulated with the results of theparticipant level analysis.", 
+            "id": "output_dir", 
+            "name": "output_dir", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[OUTPUT_DIR]"
+        }, 
+        {
+            "description": "Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel) using the same output_dir. \"group1\" creates study specific group template. \"group2\" exports group stats tables for cortical parcellation, subcortical segmentation a table with euler numbers.", 
+            "id": "analysis_level", 
+            "name": "analysis_level", 
+            "optional": false, 
+            "type": "String", 
+            "value-choices": [
+                "participant", 
+                "group1", 
+                "group2"
+            ], 
+            "value-key": "[ANALYSIS_LEVEL]"
+        }, 
+        {
+            "command-line-flag": "--participant_label", 
+            "description": "The label of the participant that should be analyzed. The label corresponds to sub-<participant_label> from the BIDS spec (so it does not include \"sub-\"). If this parameter is not provided all subjects should be analyzed. Multiple participants can be specified with a space separated list.", 
+            "id": "participant_label", 
+            "list": true, 
+            "name": "participant_label", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[PARTICIPANT_LABEL]"
+        }, 
+        {
+            "command-line-flag": "--session_label", 
+            "description": "The label of the session that should be analyzed. The label corresponds to ses-<session_label> from the BIDS spec (so it does not include \"ses-\"). If this parameter is not provided all sessions should be analyzed. Multiple sessions can be specified with a space separated list.", 
+            "id": "session_label", 
+            "list": true, 
+            "name": "session_label", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[SESSION_LABEL]"
+        }, 
+        {
+            "command-line-flag": "--n_cpus", 
+            "default-value": 1, 
+            "description": "Number of CPUs/cores available to use.", 
+            "id": "n_cpus", 
+            "name": "n_cpus", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[N_CPUS]"
+        }, 
+        {
+            "command-line-flag": "--stages", 
+            "default-value": [
+                "autorecon-all"
+            ], 
+            "description": "Autorecon stages to run.", 
+            "id": "stages", 
+            "list": true, 
+            "name": "stages", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "autorecon1", 
+                "autorecon2", 
+                "autorecon2-cp", 
+                "autorecon2-wm", 
+                "autorecon-pial", 
+                "autorecon3", 
+                "autorecon-all", 
+                "all"
+            ], 
+            "value-key": "[STAGES]"
+        }, 
+        {
+            "command-line-flag": "--steps", 
+            "default-value": [
+                "cross-sectional", 
+                "template", 
+                "longitudinal"
+            ], 
+            "description": "Longitudinal pipeline steps to run.", 
+            "id": "steps", 
+            "list": true, 
+            "name": "steps", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "cross-sectional", 
+                "template", 
+                "longitudinal"
+            ], 
+            "value-key": "[STEPS]"
+        }, 
+        {
+            "command-line-flag": "--template_name", 
+            "default-value": "average", 
+            "description": "Name for the custom group level template generated for this dataset", 
+            "id": "template_name", 
+            "name": "template_name", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[TEMPLATE_NAME]"
+        }, 
+        {
+            "command-line-flag": "--license_file", 
+            "description": "Path to FreeSurfer license key file. To obtain it you need to register (for free) at https://surfer.nmr.mgh.harvard.edu/registration.html", 
+            "id": "license_file", 
+            "name": "license_file", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[LICENSE_FILE]"
+        }, 
+        {
+            "command-line-flag": "--acquisition_label", 
+            "description": "If the dataset contains multiple T1 weighted images from different acquisitions which one should be used? Corresponds to \"acq-<acquisition_label>\"", 
+            "id": "acquisition_label", 
+            "name": "acquisition_label", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[ACQUISITION_LABEL]"
+        }, 
+        {
+            "command-line-flag": "--refine_pial_acquisition_label", 
+            "description": "If the dataset contains multiple T2 or FLAIR weighted images from different acquisitions which one should be used? Corresponds to \"acq-<acquisition_label>\"", 
+            "id": "refine_pial_acquisition_label", 
+            "name": "refine_pial_acquisition_label", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[REFINE_PIAL_ACQUISITION_LABEL]"
+        }, 
+        {
+            "command-line-flag": "--multiple_sessions", 
+            "default-value": "longitudinal", 
+            "description": "For datasets with multiday sessions where you do not want to use the longitudinal pipeline, i.e., sessions were back-to-back, set this to multiday, otherwise sessions with T1w data will be considered independent sessions for longitudinal analysis.", 
+            "id": "multiple_sessions", 
+            "name": "multiple_sessions", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "longitudinal", 
+                "multiday"
+            ], 
+            "value-key": "[MULTIPLE_SESSIONS]"
+        }, 
+        {
+            "command-line-flag": "--refine_pial", 
+            "default-value": [
+                "T2"
+            ], 
+            "description": "If the dataset contains 3D T2 or T2 FLAIR weighted images (~1x1x1), these can be used to refine the pial surface. If you want to ignore these, specify None or  T1only to base surfaces on the T1 alone.", 
+            "id": "refine_pial", 
+            "name": "refine_pial", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "T2", 
+                "FLAIR", 
+                "None", 
+                "T1only"
+            ], 
+            "value-key": "[REFINE_PIAL]"
+        }, 
+        {
+            "command-line-flag": "--hires_mode", 
+            "default-value": "auto", 
+            "description": "Submilimiter (high resolution) processing. 'auto' - use only if <1.0mm data detected, 'enable' - force on, 'disable' - force off", 
+            "id": "hires_mode", 
+            "name": "hires_mode", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "auto", 
+                "enable", 
+                "disable"
+            ], 
+            "value-key": "[HIRES_MODE]"
+        }, 
+        {
+            "command-line-flag": "--parcellations", 
+            "default-value": [
+                "aparc"
+            ], 
+            "description": "Group2 option: cortical parcellation(s) to extract stats from.", 
+            "id": "parcellations", 
+            "list": true, 
+            "name": "parcellations", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "aparc", 
+                "aparc.a2009s"
+            ], 
+            "value-key": "[PARCELLATIONS]"
+        }, 
+        {
+            "command-line-flag": "--measurements", 
+            "default-value": [
+                "thickness"
+            ], 
+            "description": "Group2 option: cortical measurements to extract stats for.", 
+            "id": "measurements", 
+            "list": true, 
+            "name": "measurements", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "area", 
+                "volume", 
+                "thickness", 
+                "thicknessstd", 
+                "meancurv", 
+                "gauscurv", 
+                "foldind", 
+                "curvind"
+            ], 
+            "value-key": "[MEASUREMENTS]"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "default-value": "==SUPPRESS==", 
+            "description": "show program's version number and exit", 
+            "id": "version", 
+            "name": "version", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[VERSION]"
+        }, 
+        {
+            "command-line-flag": "--bids_validator_config", 
+            "description": "JSON file specifying configuration of bids-validator: See https://github.com/INCF/bids-validator for more info", 
+            "id": "bids_validator_config", 
+            "name": "bids_validator_config", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[BIDS_VALIDATOR_CONFIG]"
+        }, 
+        {
+            "command-line-flag": "--skip_bids_validator", 
+            "description": "skips bids validation", 
+            "id": "skip_bids_validator", 
+            "name": "skip_bids_validator", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[SKIP_BIDS_VALIDATOR]"
+        }, 
+        {
+            "command-line-flag": "--3T", 
+            "default-value": "true", 
+            "description": "enables the two 3T specific options that recon-all supports: nu intensity correction params, and the special schwartz atlas", 
+            "id": "3T", 
+            "name": "3T", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "value-key": "[3T]"
+        }, 
+        {
+            "description": "Directory containing the output of the participants analysis.", 
+            "id": "participant_level_analysis_dir", 
+            "name": "Participants dir", 
+            "optional": true, 
+            "type": "File", 
+            "value-key": "[OUTPUT_DIR]"
+        }
+    ], 
+    "invocation-schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#", 
+        "additionalProperties": false, 
+        "allOf": [
+            {
+                "anyOf": [
+                    {
+                        "required": [
+                            "output_dir"
+                        ]
+                    }, 
+                    {
+                        "required": [
+                            "participant_level_analysis_dir"
+                        ]
+                    }
+                ]
+            }
+        ], 
+        "dependencies": {
+            "output_dir": {
+                "properties": {
+                    "participant_level_analysis_dir": {
+                        "not": {}
+                    }
+                }
+            }, 
+            "participant_level_analysis_dir": {
+                "properties": {
+                    "output_dir": {
+                        "not": {}
+                    }
+                }
+            }
+        }, 
+        "description": "Invocation schema for tool name.", 
+        "properties": {
+            "3T": {
+                "enum": [
+                    "true", 
+                    "false"
+                ]
+            }, 
+            "acquisition_label": {
+                "type": "string"
+            }, 
+            "analysis_level": {
+                "enum": [
+                    "participant", 
+                    "group1", 
+                    "group2"
+                ]
+            }, 
+            "bids_dir": {
+                "type": "string"
+            }, 
+            "bids_validator_config": {
+                "type": "string"
+            }, 
+            "hires_mode": {
+                "enum": [
+                    "auto", 
+                    "enable", 
+                    "disable"
+                ]
+            }, 
+            "license_file": {
+                "type": "string"
+            }, 
+            "measurements": {
+                "items": {
+                    "enum": [
+                        "area", 
+                        "volume", 
+                        "thickness", 
+                        "thicknessstd", 
+                        "meancurv", 
+                        "gauscurv", 
+                        "foldind", 
+                        "curvind"
+                    ]
+                }, 
+                "type": "array"
+            }, 
+            "multiple_sessions": {
+                "enum": [
+                    "longitudinal", 
+                    "multiday"
+                ]
+            }, 
+            "n_cpus": {
+                "type": "number"
+            }, 
+            "output_dir": {
+                "type": "string"
+            }, 
+            "parcellations": {
+                "items": {
+                    "enum": [
+                        "aparc", 
+                        "aparc.a2009s"
+                    ]
+                }, 
+                "type": "array"
+            }, 
+            "participant_label": {
+                "items": {
+                    "type": "string"
+                }, 
+                "type": "array"
+            }, 
+            "participant_level_analysis_dir": {
+                "type": "string"
+            }, 
+            "refine_pial": {
+                "enum": [
+                    "T2", 
+                    "FLAIR", 
+                    "None", 
+                    "T1only"
+                ]
+            }, 
+            "refine_pial_acquisition_label": {
+                "type": "string"
+            }, 
+            "session_label": {
+                "items": {
+                    "type": "string"
+                }, 
+                "type": "array"
+            }, 
+            "skip_bids_validator": {
+                "type": "boolean"
+            }, 
+            "stages": {
+                "items": {
+                    "enum": [
+                        "autorecon1", 
+                        "autorecon2", 
+                        "autorecon2-cp", 
+                        "autorecon2-wm", 
+                        "autorecon-pial", 
+                        "autorecon3", 
+                        "autorecon-all", 
+                        "all"
+                    ]
+                }, 
+                "type": "array"
+            }, 
+            "steps": {
+                "items": {
+                    "enum": [
+                        "cross-sectional", 
+                        "template", 
+                        "longitudinal"
+                    ]
+                }, 
+                "type": "array"
+            }, 
+            "template_name": {
+                "type": "string"
+            }, 
+            "version": {
+                "type": "string"
+            }
+        }, 
+        "required": [
+            "bids_dir", 
+            "analysis_level", 
+            "license_file"
+        ], 
+        "title": "tool name.invocationSchema", 
+        "type": "object"
+    }, 
+    "name": "BIDS App - FreeSurfer 6.0", 
+    "schema-version": "0.5", 
+    "suggested-resources": {
+        "cpu-cores": 1, 
+        "ram": 1, 
+        "walltime-estimate": 60
+    }, 
+    "tags": {}, 
+    "tool-version": "v6.0.0"
+}

--- a/app/static/pipelines/zenodo-1494308.json
+++ b/app/static/pipelines/zenodo-1494308.json
@@ -1,0 +1,276 @@
+{
+    "tool-version": "5.0.0", 
+    "name": "fsl_fast", 
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_fast.json",
+    "command-line": "fast [NUM_CLASSES] [LOOP_ITERS] [BF_SMOOTHING] [IMG_TYPE] [INIT_SEG_SMOOTHNESS] [BINARY_SEGMENTS] [PRIOR_INIT] [NO_PVE] [BIAS_FIELD] [BIAS_CORR_IMG] [NO_BIAS_RM] [OUTPUT_BASENAME] [PRIORS_THROUGHOUT] [SEG_INIT_ITERS] [MIXEL_SMOOTHNESS] [NUM_MAIN_LOOP_ITERS] [HYPER_SEG_SMOOTHNESS] [VERBOSE] [MANUAL_INTENSITIES_FILE] [OUTPUT_PROB_MAPS] [IN_FILES]; mkdir [OUTPUT_DIRECTORY]; mv [OUTPUT_DIRECTORY]_* [OUTPUT_DIRECTORY]", 
+    "container-image": {
+        "image": "mcin/docker-fsl:latest", 
+        "index": "index.docker.io", 
+        "type": "docker"
+    }, 
+    "inputs": [
+        {
+            "command-line-flag": "-n", 
+            "description": "Number of tissue-type classes; default = 3.", 
+            "value-key": "[NUM_CLASSES]", 
+            "type": "Number", 
+            "list": false, 
+            "minimum": 1, 
+            "integer": true, 
+            "optional": true, 
+            "id": "num_classes", 
+            "name": "Number of tissue-type classes"
+        }, 
+        {
+            "command-line-flag": "-I", 
+            "description": "Number of main-loop iterations during bias-field removal (default = 4).", 
+            "value-key": "[LOOP_ITERS]", 
+            "type": "Number", 
+            "list": false, 
+            "minimum": 1, 
+            "integer": true, 
+            "optional": true, 
+            "id": "loop_iters", 
+            "name": "Bias removal main-loop iterations"
+        }, 
+        {
+            "command-line-flag": "-l", 
+            "description": "Bias field smoothing extent (FWHM) in mm (default = 20).", 
+            "value-key": "[BF_SMOOTHING]", 
+            "optional": true, 
+            "list": false, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "bf_smoothing", 
+            "name": "Bias field smoothing"
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "Type of image: 1 = T1, 2 = T2, 3 = PD. Default = T1.", 
+            "value-key": "[IMG_TYPE]", 
+            "type": "String", 
+            "list": false, 
+            "value-choices": [
+                "1", 
+                "2", 
+                "3"
+            ], 
+            "optional": true, 
+            "id": "img_type", 
+            "name": "Image type"
+        }, 
+        {
+            "command-line-flag": "-f", 
+            "description": "Initial segmentation spatial smoothness (during bias field estimation); default = 0.02.", 
+            "value-key": "[INIT_SEG_SMOOTHNESS]", 
+            "type": "Number", 
+            "list": false, 
+            "optional": true, 
+            "id": "init_seg_smoothness", 
+            "name": "Initial segmentation smoothness"
+        }, 
+        {
+            "command-line-flag": "-g", 
+            "description": "Outputs a separate binary image for each tissue type", 
+            "value-key": "[BINARY_SEGMENTS]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "binary_segments", 
+            "name": "Binary images"
+        }, 
+        {
+            "command-line-flag": "-a", 
+            "description": "Initialize using priors. A FLIRT transform must be provided (e.g. std2input.mat)", 
+            "value-key": "[PRIOR_INIT]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "prior_init", 
+            "name": "Prior Initialization"
+        }, 
+        {
+            "command-line-flag": "--nopve", 
+            "description": "Turn off PVE (partial volume estimation).", 
+            "value-key": "[NO_PVE]", 
+            "optional": true, 
+            "list": false, 
+            "type": "Flag", 
+            "id": "no_pve", 
+            "name": "No PVE"
+        }, 
+        {
+            "command-line-flag": "-b", 
+            "description": "Output estimated bias field.", 
+            "value-key": "[BIAS_FIELD]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "bias_field", 
+            "name": "Bias field"
+        }, 
+        {
+            "command-line-flag": "-B", 
+            "description": "Output bias corrected image.", 
+            "value-key": "[BIAS_CORR_IMG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "bias_corr_img", 
+            "name": "Bias corrected image"
+        }, 
+        {
+            "command-line-flag": "-N", 
+            "description": "Does not remove the bias field.", 
+            "value-key": "[NO_BIAS_RM]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_bias_rm", 
+            "name": "No bias removal"
+        }, 
+        {
+            "command-line-flag": "-o", 
+            "description": "The basename of the output files.", 
+            "default-value": "fast", 
+            "value-key": "[OUTPUT_BASENAME]", 
+            "type": "String", 
+            "list": false, 
+            "optional": false, 
+            "id": "output_basename", 
+            "name": "Output basename"
+        }, 
+        {
+            "command-line-flag": "-P", 
+            "description": "Use priors throughout the process", 
+            "value-key": "[PRIORS_THROUGHOUT]", 
+            "type": "Flag", 
+            "list": false, 
+            "requires-inputs": [
+                "prior_init"
+            ], 
+            "optional": true, 
+            "id": "priors_throughout", 
+            "name": "Use priors throughout"
+        }, 
+        {
+            "command-line-flag": "-W", 
+            "description": "Number of segmentation-initialisation iterations; default = 15.", 
+            "value-key": "[SEG_INIT_ITERS]", 
+            "optional": true, 
+            "list": false, 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "seg_init_iters", 
+            "name": "Segmentation initialization iterations"
+        }, 
+        {
+            "command-line-flag": "-R", 
+            "description": "Spatial smoothness of mixeltype; default = 0.3.", 
+            "value-key": "[MIXEL_SMOOTHNESS]", 
+            "type": "Number", 
+            "list": false, 
+            "optional": true, 
+            "id": "mixel_smoothness", 
+            "name": "Mixeltype Smoothness"
+        }, 
+        {
+            "command-line-flag": "-O", 
+            "description": "Number of main-loop iterations after bias-field removal (default = 4).", 
+            "value-key": "[NUM_MAIN_LOOP_ITERS]", 
+            "optional": true, 
+            "list": false, 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "num_main_loop_iters", 
+            "name": "Main loop iterations"
+        }, 
+        {
+            "command-line-flag": "-H", 
+            "description": "Segmentation spatial smoothness; default = 0.1.", 
+            "value-key": "[HYPER_SEG_SMOOTHNESS]", 
+            "type": "Number", 
+            "list": false, 
+            "optional": true, 
+            "id": "hyper_seg_smoothness", 
+            "name": "Segmentation spatial smoothness"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "description": "Verbose mode", 
+            "value-key": "[VERBOSE]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "verbose", 
+            "name": "Verbose"
+        }, 
+        {
+            "command-line-flag": "-s", 
+            "description": "Filename containing the intensities", 
+            "value-key": "[MANUAL_INTENSITIES_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "manual_intensities_file", 
+            "name": "Manual segmentation"
+        }, 
+        {
+            "command-line-flag": "-p", 
+            "description": "Output individual probability maps", 
+            "value-key": "[OUTPUT_PROB_MAPS]", 
+            "optional": true, 
+            "list": false, 
+            "type": "Flag", 
+            "id": "output_prob_maps", 
+            "name": "Single probability maps"
+        }, 
+        {
+            "description": "Input file", 
+            "value-key": "[IN_FILES]", 
+            "type": "File", 
+            "list": false, 
+            "optional": false, 
+            "id": "in_files", 
+            "name": "Input file"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "description": "Output files from FSL FAST", 
+            "value-key": "[OUTPUT_DIRECTORY]", 
+            "id": "output_dir", 
+            "optional": false, 
+            "path-template": "[OUTPUT_BASENAME]", 
+            "name": "Output Directory"
+        }
+    ], 
+    "tests": [
+            {
+             "name": "fsl_fast_test",
+             "invocation": {
+                    "in_files": "sub-01_T1w.nii.gz",
+                    "output_basename": "img_fast"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "output_dir"
+                        }
+                    ]
+                }
+        }
+    ],
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "mri"
+        ]
+    },
+    "description": "FAST (FMRIB's Automated Segmentation Tool) segments a 3D image of the brain into different tissue types (Grey Matter, White Matter, CSF, etc.), whilst also correcting for spatial intensity variations (also known as bias field or RF inhomogeneities), via a hidden Markov random field model and an associated EM algorithm. Note that the alternative priors option is not supported at this time."
+}

--- a/app/static/pipelines/zenodo-1494312.json
+++ b/app/static/pipelines/zenodo-1494312.json
@@ -1,0 +1,138 @@
+{
+    "tool-version": "5.0.0",
+    "name": "fsl_first",
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_first.json",
+    "command-line": "mkdir -p [OUTPUT_DIR]; run_first_all [METHOD] [BRAIN_EXTRACTED] [SPECIFIED_STRUCTURE] [AFFINE] [THREE_STAGE] [VERBOSE] [INPUT_FILE] -o [OUTPUT_DIR]/[PREFIX]",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest", 
+        "index": "index.docker.io", 
+        "type": "docker"
+    },
+    "inputs": [
+        {
+            "command-line-flag": "-m",
+            "description": "Method must be one of 'auto' (default), 'fast', 'none', or it can be a numerical threshold value. This specifies the boundary correction method. Auto chooses different options for different structures using the settings that were found to be empirically optimal for each structure. Other options use: fast (using FAST-based, mixture-model, tissue-type classification) or threshold (thresholds a simple single-Gaussian intensity model).",
+            "value-key": "[METHOD]",
+            "type": "String",
+            "list": false,
+            "optional": true,
+            "id": "method",
+            "name": "Method"
+        },
+        {
+            "command-line-flag": "-i",
+            "description": "Input image file (e.g. img.nii.gz).",
+            "value-key": "[INPUT_FILE]",
+            "type": "File",
+            "list": false,
+            "optional": false,
+            "id": "input_file",
+            "name": "Input file"
+        },
+        {
+            "command-line-flag": "-b",
+            "description": "Whether the input is already brain extracted.",
+            "value-key": "[BRAIN_EXTRACTED]",
+            "type": "Flag",
+            "list": false,
+            "optional": true,
+            "id": "brain_extracted",
+            "name": "Brain extracted"
+        },
+        {
+            "command-line-flag": "-s",
+            "description": "Run only on one specified structure (e.g. L_Hipp) or a comma-separated list (no spaces). Choose from: 'L_Hipp', 'R_Hipp', 'L_Accu', 'R_Accu', 'L_Amyg', 'R_Amyg', 'L_Caud', 'R_Caud', 'L_Pall', 'R_Pall', 'L_Puta', 'R_Puta', 'L_Thal', 'R_Thal', 'BrStem'.",
+            "value-key": "[SPECIFIED_STRUCTURE]",
+            "type": "String",
+            "list": false,
+            "optional": true,
+            "id": "specified_structure",
+            "name": "Specify structure"
+        },
+        {
+            "command-line-flag": "-a",
+            "description": "Use affine matrix (i.e. do not re-run registration).",
+            "value-key": "[AFFINE]",
+            "type": "File",
+            "list": false,
+            "optional": true,
+            "id": "affine",
+            "name": "Use Affine Matrix"
+        },
+        {
+            "command-line-flag": "-3",
+            "description": "Use 3-stage affine registration. Only currently implemented for the hippocampus.",
+            "value-key": "[THREE_STAGE]",
+            "type": "Flag",
+            "list": false,
+            "optional": true,
+            "id": "three_stage",
+            "name": "Three stage registration"
+        },
+        {
+            "command-line-flag": "-v",
+            "description": "Verbose output.",
+            "value-key": "[VERBOSE]",
+            "type": "Flag",
+            "list": false,
+            "optional": true,
+            "id": "verbose",
+            "name": "Verbose"
+        },
+        {
+            "description": "Prefix for each files in the directory output.",
+            "value-key": "[PREFIX]",
+            "type": "String",
+            "optional": false,
+            "list": false,
+            "default-value": "output",
+            "id": "prefix",
+            "name": "Prefix"
+        }
+    ],
+    "schema-version": "0.5",
+    "output-files": [
+	{
+	"id": "outputs",
+	"name": "First Outputs",
+	"description": "Output directory of First",
+	"value-key": "[OUTPUT_DIR]",
+	"path-template": "[INPUT_FILE]",
+	"list": false,
+	"path-template-stripped-extensions": [".nii.gz", ".nii"]
+	},
+        {
+        "id": "std_sub_outputs",
+        "name": "Registered outputs",
+        "description": "Std sub output",
+        "path-template": "[INPUT_FILE]_to_std_sub*",
+        "list": true,
+        "path-template-stripped-extensions": [".nii.gz", ".nii"]
+        }
+    ],
+    "tests": [
+            {
+             "name": "fsl_first_test",
+             "invocation": {
+                    "input_file": "sub-01_T1w.nii.gz",
+                    "prefix": "img_first"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "outputs"
+                        }
+                    ]
+                }
+        }
+    ],
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    }, 
+    "description": "FIRST is a model-based segmentation and registration tool, based on a Bayesian model of shape and appearance for subcortical structures."
+}

--- a/app/static/pipelines/zenodo-1895219.json
+++ b/app/static/pipelines/zenodo-1895219.json
@@ -1,0 +1,480 @@
+{
+    "command-line": "fmriprep [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [VERSION] [PARTICIPANT_LABEL] [TASK_ID] [NTHREADS] [OMP_NTHREADS] [MEM_MB] [LOW_MEM] [USE_PLUGIN] [ANAT_ONLY] [BOILERPLATE] [IGNORE_AROMA_DENOISING_ERRORS] [VERBOSE_COUNT] [DEBUG] [IGNORE] [LONGITUDINAL] [T2S_COREG] [BOLD2T1W_DOF] [OUTPUT_SPACE] [USE_BBR] [TEMPLATE] [OUTPUT_GRID_REFERENCE] [TEMPLATE_RESAMPLING_GRID] [MEDIAL_SURFACE_NAN] [USE_AROMA] [AROMA_MELODIC_DIMENSIONALITY] [SKULL_STRIP_TEMPLATE] [SKULL_STRIP_FIXED_SEED] [FMAP_BSPLINE] [FMAP_NO_DEMEAN] [USE_SYN_SDC] [FORCE_SYN] [FS_LICENSE_FILE] [HIRES] [CIFTI_OUTPUT] [RUN_RECONALL] [WORK_DIR] [RESOURCE_MONITOR] [REPORTS_ONLY] [RUN_UUID] [WRITE_GRAPH] [STOP_ON_FIRST_CRASH] [NOTRACK] [SLOPPY]", 
+    "description": "fMRIprep is a functional magneticresonance image pre-processing pipeline that is designed to provide an easily accessible, state-of-the-art interface that is robust to differences in scan acquisition protocols and that requires minimal user input, while providing easily interpretable and comprehensive error and output reporting. https://fmriprep.readthedocs.io", 
+    "author": "Poldrack lab",
+    "url": "https://fmriprep.readthedocs.io",
+    "inputs": [
+        {
+            "description": "the root folder of a BIDS valid dataset (sub-XXXXX folders should be found at the top level in this folder).", 
+            "id": "bids_dir", 
+            "name": "bids_dir", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[BIDS_DIR]"
+        }, 
+        {
+            "description": "the output path for the outcomes of preprocessing and visual reports", 
+            "id": "output_dir", 
+            "name": "output_dir", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[OUTPUT_DIR]"
+        }, 
+        {
+            "description": "processing stage to be run, only \"participant\" in the case of FMRIPREP (see BIDS-Apps specification).", 
+            "id": "analysis_level", 
+            "name": "analysis_level", 
+            "optional": false, 
+            "type": "String", 
+            "value-choices": [
+                "participant"
+            ], 
+            "value-key": "[ANALYSIS_LEVEL]"
+        }, 
+        {
+            "command-line-flag": "--version", 
+            "default-value": "==SUPPRESS==", 
+            "description": "show program's version number and exit", 
+            "id": "version", 
+            "name": "version", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[VERSION]"
+        }, 
+        {
+            "command-line-flag": "--participant_label", 
+            "description": "a space delimited list of participant identifiers or a single identifier (the sub- prefix can be removed)", 
+            "id": "participant_label", 
+            "list": true, 
+            "name": "participant_label", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[PARTICIPANT_LABEL]"
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "select a specific task to be processed", 
+            "id": "task_id", 
+            "name": "task_id", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[TASK_ID]"
+        }, 
+        {
+            "command-line-flag": "--nthreads", 
+            "description": "maximum number of threads across all processes", 
+            "id": "nthreads", 
+            "name": "nthreads", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[NTHREADS]"
+        }, 
+        {
+            "command-line-flag": "--omp-nthreads", 
+            "description": "maximum number of threads per-process", 
+            "id": "omp_nthreads", 
+            "name": "omp_nthreads", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[OMP_NTHREADS]"
+        }, 
+        {
+            "command-line-flag": "--mem_mb", 
+            "description": "upper bound memory limit for FMRIPREP processes", 
+            "id": "mem_mb", 
+            "name": "mem_mb", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[MEM_MB]"
+        }, 
+        {
+            "command-line-flag": "--low-mem", 
+            "description": "attempt to reduce memory usage (will increase disk usage in working directory)", 
+            "id": "low_mem", 
+            "name": "low_mem", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[LOW_MEM]"
+        }, 
+        {
+            "command-line-flag": "--use-plugin", 
+            "description": "nipype plugin configuration file", 
+            "id": "use_plugin", 
+            "name": "use_plugin", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[USE_PLUGIN]"
+        }, 
+        {
+            "command-line-flag": "--anat-only", 
+            "description": "run anatomical workflows only", 
+            "id": "anat_only", 
+            "name": "anat_only", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[ANAT_ONLY]"
+        }, 
+        {
+            "command-line-flag": "--boilerplate", 
+            "description": "generate boilerplate only", 
+            "id": "boilerplate", 
+            "name": "boilerplate", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[BOILERPLATE]"
+        }, 
+        {
+            "command-line-flag": "--ignore-aroma-denoising-errors", 
+            "description": "ignores the errors ICA_AROMA returns when there are no components classified as either noise or signal", 
+            "id": "ignore_aroma_denoising_errors", 
+            "name": "ignore_aroma_denoising_errors", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[IGNORE_AROMA_DENOISING_ERRORS]"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "description": "increases log verbosity for each occurence, debug level is -vvv", 
+            "id": "verbose_count", 
+            "name": "verbose_count", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[VERBOSE_COUNT]"
+        }, 
+        {
+            "command-line-flag": "--debug", 
+            "description": "DEPRECATED - Does not do what you want.", 
+            "id": "debug", 
+            "name": "debug", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[DEBUG]"
+        }, 
+        {
+            "command-line-flag": "--ignore", 
+            "description": "ignore selected aspects of the input dataset to disable corresponding parts of the workflow (a space delimited list)", 
+            "id": "ignore", 
+            "list": true, 
+            "name": "ignore", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "fieldmaps", 
+                "slicetiming", 
+                "sbref"
+            ], 
+            "value-key": "[IGNORE]"
+        }, 
+        {
+            "command-line-flag": "--longitudinal", 
+            "description": "treat dataset as longitudinal - may increase runtime", 
+            "id": "longitudinal", 
+            "name": "longitudinal", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[LONGITUDINAL]"
+        }, 
+        {
+            "command-line-flag": "--t2s-coreg", 
+            "description": "If provided with multi-echo BOLD dataset, create T2*-map and perform T2*-driven coregistration. When multi-echo data is provided and this option is not enabled, standard EPI-T1 coregistration is performed using the middle echo.", 
+            "id": "t2s_coreg", 
+            "name": "t2s_coreg", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[T2S_COREG]"
+        }, 
+        {
+            "command-line-flag": "--bold2t1w-dof", 
+            "default-value": 6, 
+            "description": "Degrees of freedom when registering BOLD to T1w images. 6 degrees (rotation and translation) are used by default.", 
+            "id": "bold2t1w_dof", 
+            "name": "bold2t1w_dof", 
+            "optional": true, 
+            "type": "Number", 
+            "value-choices": [
+                6, 
+                9, 
+                12
+            ], 
+            "value-key": "[BOLD2T1W_DOF]"
+        }, 
+        {
+            "command-line-flag": "--output-space", 
+            "default-value": [
+                "template", 
+                "fsaverage5"
+            ], 
+            "description": "volume and surface spaces to resample functional series into\n - T1w: subject anatomical volume\n - template: normalization target specified by --template\n - fsnative: individual subject surface\n - fsaverage*: FreeSurfer average meshes\nthis argument can be single value or a space delimited list,\nfor example: --output-space T1w fsnative", 
+            "id": "output_space", 
+            "list": true, 
+            "name": "output_space", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "T1w", 
+                "template", 
+                "fsnative", 
+                "fsaverage", 
+                "fsaverage6", 
+                "fsaverage5"
+            ], 
+            "value-key": "[OUTPUT_SPACE]"
+        }, 
+        {
+            "command-line-flag": "--force-bbr", 
+            "description": "Always use boundary-based registration (no goodness-of-fit checks)", 
+            "id": "use_bbr", 
+            "name": "use_bbr", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[USE_BBR]"
+        }, 
+        {
+            "command-line-flag": "--template", 
+            "default-value": "MNI152NLin2009cAsym", 
+            "description": "volume template space (default: MNI152NLin2009cAsym)", 
+            "id": "template", 
+            "name": "template", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "MNI152NLin2009cAsym"
+            ], 
+            "value-key": "[TEMPLATE]"
+        }, 
+        {
+            "command-line-flag": "--output-grid-reference", 
+            "description": "Deprecated after FMRIPREP 1.0.8. Please use --template-resampling-grid instead.", 
+            "id": "output_grid_reference", 
+            "name": "output_grid_reference", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[OUTPUT_GRID_REFERENCE]"
+        }, 
+        {
+            "command-line-flag": "--template-resampling-grid", 
+            "default-value": "native", 
+            "description": "Keyword (\"native\", \"1mm\", or \"2mm\") or path to an existing file. Allows to define a reference grid for the resampling of BOLD images in template space. Keyword \"native\" will use the original BOLD grid as reference. Keywords \"1mm\" and \"2mm\" will use the corresponding isotropic template resolutions. If a path is given, the grid of that image will be used. It determines the field of view and resolution of the output images, but is not used in normalization.", 
+            "id": "template_resampling_grid", 
+            "name": "template_resampling_grid", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[TEMPLATE_RESAMPLING_GRID]"
+        }, 
+        {
+            "command-line-flag": "--medial-surface-nan", 
+            "description": "Replace medial wall values with NaNs on functional GIFTI files. Only performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).", 
+            "id": "medial_surface_nan", 
+            "name": "medial_surface_nan", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[MEDIAL_SURFACE_NAN]"
+        }, 
+        {
+            "command-line-flag": "--use-aroma", 
+            "description": "add ICA_AROMA to your preprocessing stream", 
+            "id": "use_aroma", 
+            "name": "use_aroma", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[USE_AROMA]"
+        }, 
+        {
+            "command-line-flag": "--aroma-melodic-dimensionality", 
+            "default-value": -200, 
+            "description": "Exact or maximum number of MELODIC components to estimate (positive = exact, negative = maximum)", 
+            "id": "aroma_melodic_dimensionality", 
+            "name": "aroma_melodic_dimensionality", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[AROMA_MELODIC_DIMENSIONALITY]"
+        }, 
+        {
+            "command-line-flag": "--skull-strip-template", 
+            "default-value": "OASIS", 
+            "description": "select ANTs skull-stripping template (default: OASIS))", 
+            "id": "skull_strip_template", 
+            "name": "skull_strip_template", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "OASIS", 
+                "NKI"
+            ], 
+            "value-key": "[SKULL_STRIP_TEMPLATE]"
+        }, 
+        {
+            "command-line-flag": "--skull-strip-fixed-seed", 
+            "description": "do not use a random seed for skull-stripping - will ensure run-to-run replicability when used with --omp-nthreads 1", 
+            "id": "skull_strip_fixed_seed", 
+            "name": "skull_strip_fixed_seed", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[SKULL_STRIP_FIXED_SEED]"
+        }, 
+        {
+            "command-line-flag": "--fmap-bspline", 
+            "description": "fit a B-Spline field using least-squares (experimental)", 
+            "id": "fmap_bspline", 
+            "name": "fmap_bspline", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[FMAP_BSPLINE]"
+        }, 
+        {
+            "command-line-flag": "--fmap-no-demean", 
+            "default-value": true, 
+            "description": "do not remove median (within mask) from fieldmap", 
+            "id": "fmap_no_demean", 
+            "name": "fmap_no_demean", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[FMAP_NO_DEMEAN]"
+        }, 
+        {
+            "command-line-flag": "--use-syn-sdc", 
+            "description": "EXPERIMENTAL: Use fieldmap-free distortion correction", 
+            "id": "use_syn_sdc", 
+            "name": "use_syn_sdc", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[USE_SYN_SDC]"
+        }, 
+        {
+            "command-line-flag": "--force-syn", 
+            "description": "EXPERIMENTAL/TEMPORARY: Use SyN correction in addition to fieldmap correction, if available", 
+            "id": "force_syn", 
+            "name": "force_syn", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[FORCE_SYN]"
+        }, 
+        {
+            "command-line-flag": "--fs-license-file", 
+            "description": "Path to FreeSurfer license key file. Get it (for free) by registering at https://surfer.nmr.mgh.harvard.edu/registration.html", 
+            "id": "fs_license_file", 
+            "name": "fs_license_file", 
+            "optional": true, 
+            "uses-absolute-path": true,
+            "type": "File", 
+            "value-key": "[FS_LICENSE_FILE]"
+        }, 
+        {
+            "command-line-flag": "--no-submm-recon", 
+            "default-value": true, 
+            "description": "disable sub-millimeter (hires) reconstruction", 
+            "id": "hires", 
+            "name": "hires", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[HIRES]"
+        }, 
+        {
+            "command-line-flag": "--cifti-output", 
+            "description": "output BOLD files as CIFTI dtseries", 
+            "id": "cifti_output", 
+            "name": "cifti_output", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[CIFTI_OUTPUT]"
+        }, 
+        {
+            "command-line-flag": "--fs-no-reconall", 
+            "default-value": true, 
+            "description": "disable FreeSurfer surface preprocessing. Note : `--no-freesurfer` is deprecated and will be removed in 1.2. Use `--fs-no-reconall` instead.", 
+            "id": "run_reconall", 
+            "name": "run_reconall", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[RUN_RECONALL]"
+        }, 
+        {
+            "command-line-flag": "-w", 
+            "description": "path where intermediate results should be stored", 
+            "id": "work_dir", 
+            "name": "work_dir", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[WORK_DIR]"
+        }, 
+        {
+            "command-line-flag": "--resource-monitor", 
+            "description": "enable Nipype's resource monitoring to keep track of memory and CPU usage", 
+            "id": "resource_monitor", 
+            "name": "resource_monitor", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[RESOURCE_MONITOR]"
+        }, 
+        {
+            "command-line-flag": "--reports-only", 
+            "description": "only generate reports, don't run workflows. This will only rerun report aggregation, not reportlet generation for specific nodes.", 
+            "id": "reports_only", 
+            "name": "reports_only", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[REPORTS_ONLY]"
+        }, 
+        {
+            "command-line-flag": "--run-uuid", 
+            "description": "Specify UUID of previous run, to include error logs in report. No effect without --reports-only.", 
+            "id": "run_uuid", 
+            "name": "run_uuid", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[RUN_UUID]"
+        }, 
+        {
+            "command-line-flag": "--write-graph", 
+            "description": "Write workflow graph.", 
+            "id": "write_graph", 
+            "name": "write_graph", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[WRITE_GRAPH]"
+        }, 
+        {
+            "command-line-flag": "--stop-on-first-crash", 
+            "description": "Force stopping on first crash, even if a work directory was specified.", 
+            "id": "stop_on_first_crash", 
+            "name": "stop_on_first_crash", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[STOP_ON_FIRST_CRASH]"
+        }, 
+        {
+            "command-line-flag": "--notrack", 
+            "description": "Opt-out of sending tracking information of this run to the FMRIPREP developers. This information helps to improve FMRIPREP and provides an indicator of real world usage crucial for obtaining funding.", 
+            "id": "notrack", 
+            "name": "notrack", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[NOTRACK]"
+        }, 
+        {
+            "command-line-flag": "--sloppy", 
+            "description": "Use low-quality tools for speed - TESTING ONLY", 
+            "id": "sloppy", 
+            "name": "sloppy", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[SLOPPY]"
+        }
+    ], 
+    "name": "BIDS App - fmriprep", 
+    "schema-version": "0.5", 
+    "tags": {
+        "application-type": [
+            "bids"
+        ], 
+        "domain": [
+            "neuroinformatics", 
+            "fmri"
+        ]
+    }, 
+        "container-image": {
+        "type": "docker",
+        "image": "poldracklab/fmriprep:1.2.3"
+     },
+    "tool-version": "1.2.3"
+}

--- a/app/static/pipelines/zenodo-2541125.json
+++ b/app/static/pipelines/zenodo-2541125.json
@@ -1,0 +1,414 @@
+{
+    "command-line": "$BEST_DIR/run_BEst.sh $MCR_ROOT [RECORDINGS] [LEADFIELD] [ADJACENCY_MATRIX] [SOURCES] [MEM_METHOD] \"[SENSOR_TYPES]\" \"[RECONSTRUCTION_WINDOW]\" \"[BASELINE_WINDOW]\" [BASELINE] [NORMALIZATION] [CLUSTERING_METHOD] [MSP_WINDOW] [MSP_THRESHOLD_METHOD] [MSP_THRESHOLD] [NEIGHBORHOOD_ORDER] [SPATIAL_SMOOTHING] [ACTIVE_MEAN_INIT] [ACTIVE_PROBA_INIT] [LAMBDA_INIT] [ACTIVE_PROBA_THRESHOLD] [ACTIVE_VAR_COEF] [INACTIVE_VAR_COEF] [NOISE_COV_METHOD] [OPTIM_METHOD] [USE_PARALLEL]", 
+    "container-image": {
+        "image": "MontrealSergiy/BEst",
+        "type": "singularity"
+    }, 
+    "name": "BEst", 
+    "author": "Obaï Bin Ka’b Ali",
+    "description": "EEG/MEG source localisation techniques based upon the Maximum Entropy on the Mean framework", 
+    "inputs": [
+        {
+            "id": "recordings", 
+            "name": "Recording data", 
+            "type": "File",
+            "optional": false,
+            "value-key": "[RECORDINGS]"
+        }, 
+        {
+            "id": "leadfield", 
+            "name": "Lead field data",
+            "type": "File", 
+            "optional": false,
+            "value-key": "[LEADFIELD]"
+        }, 
+        {
+            "id": "adjacency_matrix", 
+            "name": "Adjacency matrix", 
+            "type": "File", 
+            "optional": false,
+            "value-key": "[ADJACENCY_MATRIX]"
+        },
+        {
+            "id": "outfile", 
+            "name": "Output file",
+            "description": "Name of the output file with extension '.mat'", 
+            "type": "String", 
+            "optional": false,
+            "default-value": "sources.mat",
+            "value-key": "[OUTFILE]"
+        },
+        {
+            "id": "mem_method", 
+            "name": "MEM method",
+            "type": "String",
+            "optional": false,
+            "value-choices": [
+                "cMEM"
+            ],
+            "default-value": "cMEM",
+            "value-key": "[MEM_METHOD]"
+        }, 
+        {
+            "id": "sensor_types", 
+            "name": "Sensor types", 
+            "description": "The data sensors types to process. If, for instance, your input recording data contains both EEG and MEG channels, then, you could choose to process only the EEG channels by setting this parameter to 'EEG'.",
+            "type": "String",
+            "optional": false,
+            "list": true,
+            "max-list-entries": 2,
+            "min-list-entries": 1,
+            "value-choices": [
+                "EEG",
+                "MEG"
+            ],
+            "value-key": "[SENSOR_TYPES]"
+        }, 
+        {
+            "id": "reconstruction_window", 
+            "name": "Reconstruction time window", 
+            "description": "This is the portion of your input recording data to reconstruct.",
+            "type": "Number",
+            "optional": false,
+            "list": true,
+            "max-list-entries": 2,
+            "min-list-entries": 2,
+            "minimum": 0,
+            "value-key": "[RECONSTRUCTION_WINDOW]"
+        }, 
+        {
+            "id": "baseline_window", 
+            "name": "Baseline time window", 
+            "description": "This is the portion of your baseline data to use for estimating a noise covariance matrix.",
+            "type": "Number",
+            "optional": false,
+            "list": true,
+            "max-list-entries": 2,
+            "min-list-entries": 2,
+            "minimum": 0,
+            "value-key": "[BASELINE_WINDOW]"
+        }, 
+        {
+            "id": "baseline", 
+            "name": "Baseline data", 
+            "description": "This is the path to your baseline file if any. If no baseline file is specified, then the baseline data will be extracted from within the recording data.",
+            "type": "File",
+            "optional": true,
+            "command-line-flag": "baseline",
+            "value-key": "[BASELINE]"
+        }, 
+        {
+            "id": "normalization", 
+            "name": "Normalization",
+            "description": "Normalization strategy used for computing the solution. If adaptive, a minimum solution is used to normalize the data.",
+            "type": "String", 
+            "optional": true,
+            "default-value": "adaptive",
+            "value-choices": [
+                "adaptive",
+                "fixed"
+            ],
+            "command-line-flag": "normalization",
+            "value-key": "[NORMALIZATION]"
+        }, 
+        {
+            "id": "clustering_method", 
+            "name": "Clustering method",
+            "description": "If dynamic, then the cortical parcels are computed within consecutive time windows specified with the option: MSP window. If static, then one set of cortical parcels is computed for the whole data.",
+            "type": "String", 
+            "optional": true,
+            "default-value": "static",
+            "value-choices": [
+                "static",
+                "dynamic"
+            ],
+            "value-disables": {
+                "static": [
+                    "msp_window"
+                ],
+                "dynamic": [
+                ]
+            }, 
+            "value-requires": {
+                "static": [
+                ],
+                "dynamic": [
+                    "msp_window" 
+                ]
+            },
+            "command-line-flag": "clusteringMethod",
+            "value-key": "[CLUSTERING_METHOD]"
+        }, 
+        {
+            "id": "msp_window", 
+            "name": "MSP window",
+            "description": "Used when clustering method is set to 'dynamic', this is the size of the sliding window in millisecond (ms).",
+            "type": "Number",
+            "optional": true,
+            "minimum": 0,
+            "default-value": 10,
+            "command-line-flag": "mspWindow",
+            "value-key": "[MSP_WINDOW]"
+        }, 
+        {
+            "id": "msp_threshold_method", 
+            "name": "MSP scores threshold method",
+            "description": "Thresholding method applied to the MSP scores. If set to 'fdr' then thresholds are learned from baseline. Otherwise, the option 'MSP scores threshold' is used.",
+            "type": "String", 
+            "optional": true,
+            "default-value": "arbitrary",
+            "value-choices": [
+                "arbitrary",
+                "fdr"
+            ],
+            "value-disables": {
+                "arbitrary": [ 
+                ],
+                "fdr": [
+                    "msp_threshold"
+                ]
+            }, 
+            "value-requires": {
+                "arbitrary": [
+                    "msp_threshold" 
+                ],
+                "fdr": [
+                ]
+            },
+            "command-line-flag": "mspThresholdMethod",
+            "value-key": "[MSP_THRESHOLD_METHOD]"
+        }, 
+        {
+            "id": "msp_threshold", 
+            "name": "MSP scores threshold",
+            "description": "Used when MSP scores threshold method is set to 'arbitrary', whole brain parcellation is set to 0.",
+            "type": "Number",
+            "optional": true,
+            "minimum": 0,
+            "maximum": 1,
+            "default-value": 0,
+            "command-line-flag": "mspThreshold",
+            "value-key": "[MSP_THRESHOLD]"
+        }, 
+        {
+            "id": "neighborhood_order", 
+            "name": "Neighborhood order",
+            "description": "Sets maximal size of cortical parcels (initial source configuration for MEM).",
+            "type": "Number",
+            "optional": true,
+            "integer": true,
+            "minimum": 0,
+            "default-value": 4,
+            "command-line-flag": "neighborhoodOrder",
+            "value-key": "[NEIGHBORHOOD_ORDER]"
+        }, 
+        {
+            "id": "spatial_smoothing", 
+            "name": "Spatial smoothing",
+            "description": "Smoothness of MEM solution: spatial regularization of the MEM (linear decay of spatial source correlations).",
+            "type": "Number",
+            "optional": true,
+            "minimum": 0,
+            "maximum": 1,
+            "default-value": 0.6,
+            "command-line-flag": "spatialSmoothing",
+            "value-key": "[SPATIAL_SMOOTHING]"
+        }, 
+        {
+            "id": "active_mean_init", 
+            "name": "Active mean initialization",
+            "description": "Initialization method of the active mean of each cluster.",
+            "type": "Number",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                1,
+                2, 
+                3, 
+                4
+            ],
+            "default-value": 2,
+            "command-line-flag": "activeMeanInit",
+            "value-key": "[ACTIVE_MEAN_INIT]"
+        }, 
+        {
+            "id": "active_proba_init", 
+            "name": "Active probability initialization",
+            "description": "Initialization method of the active probability of each cluster.",
+            "type": "Number",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                1,
+                2, 
+                3, 
+                4,
+                5
+            ],
+            "default-value": 3,
+            "command-line-flag": "activeProbaInit",
+            "value-key": "[ACTIVE_PROBA_INIT]"
+        }, 
+        {
+            "id": "lambda_init", 
+            "name": "Lambda initialization",
+            "description": "Initialization method of the sensor weights vector.",
+            "type": "Number",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ],
+            "default-value": 1,
+            "command-line-flag": "lambdaInit",
+            "value-key": "[LAMBDA_INIT]"
+        }, 
+        {
+            "id": "active_proba_threshold", 
+            "name": "Active probability threshold",
+            "description": "Used to exclude clusters with low probability from the computed solution.",
+            "type": "Number",
+            "optional": true,
+            "minimum": 0,
+            "maximum": 1,
+            "default-value": 0,
+            "command-line-flag": "activeProbaThreshold",
+            "value-key": "[ACTIVE_PROBA_THRESHOLD]"
+        }, 
+        {
+            "id": "active_var_coef", 
+            "name": "Active variance coefficient",
+            "description": "A weight applied to the active variance of each cluster.",
+            "type": "Number",
+            "optional": true,
+            "minimum": 0,
+            "maximum": 1,
+            "default-value": 0.05,
+            "command-line-flag": "activeVarCoef",
+            "value-key": "[ACTIVE_VAR_COEF]"
+        }, 
+        {
+            "id": "inactive_var_coef", 
+            "name": "Inactive variance coefficient",
+            "description": "A weight applied to the inactive variance of each cluster.",
+            "type": "Number",
+            "optional": true,
+            "minimum": 0,
+            "maximum": 1,
+            "default-value": 0,
+            "command-line-flag": "inactiveVarCoef",
+            "value-key": "[INACTIVE_VAR_COEF]"
+        }, 
+        {
+            "id": "noise_cov_method", 
+            "name": "Noise covariance method",
+            "description": "The performance of the MEM is tied to a consistent estimation of the noise covariance matrix. We recommend using the 'diagonal' method.",
+            "type": "Number",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1,
+                2, 
+                3, 
+                4
+            ],
+            "default-value": 2,
+            "command-line-flag": "noiseCovMethod",
+            "value-key": "[NOISE_COV_METHOD]"
+        }, 
+        {
+            "id": "optim_method", 
+            "name": "Optimization routine",
+            "description": "'fminunc': MATLAB standard unconstrained optimization (optimization toolbox required). 'minFunc': Unconstrained optimization, copyright Mark Schmidt, INRIA.",
+            "type": "String", 
+            "optional": true,
+            "default-value": "fminunc",
+            "value-choices": [
+                "fminunc",
+                "minfunc"
+            ],
+            "command-line-flag": "optimMethod",
+            "value-key": "[OPTIM_METHOD]"
+        }, 
+        {
+            "id": "use_parallel",
+            "name": "Parallel computing",
+            "description": "0: default - false, 1: true",
+            "type": "Number",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ],
+            "default-value": 0,
+            "command-line-flag": "useParallel",
+            "value-key": "[USE_PARALLEL]"
+        }
+    ], 
+    "output-files": [
+        {
+            "id": "sources", 
+            "name": "Sources",
+            "path-template": "[OUTFILE].mat",
+            "path-template-stripped-extensions": [
+                ".mat"
+            ],
+            "optional": false,
+            "value-key": "[SOURCES]"
+        }
+    ],
+    "groups": [
+        {
+            "id": "data_definition",
+            "name": "Data definition",
+            "members": [
+                "sensor_types",
+                "reconstruction_window",
+                "baseline",
+                "baseline_window",
+                "normalization"
+            ]
+        },
+        {
+            "id": "clustering",
+            "name": "Clustering",
+            "members": [
+                "clustering_method",
+                "msp_window",
+                "msp_threshold_method",
+                "msp_threshold",
+                "neighborhood_order",
+                "spatial_smoothing"
+            ]
+        },
+        {
+            "id": "model_priors",
+            "name": "Model priors",
+            "members": [
+                "active_mean_init",
+                "active_proba_init",
+                "lambda_init",
+                "active_proba_threshold",
+                "active_var_coef",
+                "inactive_var_coef"
+            ]
+        },
+        {
+            "id": "solver_options",
+            "name": "Solver options",
+            "members": [
+                "noise_cov_method",
+                "optim_method",
+                "use_parallel"
+            ]
+        }
+    ],
+    "schema-version": "0.5", 
+    "tags": {
+        "domain": "neuroinformatics"
+    }, 
+    "tool-version": "1.0"
+}

--- a/app/static/pipelines/zenodo-2563057.json
+++ b/app/static/pipelines/zenodo-2563057.json
@@ -1,0 +1,543 @@
+{
+    "author": "Poldrack lab", 
+    "command-line": "fmriprep [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [PARTICIPANT_LABEL] [TASK_ID] [VERSION] [NTHREADS] [OMP_NTHREADS] [MEM_MB] [LOW_MEM] [USE_PLUGIN] [ANAT_ONLY] [BOILERPLATE] [IGNORE_AROMA_DENOISING_ERRORS] [VERBOSE_COUNT] [DEBUG] [IGNORE] [LONGITUDINAL] [T2S_COREG] [BOLD2T1W_DOF] [OUTPUT_SPACE] [USE_BBR] [TEMPLATE] [OUTPUT_GRID_REFERENCE] [TEMPLATE_RESAMPLING_GRID] [MEDIAL_SURFACE_NAN] [USE_AROMA] [AROMA_MELODIC_DIMENSIONALITY] [SKULL_STRIP_TEMPLATE] [SKULL_STRIP_FIXED_SEED] [FMAP_BSPLINE] [FMAP_NO_DEMEAN] [USE_SYN_SDC] [FORCE_SYN] [FS_LICENSE_FILE] [HIRES] [CIFTI_OUTPUT] [RUN_RECONALL] [WORK_DIR] [RESOURCE_MONITOR] [REPORTS_ONLY] [RUN_UUID] [WRITE_GRAPH] [STOP_ON_FIRST_CRASH] [NOTRACK] [SLOPPY]", 
+    "container-image": {
+        "image": "shots47s/bids-fmriprep-1.2.3", 
+        "type": "singularity"
+    }, 
+    "custom": {
+        "cbrain:readonly-input-files": true
+    }, 
+    "description": "fMRIprep is a functional magneticresonance image pre-processing pipeline that is designed to provide an easily accessible, state-of-the-art interface that is robust to differences in scan acquisition protocols and that requires minimal user input, while providing easily interpretable and comprehensive error and output reporting. https://fmriprep.readthedocs.io", 
+    "groups": [
+        {
+            "description": "Paramters used to define memory requirements and multithreading", 
+            "id": "memory_and_parallelism", 
+            "members": [
+                "nthreads", 
+                "omp_nthreads", 
+                "mem_mb", 
+                "low_mem"
+            ], 
+            "name": "Memory and Parallel Control Parameters"
+        }, 
+        {
+            "description": "Diagnostic parameters for debugging fMRIprep", 
+            "id": "debugging", 
+            "members": [
+                "version", 
+                "verbose_count", 
+                "resource_monitor", 
+                "reports_only", 
+                "run_uuid", 
+                "stop_on_first_crash", 
+                "notrack", 
+                "write_graph", 
+                "sloppy"
+            ], 
+            "name": "Debugging Parameters"
+        }, 
+        {
+            "description": "Parameters that one should use at their own risk.", 
+            "id": "experimental", 
+            "members": [
+                "use_syn_sdc", 
+                "force_syn"
+            ], 
+            "name": "Experimental Parameters"
+        }, 
+        {
+            "description": "Parameters that are no longer useful or supported", 
+            "id": "deprecated", 
+            "members": [
+                "debug", 
+                "output_grid_reference"
+            ], 
+            "name": "Deprecated Parameters"
+        }
+    ], 
+    "inputs": [
+        {
+            "description": "the root folder of a BIDS valid dataset (sub-XXXXX folders should be found at the top level in this folder).", 
+            "id": "bids_dir", 
+            "name": "bids_dir", 
+            "optional": false, 
+            "type": "File", 
+            "value-key": "[BIDS_DIR]"
+        }, 
+        {
+            "description": "the output path for the outcomes of preprocessing and visual reports", 
+            "id": "output_dir", 
+            "name": "output_dir", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[OUTPUT_DIR]"
+        }, 
+        {
+            "description": "processing stage to be run, only \"participant\" in the case of FMRIPREP (see BIDS-Apps specification).", 
+            "id": "analysis_level", 
+            "name": "analysis_level", 
+            "optional": false, 
+            "type": "String", 
+            "value-choices": [
+                "participant"
+            ], 
+            "value-key": "[ANALYSIS_LEVEL]"
+        }, 
+        {
+            "command-line-flag": "--version", 
+            "default-value": false, 
+            "description": "show program's version number and exit", 
+            "id": "version", 
+            "name": "version", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[VERSION]"
+        }, 
+        {
+            "command-line-flag": "--participant_label", 
+            "description": "a space delimited list of participant identifiers or a single identifier (the sub- prefix can be removed)", 
+            "id": "participant_label", 
+            "list": true, 
+            "name": "participant_label", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[PARTICIPANT_LABEL]"
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "select a specific task to be processed", 
+            "id": "task_id", 
+            "name": "task_id", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[TASK_ID]"
+        }, 
+        {
+            "command-line-flag": "--fs-license-file", 
+            "description": "Path to FreeSurfer license key file. Get it (for free) by registering at https://surfer.nmr.mgh.harvard.edu/registration.html", 
+            "id": "fs_license_file", 
+            "name": "fs_license_file", 
+            "optional": true, 
+            "type": "File", 
+            "uses-absolute-path": true, 
+            "value-key": "[FS_LICENSE_FILE]"
+        }, 
+        {
+            "command-line-flag": "--nthreads", 
+            "default-value": 4, 
+            "description": "maximum number of threads across all processes", 
+            "id": "nthreads", 
+            "name": "nthreads", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[NTHREADS]"
+        }, 
+        {
+            "command-line-flag": "--omp-nthreads", 
+            "default-value": 4, 
+            "description": "maximum number of threads per-process", 
+            "id": "omp_nthreads", 
+            "name": "omp_nthreads", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[OMP_NTHREADS]"
+        }, 
+        {
+            "command-line-flag": "--mem_mb", 
+            "default-value": 8192, 
+            "description": "upper bound memory limit for FMRIPREP processes", 
+            "id": "mem_mb", 
+            "name": "mem_mb", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[MEM_MB]"
+        }, 
+        {
+            "command-line-flag": "--low-mem", 
+            "description": "attempt to reduce memory usage (will increase disk usage in working directory)", 
+            "id": "low_mem", 
+            "name": "low_mem", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[LOW_MEM]"
+        }, 
+        {
+            "command-line-flag": "--use-plugin", 
+            "description": "nipype plugin configuration file", 
+            "id": "use_plugin", 
+            "name": "use_plugin", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[USE_PLUGIN]"
+        }, 
+        {
+            "command-line-flag": "--anat-only", 
+            "description": "run anatomical workflows only", 
+            "id": "anat_only", 
+            "name": "anat_only", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[ANAT_ONLY]"
+        }, 
+        {
+            "command-line-flag": "--boilerplate", 
+            "description": "generate boilerplate only", 
+            "id": "boilerplate", 
+            "name": "boilerplate", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[BOILERPLATE]"
+        }, 
+        {
+            "command-line-flag": "--ignore-aroma-denoising-errors", 
+            "description": "ignores the errors ICA_AROMA returns when there are no components classified as either noise or signal", 
+            "id": "ignore_aroma_denoising_errors", 
+            "name": "ignore_aroma_denoising_errors", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[IGNORE_AROMA_DENOISING_ERRORS]"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "description": "increases log verbosity for each occurence, debug level is -vvv", 
+            "id": "verbose_count", 
+            "name": "verbose_count", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[VERBOSE_COUNT]"
+        }, 
+        {
+            "command-line-flag": "--debug", 
+            "description": "DEPRECATED - Does not do what you want.", 
+            "id": "debug", 
+            "name": "debug", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[DEBUG]"
+        }, 
+        {
+            "command-line-flag": "--ignore", 
+            "description": "ignore selected aspects of the input dataset to disable corresponding parts of the workflow (a space delimited list)", 
+            "id": "ignore", 
+            "list": true, 
+            "name": "ignore", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "fieldmaps", 
+                "slicetiming", 
+                "sbref"
+            ], 
+            "value-key": "[IGNORE]"
+        }, 
+        {
+            "command-line-flag": "--longitudinal", 
+            "description": "treat dataset as longitudinal - may increase runtime", 
+            "id": "longitudinal", 
+            "name": "longitudinal", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[LONGITUDINAL]"
+        }, 
+        {
+            "command-line-flag": "--t2s-coreg", 
+            "description": "If provided with multi-echo BOLD dataset, create T2*-map and perform T2*-driven coregistration. When multi-echo data is provided and this option is not enabled, standard EPI-T1 coregistration is performed using the middle echo.", 
+            "id": "t2s_coreg", 
+            "name": "t2s_coreg", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[T2S_COREG]"
+        }, 
+        {
+            "command-line-flag": "--bold2t1w-dof", 
+            "default-value": 6, 
+            "description": "Degrees of freedom when registering BOLD to T1w images. 6 degrees (rotation and translation) are used by default.", 
+            "id": "bold2t1w_dof", 
+            "name": "bold2t1w_dof", 
+            "optional": true, 
+            "type": "Number", 
+            "value-choices": [
+                6, 
+                9, 
+                12
+            ], 
+            "value-key": "[BOLD2T1W_DOF]"
+        }, 
+        {
+            "command-line-flag": "--output-space", 
+            "description": "volume and surface spaces to resample functional series into\n - T1w: subject anatomical volume\n - template: normalization target specified by --template\n - fsnative: individual subject surface\n - fsaverage*: FreeSurfer average meshes\nthis argument can be single value or a space delimited list,\nfor example: --output-space T1w fsnative", 
+            "id": "output_space", 
+            "list": true, 
+            "name": "output_space", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "T1w", 
+                "template", 
+                "fsnative", 
+                "fsaverage", 
+                "fsaverage6", 
+                "fsaverage5"
+            ], 
+            "value-key": "[OUTPUT_SPACE]"
+        }, 
+        {
+            "command-line-flag": "--force-bbr", 
+            "description": "Always use boundary-based registration (no goodness-of-fit checks)", 
+            "id": "use_bbr", 
+            "name": "use_bbr", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[USE_BBR]"
+        }, 
+        {
+            "command-line-flag": "--template", 
+            "default-value": "MNI152NLin2009cAsym", 
+            "description": "volume template space (default: MNI152NLin2009cAsym)", 
+            "id": "template", 
+            "name": "template", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "MNI152NLin2009cAsym"
+            ], 
+            "value-key": "[TEMPLATE]"
+        }, 
+        {
+            "command-line-flag": "--output-grid-reference", 
+            "description": "Deprecated after FMRIPREP 1.0.8. Please use --template-resampling-grid instead.", 
+            "id": "output_grid_reference", 
+            "name": "output_grid_reference", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[OUTPUT_GRID_REFERENCE]"
+        }, 
+        {
+            "command-line-flag": "--template-resampling-grid", 
+            "default-value": "native", 
+            "description": "Keyword (\"native\", \"1mm\", or \"2mm\") or path to an existing file. Allows to define a reference grid for the resampling of BOLD images in template space. Keyword \"native\" will use the original BOLD grid as reference. Keywords \"1mm\" and \"2mm\" will use the corresponding isotropic template resolutions. If a path is given, the grid of that image will be used. It determines the field of view and resolution of the output images, but is not used in normalization.", 
+            "id": "template_resampling_grid", 
+            "name": "template_resampling_grid", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[TEMPLATE_RESAMPLING_GRID]"
+        }, 
+        {
+            "command-line-flag": "--medial-surface-nan", 
+            "description": "Replace medial wall values with NaNs on functional GIFTI files. Only performed for GIFTI files mapped to a freesurfer subject (fsaverage or fsnative).", 
+            "id": "medial_surface_nan", 
+            "name": "medial_surface_nan", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[MEDIAL_SURFACE_NAN]"
+        }, 
+        {
+            "command-line-flag": "--use-aroma", 
+            "description": "add ICA_AROMA to your preprocessing stream", 
+            "id": "use_aroma", 
+            "name": "use_aroma", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[USE_AROMA]"
+        }, 
+        {
+            "command-line-flag": "--aroma-melodic-dimensionality", 
+            "default-value": -200, 
+            "description": "Exact or maximum number of MELODIC components to estimate (positive = exact, negative = maximum)", 
+            "id": "aroma_melodic_dimensionality", 
+            "name": "aroma_melodic_dimensionality", 
+            "optional": true, 
+            "type": "Number", 
+            "value-key": "[AROMA_MELODIC_DIMENSIONALITY]"
+        }, 
+        {
+            "command-line-flag": "--skull-strip-template", 
+            "default-value": "OASIS", 
+            "description": "select ANTs skull-stripping template (default: OASIS))", 
+            "id": "skull_strip_template", 
+            "name": "skull_strip_template", 
+            "optional": true, 
+            "type": "String", 
+            "value-choices": [
+                "OASIS", 
+                "NKI"
+            ], 
+            "value-key": "[SKULL_STRIP_TEMPLATE]"
+        }, 
+        {
+            "command-line-flag": "--skull-strip-fixed-seed", 
+            "description": "do not use a random seed for skull-stripping - will ensure run-to-run replicability when used with --omp-nthreads 1", 
+            "id": "skull_strip_fixed_seed", 
+            "name": "skull_strip_fixed_seed", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[SKULL_STRIP_FIXED_SEED]"
+        }, 
+        {
+            "command-line-flag": "--fmap-bspline", 
+            "description": "fit a B-Spline field using least-squares (experimental)", 
+            "id": "fmap_bspline", 
+            "name": "fmap_bspline", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[FMAP_BSPLINE]"
+        }, 
+        {
+            "command-line-flag": "--fmap-no-demean", 
+            "default-value": true, 
+            "description": "do not remove median (within mask) from fieldmap", 
+            "id": "fmap_no_demean", 
+            "name": "fmap_no_demean", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[FMAP_NO_DEMEAN]"
+        }, 
+        {
+            "command-line-flag": "--use-syn-sdc", 
+            "description": "EXPERIMENTAL: Use fieldmap-free distortion correction", 
+            "id": "use_syn_sdc", 
+            "name": "use_syn_sdc", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[USE_SYN_SDC]"
+        }, 
+        {
+            "command-line-flag": "--force-syn", 
+            "description": "EXPERIMENTAL/TEMPORARY: Use SyN correction in addition to fieldmap correction, if available", 
+            "id": "force_syn", 
+            "name": "force_syn", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[FORCE_SYN]"
+        }, 
+        {
+            "command-line-flag": "--no-submm-recon", 
+            "default-value": true, 
+            "description": "disable sub-millimeter (hires) reconstruction", 
+            "id": "hires", 
+            "name": "hires", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[HIRES]"
+        }, 
+        {
+            "command-line-flag": "--cifti-output", 
+            "description": "output BOLD files as CIFTI dtseries", 
+            "id": "cifti_output", 
+            "name": "cifti_output", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[CIFTI_OUTPUT]"
+        }, 
+        {
+            "command-line-flag": "--fs-no-reconall", 
+            "default-value": true, 
+            "description": "disable FreeSurfer surface preprocessing. Note : `--no-freesurfer` is deprecated and will be removed in 1.2. Use `--fs-no-reconall` instead.", 
+            "id": "run_reconall", 
+            "name": "run_reconall", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[RUN_RECONALL]"
+        }, 
+        {
+            "command-line-flag": "-w", 
+            "description": "path where intermediate results should be stored", 
+            "id": "work_dir", 
+            "name": "work_dir", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[WORK_DIR]"
+        }, 
+        {
+            "command-line-flag": "--resource-monitor", 
+            "description": "enable Nipype's resource monitoring to keep track of memory and CPU usage", 
+            "id": "resource_monitor", 
+            "name": "resource_monitor", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[RESOURCE_MONITOR]"
+        }, 
+        {
+            "command-line-flag": "--reports-only", 
+            "description": "only generate reports, don't run workflows. This will only rerun report aggregation, not reportlet generation for specific nodes.", 
+            "id": "reports_only", 
+            "name": "reports_only", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[REPORTS_ONLY]"
+        }, 
+        {
+            "command-line-flag": "--run-uuid", 
+            "description": "Specify UUID of previous run, to include error logs in report. No effect without --reports-only.", 
+            "id": "run_uuid", 
+            "name": "run_uuid", 
+            "optional": true, 
+            "type": "String", 
+            "value-key": "[RUN_UUID]"
+        }, 
+        {
+            "command-line-flag": "--write-graph", 
+            "description": "Write workflow graph.", 
+            "id": "write_graph", 
+            "name": "write_graph", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[WRITE_GRAPH]"
+        }, 
+        {
+            "command-line-flag": "--stop-on-first-crash", 
+            "description": "Force stopping on first crash, even if a work directory was specified.", 
+            "id": "stop_on_first_crash", 
+            "name": "stop_on_first_crash", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[STOP_ON_FIRST_CRASH]"
+        }, 
+        {
+            "command-line-flag": "--notrack", 
+            "description": "Opt-out of sending tracking information of this run to the FMRIPREP developers. This information helps to improve FMRIPREP and provides an indicator of real world usage crucial for obtaining funding.", 
+            "id": "notrack", 
+            "name": "notrack", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[NOTRACK]"
+        }, 
+        {
+            "command-line-flag": "--sloppy", 
+            "description": "Use low-quality tools for speed - TESTING ONLY", 
+            "id": "sloppy", 
+            "name": "sloppy", 
+            "optional": true, 
+            "type": "Flag", 
+            "value-key": "[SLOPPY]"
+        }
+    ], 
+    "name": "BIDS App - fmriprep", 
+    "output-files": [
+        {
+            "description": "This is the directory where the overall outputs are to be stored.", 
+            "id": "output_directory", 
+            "name": "Output Directory", 
+            "optional": false, 
+            "path-template": "[OUTPUT_DIR]"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "suggested-resources": {
+        "cpu-cores": 4, 
+        "ram": 4, 
+        "walltime-estimate": 172000
+    }, 
+    "tags": {
+        "application-type": [
+            "bids"
+        ], 
+        "domain": [
+            "neuroinformatics", 
+            "fmri"
+        ]
+    }, 
+    "tool-version": "1.2.3", 
+    "url": "https://fmriprep.readthedocs.io"
+}

--- a/app/static/pipelines/zenodo-2566443.json
+++ b/app/static/pipelines/zenodo-2566443.json
@@ -1,0 +1,73 @@
+{
+    "author": "Greg Kiar",
+    "command-line": "python3 /opt/mask2boundary.py [MASK] [OUTPUT] [WIDTH] [BOUTIQUES]",
+    "container-image": {
+        "image": "gkiar/mask2boundary:v0.1.0",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "description": "Transforms a binary mask of a niftii image (such as a brain or white matter mask) into a boundary mask. This tool was originally developed to transform a white matter mask into a mask of seed locations for performing tractography in diffusion images.",
+    "inputs": [
+        {
+            "description": "Nifti image containing a binary mask.",
+            "id": "mask",
+            "name": "mask",
+            "optional": false,
+            "type": "String",
+            "value-key": "[MASK]"
+        },
+        {
+            "description": "Path for output Nifti image containing the mask boundary.",
+            "id": "output",
+            "name": "output",
+            "optional": false,
+            "type": "String",
+            "value-key": "[OUTPUT]"
+        },
+        {
+            "command-line-flag": "--width",
+            "default-value": 3,
+            "description": "Width of the boundary to be stored.",
+            "id": "width",
+            "integer": true,
+            "minimum": 1,
+            "name": "width",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[WIDTH]"
+        },
+        {
+            "command-line-flag": "--boutiques",
+            "description": "Toggles creation of a Boutiques descriptor and invocation from the tool and inputs.",
+            "id": "boutiques",
+            "name": "boutiques",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[BOUTIQUES]"
+        }
+    ],
+    "name": "mask2boundary",
+    "output-files": [
+        {
+            "path-template": "[OUTPUT]",
+            "optional": false,
+            "id": "mask_boundary",
+            "name": "Boundary Mask"
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 1,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "mri",
+            "nifti",
+            "dmri"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/app/static/pipelines/zenodo-2566450.json
+++ b/app/static/pipelines/zenodo-2566450.json
@@ -1,0 +1,165 @@
+{
+    "author": "Greg Kiar",
+    "command-line": "ndmg_bids BIDS_DIR OUTPUT_DIR ANALYSIS_LEVEL PARTICIPANT_LABEL SESSION_LABEL BUCKET REMOTE_PATH PUSH_DATA DATASET ATLAS MINIMAL HEMISPHERES LOG DEBUG STC",
+    "container-image": {
+      "image": "bids/ndmg:v0.1.0",
+      "index": "index.docker.io",
+      "type": "docker"
+    },
+    "description": "ndmg connectome estimation pipeline",
+    "inputs": [
+        {
+            "description": "The directory with the input dataset formatted according to the BIDS standard.",
+            "id": "bids_dir",
+            "name": "bids_dir",
+            "optional": false,
+            "type": "File",
+            "value-key": "BIDS_DIR"
+        },
+        {
+            "description": "The directory where the output files should be stored. If you are running group level analysis this folder should be prepopulated with the results of the participant level analysis.",
+            "id": "output_dir",
+            "name": "output_dir",
+            "optional": false,
+            "type": "File",
+            "value-key": "OUTPUT_DIR"
+        },
+        {
+            "description": "Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel) using the same output_dir.",
+            "id": "analysis_level",
+            "name": "analysis_level",
+            "optional": false,
+            "type": "String",
+            "value-choices": [
+                "participant",
+                "group"
+            ],
+            "value-key": "ANALYSIS_LEVEL"
+        },
+        {
+            "command-line-flag": "--participant_label",
+            "description": "The label(s) of the participant(s) that should be analyzed. The label corresponds to sub-<participant_label> from the BIDS spec (so it does not include \"sub-\"). If this parameter is not provided all subjects should be analyzed. Multiple participants can be specified with a space separated list.",
+            "id": "participant_label",
+            "name": "participant_label",
+            "optional": true,
+            "type": "String",
+				    "list" : true,
+            "value-key": "PARTICIPANT_LABEL"
+        },
+        {
+            "command-line-flag": "--session_label",
+            "description": "The label(s) of the session that should be analyzed. The label corresponds to ses-<participant_label> from the BIDS spec (so it does not include \"ses-\"). If this parameter is not provided all sessions should be analyzed. Multiple sessions can be specified with a space separated list.",
+            "id": "session_label",
+            "name": "session_label",
+            "optional": true,
+            "type": "String",
+				    "list" : true,
+            "value-key": "SESSION_LABEL"
+        },
+        {
+            "command-line-flag": "--bucket",
+            "description": "The name of an S3 bucket which holds BIDS organized data. You must have built your bucket with credentials to the S3 bucket you wish to access.",
+            "id": "bucket",
+            "name": "bucket",
+            "optional": true,
+            "type": "String",
+            "value-key": "BUCKET"
+        },
+        {
+            "command-line-flag": "--remote_path",
+            "description": "The path to the data on your S3 bucket. The data will be downloaded to the provided bids_dir on your machine.",
+            "id": "remote_path",
+            "name": "remote_path",
+            "optional": true,
+            "type": "String",
+            "value-key": "REMOTE_PATH"
+        },
+        {
+            "command-line-flag": "--push_data",
+            "description": "flag to push derivatives back up to S3.",
+            "id": "push_data",
+            "name": "push_data",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "PUSH_DATA"
+        },
+        {
+            "command-line-flag": "--dataset",
+            "description": "The name of the dataset you are perfoming QC on.",
+            "id": "dataset",
+            "name": "dataset",
+            "optional": true,
+            "type": "String",
+            "value-key": "DATASET"
+        },
+        {
+            "command-line-flag": "--atlas",
+            "description": "The atlas being analyzed in QC (if you only want one).",
+            "id": "atlas",
+            "name": "atlas",
+            "optional": true,
+            "type": "String",
+            "value-key": "ATLAS"
+        },
+        {
+            "command-line-flag": "--minimal",
+            "description": "Determines whether to show a minimal or full set of plots.",
+            "id": "minimal",
+            "name": "minimal",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "MINIMAL"
+        },
+        {
+            "command-line-flag": "--hemispheres",
+            "description": "Whether or not to break degrees into hemispheres or not",
+            "id": "hemispheres",
+            "name": "hemispheres",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "HEMISPHERES"
+        },
+        {
+            "command-line-flag": "--log",
+            "description": "Determines axis scale for plotting.",
+            "id": "log",
+            "name": "log",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "LOG"
+        },
+        {
+            "command-line-flag": "--debug",
+            "description": "flag to store temp files along the path of processing.",
+            "id": "debug",
+            "name": "debug",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "DEBUG"
+        }
+    ],
+    "name": "BIDS App - ndmg",
+    "output-files": [
+      {
+        "id": "output_directory",
+        "name": "BIDS derivatives directory from ndmg",
+        "optional": false,
+        "path-template": "OUTPUT_DIR"
+      }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 12,
+        "walltime-estimate": 7200
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "diffusion",
+            "mri",
+            "bids"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/app/static/pipelines/zenodo-2566455.json
+++ b/app/static/pipelines/zenodo-2566455.json
@@ -1,0 +1,128 @@
+{
+    "author": "Greg Kiar, using FSL from FMRIB at Oxford",
+    "command-line": "python3 /opt/preprocessing_pipeline.py [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [PARTICIPANT_LABEL] [SESSION_LABEL] [VERBOSE] [BOUTIQUES] [GPU] [FSLDIR] [PARCELLATION]",
+    "container-image": {
+        "image": "gkiar/dwipreproc_fsl-5.0.11_minified",
+        "index": "docker.io",
+        "type": "docker"
+    },
+    "description": "Preprocessing pipeline for diffusion MRI data using the FSL software suite.",
+    "inputs": [
+        {
+            "description": "Directory to a BIDS-organized dataset.",
+            "id": "bids_dir",
+            "name": "bids_dir",
+            "optional": false,
+            "type": "String",
+            "value-key": "[BIDS_DIR]"
+        },
+        {
+            "description": "Directory to store the preprocessed derivatives.",
+            "id": "output_dir",
+            "name": "output_dir",
+            "optional": false,
+            "type": "String",
+            "value-key": "[OUTPUT_DIR]"
+        },
+        {
+            "description": "Level of analysis to perform. Options: session",
+            "id": "analysis_level",
+            "name": "analysis_level",
+            "optional": false,
+            "type": "String",
+            "value-choices": [
+                "session"
+            ],
+            "value-key": "[ANALYSIS_LEVEL]"
+        },
+        {
+            "command-line-flag": "--participant_label",
+            "description": "Label of the participant(s) to process, omitting the 'sub-' portion of the directory name. Supplying none means the entire dataset will be processed.",
+            "id": "participant_label",
+            "name": "participant_label",
+            "optional": true,
+            "type": "String",
+            "value-key": "[PARTICIPANT_LABEL]"
+        },
+        {
+            "command-line-flag": "--session_label",
+            "description": "Label of the session(s) to process, omitting the 'ses-' portion of the directory name. Supplying none means the entire dataset will be processed.",
+            "id": "session_label",
+            "name": "session_label",
+            "optional": true,
+            "type": "String",
+            "value-key": "[SESSION_LABEL]"
+        },
+        {
+            "command-line-flag": "--verbose",
+            "description": "Flag toggling verbose output statements.",
+            "id": "verbose",
+            "name": "verbose",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERBOSE]"
+        },
+        {
+            "command-line-flag": "--boutiques",
+            "description": "Flag toggling descriptor creation.",
+            "id": "boutiques",
+            "name": "boutiques",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[BOUTIQUES]"
+        },
+        {
+            "command-line-flag": "--gpu",
+            "description": "Toggles using GPU accelerated eddy.",
+            "id": "gpu",
+            "name": "gpu",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[GPU]"
+        },
+        {
+            "command-line-flag": "--fsldir",
+            "default-value": "/usr/share/fsl/",
+            "description": "Path to local installation of FSL. Defaults to /usr/share/fsl/.",
+            "id": "fsldir",
+            "name": "fsldir",
+            "optional": true,
+            "type": "String",
+            "value-key": "[FSLDIR]"
+        },
+        {
+            "command-line-flag": "--parcellation",
+            "description": "Parcellation/Label volumes which will be transformed into the subject/session DWI space.",
+            "id": "parcellation",
+            "list": true,
+            "name": "parcellation",
+            "optional": true,
+            "type": "String",
+            "value-key": "[PARCELLATION]"
+        }
+    ],
+    "name": "BIDS App - FSL Diffusion Preprocessing",
+    "output-files": [
+        {
+            "description": "Directory to store the preprocessed derivatives.",
+            "id": "output_dir_path",
+            "name": "Output directory",
+            "optional": false,
+            "path-template": "[OUTPUT_DIR]"
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 8,
+        "walltime-estimate": 10800
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "diffusion MRI",
+            "dwi"
+        ]
+    },
+    "tool-version": "5.0.9"
+}

--- a/app/static/pipelines/zenodo-2573071.json
+++ b/app/static/pipelines/zenodo-2573071.json
@@ -1,0 +1,89 @@
+{
+    "author": "Gilles Mathieu, using GATE application", 
+    "command-line": "unzip [INDATA]; source [GATERELEASEPATH]/env.sh [GATERELEASEPATH]; [GATERELEASEPATH]/shared_libs/ld-linux-x86-64.so.2 --library-path [GATERELEASEPATH]/root/lib:[GATERELEASEPATH]/shared_libs/ [GATERELEASEPATH]/Gate -a [Source_ID,[ORGANID]][particle,[PARTICLETYPE]][energy,[ENERGY]][nb,[NBPRIMARIES]] [MACFILE] > output.log;  tar czf [RESULTS] ./output output.log", 
+    "description": "Descriptor for the GATE command with input parameters, used for import in VIP via Boutiques", 
+    "error-codes": [
+        {
+            "code": 1, 
+            "description": "Crashed"
+        }
+    ], 
+    "inputs": [
+        {
+            "command-line-flag": "", 
+            "command-line-flag-separator": "", 
+            "id": "gatereleasepath", 
+            "name": "Path to the Gate Release used by the application", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[GATERELEASEPATH]"
+        }, 
+        {
+            "id": "indata", 
+            "name": "LFN of the archive containing all input data", 
+            "optional": false, 
+            "type": "File", 
+            "value-key": "[INDATA]"
+        }, 
+        {
+            "command-line-flag": "", 
+            "command-line-flag-separator": "", 
+            "id": "organid", 
+            "name": "Organ ID ref to the organs table", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[ORGANID]"
+        }, 
+        {
+            "command-line-flag": "", 
+            "command-line-flag-separator": "", 
+            "id": "particletype", 
+            "name": "Type of Particle to simulate", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[PARTICLETYPE]"
+        }, 
+        {
+            "command-line-flag": "", 
+            "command-line-flag-separator": "", 
+            "id": "energy", 
+            "name": "The level of energy to simulate", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[ENERGY]"
+        }, 
+        {
+            "command-line-flag": "", 
+            "command-line-flag-separator": "", 
+            "id": "nbprimaries", 
+            "name": "The number of primaries to simulate", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[NBPRIMARIES]"
+        }, 
+        {
+            "id": "macfile", 
+            "name": "The name of the main macro file", 
+            "optional": false, 
+            "type": "String", 
+            "value-key": "[MACFILE]"
+        }
+    ], 
+    "name": "GateCLforOpenDose", 
+    "output-files": [
+        {
+            "description": "archive of the output folder containing execution results, and the output of the command", 
+            "id": "results", 
+            "name": "results", 
+            "optional": false, 
+            "path-template": "OpenDose_[ORGANID]_[PARTICLETYPE]_[ENERGY]_[NBPRIMARIES].tar.gz", 
+            "value-key": "[RESULTS]"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "tags": {
+        "application": "GATE", 
+        "domain": "nuclear medicine"
+    }, 
+    "tool-version": "v0.2.0"
+}

--- a/app/static/pipelines/zenodo-2573287.json
+++ b/app/static/pipelines/zenodo-2573287.json
@@ -1,0 +1,189 @@
+{
+    "author": "Greg Kiar <gkiar.github.io>",
+    "command-line": "python3 /opt/oneVoxel.py [IMAGE_FILE] [OUTPUT_DIRECTORY] [MASK_FILE] [NO_SCALE] [INTENSITY] [ERODE] [LOCATION] [FORCE] [MODE] [CLEAN] [APPLY_NOISE] [VERBOSE] [BOUTIQUES]",
+    "container-image": {
+        "image": "gkiar/onevoxel:v0.2.0",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "description": "Adds 1-voxel noise to a Nifti image at either a provided or random location within a mask.",
+    "groups": [
+        {
+            "id": "noise_position_group",
+            "members": [
+                "mask_file",
+                "apply_noise"
+            ],
+            "name": "noise_position_group",
+            "one-is-required": true
+        }
+    ],
+    "inputs": [
+        {
+            "description": "Nifti image to be injected with one-voxel noise. Default behaviour is that this will be done at a random location within an image mask.",
+            "id": "image_file",
+            "name": "image_file",
+            "optional": false,
+            "type": "File",
+            "value-key": "[IMAGE_FILE]"
+        },
+        {
+            "description": "Path for where the resulting Nifti image with one voxel noise will be stored.",
+            "id": "output_directory",
+            "name": "output_directory",
+            "optional": false,
+            "type": "File",
+            "value-key": "[OUTPUT_DIRECTORY]"
+        },
+        {
+            "command-line-flag": "--mask_file",
+            "description": "Nifti image containing a binary mask for the input image. The noise location will be selected randomly within this mask, unless a location is provided.",
+            "id": "mask_file",
+            "name": "mask_file",
+            "optional": true,
+            "type": "File",
+            "value-key": "[MASK_FILE]"
+        },
+        {
+            "command-line-flag": "--no_scale",
+            "description": "Dictates the way in which noise is aplpied to the image. If set, the value specified with the intensity flag will be set to the new value. If not set, the intensity value will be multiplied by the original image value at the location.",
+            "id": "scale",
+            "name": "scale",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[NO_SCALE]"
+        },
+        {
+            "command-line-flag": "--intensity",
+            "default-value": 0.01,
+            "description": "The intensity of the noise to be injected in the image. Default value is 0.01 so specifying the scale flag alone will result in a 1%% intensity change at the target location.",
+            "id": "intensity",
+            "minimum": 0,
+            "name": "intensity",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[INTENSITY]"
+        },
+        {
+            "command-line-flag": "--erode",
+            "default-value": 3,
+            "description": "Value dictating how much to erode the binary mask before selecting a location for noise. The default value assumes a slightly generous mask.",
+            "id": "erode",
+            "integer": true,
+            "minimum": 0,
+            "name": "erode",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[ERODE]"
+        },
+        {
+            "command-line-flag": "--location",
+            "description": "Specifies a target location for injecting noise. This location must live within the provided mask in voxel coordinates. If not provided, a random location within the mask will be used.",
+            "id": "location",
+            "integer": true,
+            "list": true,
+            "name": "location",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[LOCATION]"
+        },
+        {
+            "command-line-flag": "--force",
+            "description": "Disables checks and restrictions on noise that may be not recommended for a typical workflow. By default, locations can only be specified within the mask, but this overrides that behaviour.",
+            "id": "force",
+            "name": "force",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FORCE]"
+        },
+        {
+            "command-line-flag": "--mode",
+            "default-value": "single",
+            "description": "Determines where noise will be injected in the case of higher-dimensional images than masks. 'Single' (default) will choose a single position in all higher dimensions, resulting in 1 point of noise. 'Uniform' will choose a location within the mask and apply it uniformly across all other dimensions. 'Independent' will generate a random location within the mask for each volume in the remaining dimensions, and is mutually exclusive with providing a location.",
+            "id": "mode",
+            "name": "mode",
+            "optional": true,
+            "type": "String",
+            "value-choices": [
+                "single",
+                "uniform",
+                "independent"
+            ],
+            "value-key": "[MODE]"
+        },
+        {
+            "command-line-flag": "--clean",
+            "description": "Deletes the noisy Nifti image from disk. This is intended to be used to save space, and the images can be regenerated using the 'apply' option and providing the associated JSON file.",
+            "id": "clean",
+            "name": "clean",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CLEAN]"
+        },
+        {
+            "command-line-flag": "--apply_noise",
+            "description": "Provided with a path to 1-voxel noise associated JSON file, will apply noise to the image. A hash is stored in this file to verify that the same noise is injected each time the file is created.",
+            "id": "apply_noise",
+            "name": "apply_noise",
+            "optional": true,
+            "type": "File",
+            "value-key": "[APPLY_NOISE]"
+        },
+        {
+            "command-line-flag": "--verbose",
+            "description": "Toggles verbose output printing.",
+            "id": "verbose",
+            "name": "verbose",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERBOSE]"
+        },
+        {
+            "command-line-flag": "--boutiques",
+            "description": "Toggles creation of a Boutiques descriptor and invocation from the tool and inputs.",
+            "id": "boutiques",
+            "name": "boutiques",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[BOUTIQUES]"
+        }
+    ],
+    "name": "oneVoxel",
+    "output-files": [
+        {
+            "id": "noisy_image",
+            "name": "Noisy Image",
+            "path-template": "[OUTPUT_DIRECTORY]*_1vox-*.nii.gz",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ],
+            "optional": true
+        },
+        {
+            "id": "noise_summary",
+            "name": "Noise Summary",
+            "path-template": "[OUTPUT_DIRECTORY]*_1vox-*.json",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ],
+            "optional": true
+        }
+    ],
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 2,
+        "walltime-estimate": 20
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "image processing",
+            "mri",
+            "noise"
+        ]
+    },
+    "tool-version": "v0.1.0"
+}

--- a/app/static/pipelines/zenodo-2587156.json
+++ b/app/static/pipelines/zenodo-2587156.json
@@ -1,0 +1,164 @@
+{
+    "inputs": [
+        {
+            "command-line-flag": "-dbtype", 
+            "description": "Molecule type of target db", 
+            "value-key": "[DBTYPE]", 
+            "optional": true, 
+            "value-choices": [
+                "nucl", 
+                "prot", 
+                "guess"
+            ], 
+            "type": "String", 
+            "id": "dbtype", 
+            "name": "Database Type"
+        }, 
+        {
+            "command-line-flag": "-db", 
+            "description": "Specify a database name", 
+            "value-key": "[DB]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "db", 
+            "name": "Database Name"
+        }, 
+        {
+            "command-line-flag": "-dir", 
+            "description": "Specify a directory containing one or more databases.", 
+            "disables-inputs": [
+                "db"
+            ], 
+            "type": "String", 
+            "value-key": "[DIR]", 
+            "optional": true, 
+            "id": "dir", 
+            "name": "Database Directory"
+        }, 
+        {
+            "command-line-flag": "-recursive", 
+            "description": "Specify true to recurse through all dbs in directory tree.", 
+            "value-key": "[RECURSIVE]", 
+            "type": "Flag", 
+            "requires-inputs": [
+                "dir"
+            ], 
+            "optional": true, 
+            "id": "recursive", 
+            "name": "Blast Archive File"
+        }, 
+        {
+            "command-line-flag": "-verbosity", 
+            "name": "Verbosity", 
+            "value-key": "[VERBOSITY]", 
+            "type": "Number", 
+            "maximum": 4, 
+            "minimum": 0, 
+            "optional": true, 
+            "id": "verbosity", 
+            "description": "Verbiosity of results.\n   0=Quiet, 1=Brief, 2=Summary, 3=Detailed, 4=Minutia"
+        }, 
+        {
+            "command-line-flag": "-full", 
+            "description": "If true, test every sequence (warning: may be slow).", 
+            "disables-inputs": [
+                "stride", 
+                "random", 
+                "ends"
+            ], 
+            "type": "Flag", 
+            "value-key": "[FULL]", 
+            "optional": true, 
+            "id": "full", 
+            "name": "Full Test"
+        }, 
+        {
+            "command-line-flag": "-stride", 
+            "description": "Check integrity of every Nth sequence.", 
+            "value-key": "[STRIDE]", 
+            "type": "Number", 
+            "minimum": 1, 
+            "optional": true, 
+            "id": "stride", 
+            "name": "Stride Sequence Integrity Test"
+        }, 
+        {
+            "command-line-flag": "-random", 
+            "description": "Check this many randomly selected sequences.", 
+            "value-key": "[RANDOM]", 
+            "type": "Number", 
+            "minimum": 1, 
+            "optional": true, 
+            "id": "random", 
+            "name": "Random Sequence Test"
+        }, 
+        {
+            "command-line-flag": "-ends", 
+            "description": "Check this many sequences at each end of the database.", 
+            "value-key": "[ENDS]", 
+            "type": "Number", 
+            "minimum": 1, 
+            "optional": true, 
+            "id": "ends", 
+            "name": "Database End Integrity Test"
+        }, 
+        {
+            "command-line-flag": "-no_isam", 
+            "description": "Disable ISAM testing.", 
+            "value-key": "[NO_ISAM]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "no_isam", 
+            "name": "NO ISAM Testing"
+        }, 
+        {
+            "command-line-flag": "-legacy", 
+            "description": "Enable check for existence of temporary files.", 
+            "value-key": "[LEGACY]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "legacy", 
+            "name": "Legacy temp file existence check"
+        }, 
+        {
+            "command-line-flag": "-must_have_taxids", 
+            "description": "Require that all sequences in the database have taxid set.", 
+            "value-key": "[MUST_HAVE_TAXIDS]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "must_have_taxids", 
+            "name": "Must Have taxid set"
+        }, 
+        {
+            "command-line-flag": "-cdd_delta", 
+            "description": "Do aditional tests for a CDD database for DELTA-BLAST", 
+            "value-key": "[CDD_DELTA]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "cdd_delta", 
+            "name": "Do CDD database tests for DELTA-BLAST"
+        }
+    ], 
+    "description": "BLAST database integrity and validity checking application", 
+    "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/blastdbcheck [DB] [DBTYPE] [DIR] [RECURSIVE] [VERBOSITY] [FULL] [STRIDE] [RANDOM] [ENDS] [NO_ISAM] [LEGACY] [MUST_HAVE_TAXIDS] [CDD_DELTA]", 
+    "author": "Altschul et al.", 
+    "tool-version": "v2.7.1", 
+    "tags": {
+        "domain": [
+            "bioinformatics", 
+            "blast"
+        ]
+    }, 
+    "container-image": {
+        "index": "docker://", 
+        "image": "c3genomics/genpipes", 
+        "type": "singularity"
+    }, 
+    "schema-version": "0.5", 
+    "suggested-resources": {
+        "walltime-estimate": 60, 
+        "ram": 1, 
+        "cpu-cores": 1
+    }, 
+    "name": "blastdbcheck"
+}

--- a/app/static/pipelines/zenodo-2587157.json
+++ b/app/static/pipelines/zenodo-2587157.json
@@ -1,0 +1,144 @@
+{
+    "tool-version": "v2.7.1", 
+    "description": "Stand-alone BLAST formatter client, version 2.7.1+", 
+    "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/blast_formatter [RID] [ARCHIVE] [OUTFORMAT] [fSHOWGIS] [NUM_DESCRIPTIONS] [NUM_ALIGNMENTS] [LINE_LENGTH] [fHTML] [MAX_TARGET_SEQS] [OUT] [fPARSE_DEFLINES]", 
+    "author": "Altschul et al.", 
+    "tags": {
+        "domain": [
+            "bioinformatics", 
+            "blast"
+        ]
+    }, 
+    "container-image": {
+        "index": "docker://", 
+        "image": "c3genomics/genpipes", 
+        "type": "singularity"
+    }, 
+    "inputs": [
+        {
+            "command-line-flag": "-show_gis", 
+            "description": "Show NCBI GIs in deflines?", 
+            "value-key": "[fSHOWGIS]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "show_gis", 
+            "name": "Show NCBI GIs"
+        }, 
+        {
+            "command-line-flag": "-html", 
+            "description": "Produce HTML Output", 
+            "value-key": "[fHTML]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "html", 
+            "name": "Show HTML"
+        }, 
+        {
+            "command-line-flag": "-parse_deflines", 
+            "description": "Should the query and subject defline(s) be parsed?", 
+            "value-key": "[fPARSE_DEFLINES]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "parse_deflines", 
+            "name": "Parse Deflines"
+        }, 
+        {
+            "command-line-flag": "-rid", 
+            "description": "BLAST Request ID (RID)", 
+            "disables-inputs": [
+                "archive"
+            ], 
+            "optional": true, 
+            "value-key": "[RID]", 
+            "type": "String", 
+            "id": "rid", 
+            "name": "BLAST Request ID"
+        }, 
+        {
+            "command-line-flag": "-archive", 
+            "description": "File containing BLAST Archive format in ASN.1 (i.e.: output format 11)", 
+            "value-key": "[ARCHIVE]", 
+            "optional": true, 
+            "type": "File", 
+            "id": "archive", 
+            "name": "Blast Archive File"
+        }, 
+        {
+            "command-line-flag": "-outfmt", 
+            "description": "   alignment view options:\n     0 = Pairwise,\n     1 = Query-anchored showing identities,\n     2 = Query-anchored no identities,\n     3 = Flat query-anchored showing identities,\n     4 = Flat query-anchored no identities,\n     5 = BLAST XML,\n     6 = Tabular,\n     7 = Tabular with comment lines,\n     8 = Seqalign (Text ASN.1),\n     9 = Seqalign (Binary ASN.1),\n    10 = Comma-separated values,\n    11 = BLAST archive (ASN.1),\n    12 = Seqalign (JSON),\n    13 = Multiple-file BLAST JSON,\n    14 = Multiple-file BLAST XML2,\n    15 = Single-file BLAST JSON,\n    16 = Single-file BLAST XML2,\n    17 = Sequence Alignment/Map (SAM),\n    18 = Organism Report\n\n   Options 6, 7, 10 and 17 can be additionally configured to produce\n   a custom format specified by space delimited format specifiers.\n   The supported format specifiers for options 6, 7 and 10 are:\n            qseqid means Query Seq-id\n               qgi means Query GI\n              qacc means Query accesion\n           qaccver means Query accesion.version\n              qlen means Query sequence length\n            sseqid means Subject Seq-id\n         sallseqid means All subject Seq-id(s), separated by a ';'\n               sgi means Subject GI\n            sallgi means All subject GIs\n              sacc means Subject accession\n           saccver means Subject accession.version\n           sallacc means All subject accessions\n              slen means Subject sequence length\n            qstart means Start of alignment in query\n              qend means End of alignment in query\n            sstart means Start of alignment in subject\n              send means End of alignment in subject\n              qseq means Aligned part of query sequence\n              sseq means Aligned part of subject sequence\n            evalue means Expect value\n          bitscore means Bit score\n             score means Raw score\n            length means Alignment length\n            pident means Percentage of identical matches\n            nident means Number of identical matches\n          mismatch means Number of mismatches\n          positive means Number of positive-scoring matches\n           gapopen means Number of gap openings\n              gaps means Total number of gaps\n              ppos means Percentage of positive-scoring matches\n            frames means Query and subject frames separated by a '/'\n            qframe means Query frame\n            sframe means Subject frame\n              btop means Blast traceback operations (BTOP)\n            staxid means Subject Taxonomy ID\n          ssciname means Subject Scientific Name\n          scomname means Subject Common Name\n        sblastname means Subject Blast Name\n         sskingdom means Subject Super Kingdom\n           staxids means unique Subject Taxonomy ID(s), separated by a ';'\n                         (in numerical order)\n         sscinames means unique Subject Scientific Name(s), separated by a ';'\n         scomnames means unique Subject Common Name(s), separated by a ';'\n        sblastnames means unique Subject Blast Name(s), separated by a ';'\n                         (in alphabetical order)\n        sskingdoms means unique Subject Super Kingdom(s), separated by a ';'\n                         (in alphabetical order)\n            stitle means Subject Title\n        salltitles means All Subject Title(s), separated by a '<>'\n           sstrand means Subject Strand\n             qcovs means Query Coverage Per Subject\n           qcovhsp means Query Coverage Per HSP\n            qcovus means Query Coverage Per Unique Subject (blastn only)\n   When not provided, the default value is:\n   'qaccver saccver pident length mismatch gapopen qstart qend sstart send\n   evalue bitscore', which is equivalent to the keyword 'std'\n   The supported format specifier for option 17 is:\n                SQ means Include Sequence Data\n                SR means Subject as Reference Seq\n  Default = `0'", 
+            "value-key": "[OUTFORMAT]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "outfmt", 
+            "name": "Alignment View Options"
+        }, 
+        {
+            "command-line-flag": "-num_descriptions", 
+            "description": "   Number of database sequences to show one-line descriptions for\n   Not applicable for outfmt > 4\n   Default = `500'", 
+            "value-key": "[NUM_DESCRIPTIONS]", 
+            "optional": true, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "num_descriptions", 
+            "name": "Number of Sequence Descriptions to Show"
+        }, 
+        {
+            "command-line-flag": "-num_alignments", 
+            "description": "   Number of database sequences to show alignments for\n   Default = `250'", 
+            "value-key": "[NUM_ALIGNMENTS]", 
+            "optional": true, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "num_alignments", 
+            "name": "Number of Sequence Alignments to Show"
+        }, 
+        {
+            "command-line-flag": "-line_length", 
+            "description": "   Line length for formatting alignments\n   Not applicable for outfmt > 4\n   Default = `60'", 
+            "value-key": "[LINE_LENGTH]", 
+            "optional": true, 
+            "minimum": 1, 
+            "type": "Number", 
+            "id": "line_length", 
+            "name": "Line Length"
+        }, 
+        {
+            "command-line-flag": "-max_target_seqs", 
+            "description": "   Maximum number of aligned sequences to keep\n   Not applicable for outfmt <= 4\n   Default = `500'", 
+            "value-key": "[MAX_TARGET_SEQS]", 
+            "optional": true, 
+            "disables-inputs": [
+                "num_descriptions", 
+                "num_alignments"
+            ], 
+            "minimum": 1, 
+            "type": "Number", 
+            "id": "max_target_seqs", 
+            "name": "Maximum Number of Aligned Sequences to Keep"
+        }, 
+        {
+            "command-line-flag": "-out", 
+            "description": "   Output file name", 
+            "value-key": "[OUT]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "out", 
+            "name": "Output file name"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[OUT]", 
+            "optional": false, 
+            "id": "output", 
+            "name": "Output File"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 60, 
+        "ram": 1, 
+        "cpu-cores": 1
+    }, 
+    "name": "blast_formatter"
+}

--- a/app/static/pipelines/zenodo-2587160.json
+++ b/app/static/pipelines/zenodo-2587160.json
@@ -1,0 +1,238 @@
+{
+    "tool-version": "v2.7.1", 
+    "description": "Application to create BLAST databases, version 2.7.1+", 
+    "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/makeblastdb [IN] [INPUT_TYPE] [DBTYPE] [TITLE] [fPARSE_SEQIDS] [fHASHINDEX] [MASK_DATA_FILES] [MASK_ALGO_IDS] [MASK_DESC] [fGI_MASK] [GI_MASK_NAME] [OUT] [MAX_FILE_SIZE] [LOG_FILE] [TAX_ID] [TAX_ID_MAP]", 
+    "author": "Altschul et al.", 
+    "tags": {
+        "domain": [
+            "bioinformatics", 
+            "blast"
+        ]
+    }, 
+    "container-image": {
+        "index": "docker://", 
+        "image": "c3genomics/genpipes", 
+        "type": "singularity"
+    }, 
+    "inputs": [
+        {
+            "command-line-flag": "-parse_seqids", 
+            "description": "A flag which enables parsing of sequence ids", 
+            "value-key": "[fPARSE_SEQIDS]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "parse_seqids", 
+            "name": "Parse Sequence IDs flag"
+        }, 
+        {
+            "command-line-flag": "-hash_index", 
+            "description": "A flag which enables the creation of sequence hash values. These hash values can then be used to quickly determine if a given sequence data exists in this BLAST database.", 
+            "value-key": "[fHASHINDEX]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "hash_index", 
+            "name": "Enable Hash indexes"
+        }, 
+        {
+            "command-line-flag": "-gi_mask", 
+            "description": "A flag which creates GI indexed masking data.", 
+            "value-key": "[fGI_MASK]", 
+            "optional": true, 
+            "requires-inputs": [
+                "parse_seqids"
+            ], 
+            "type": "Flag", 
+            "id": "gi_mask", 
+            "name": "GI indexed masking data flag"
+        }, 
+        {
+            "command-line-flag": "-gi_mask_name", 
+            "description": "Comma-separated list of masking data output files.", 
+            "value-key": "[GI_MASK_NAME]", 
+            "type": "File", 
+            "list": true, 
+            "requires-inputs": [
+                "mask_data", 
+                "gi_mask"
+            ], 
+            "list-separator": ",", 
+            "optional": true, 
+            "id": "gi_mask_name", 
+            "min-list-entries": 1, 
+            "name": "Masking data"
+        }, 
+        {
+            "command-line-flag": "-dbtype", 
+            "description": "Molecule type of target db", 
+            "value-key": "[DBTYPE]", 
+            "optional": false, 
+            "value-choices": [
+                "nucl", 
+                "prot"
+            ], 
+            "type": "String", 
+            "id": "dbtype", 
+            "name": "Database Type"
+        }, 
+        {
+            "command-line-flag": "-in", 
+            "description": "The input source, either a file name or standard in (-, the default)", 
+            "value-key": "[IN]", 
+            "optional": true, 
+            "type": "File", 
+            "id": "in", 
+            "name": "Input file/database name"
+        }, 
+        {
+            "command-line-flag": "-out", 
+            "description": "   Name of BLAST database to be created\n   Default = input file name provided to -in argument\n   Required if multiple file(s)/database(s)\n   are provided as input", 
+            "value-key": "[OUT]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "out", 
+            "name": "Name of BLAST database to be created"
+        }, 
+        {
+            "command-line-flag": "-input_type", 
+            "description": "Type of the data specified in input_file. Will default to 'fasta'", 
+            "value-key": "[INPUT_TYPE]", 
+            "optional": true, 
+            "value-choices": [
+                "asn1_bin", 
+                "asn1_txt", 
+                "blastdb", 
+                "fasta"
+            ], 
+            "type": "String", 
+            "id": "input_type", 
+            "name": "Type of the data specified in input_file"
+        }, 
+        {
+            "command-line-flag": "-title", 
+            "description": "Title for BLAST database. Defaults to input file name.", 
+            "value-key": "[TITLE]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "title", 
+            "name": "Title for BLAST database"
+        }, 
+        {
+            "command-line-flag": "-mask_data", 
+            "description": "Title for BLAST database. Defaults to input file name.", 
+            "value-key": "[MASK_DATA_FILES]", 
+            "type": "File", 
+            "list": true, 
+            "list-separator": ",", 
+            "optional": true, 
+            "id": "mask_data", 
+            "min-list-entries": 1, 
+            "name": "Title for BLAST database"
+        }, 
+        {
+            "command-line-flag": "-mask_id", 
+            "description": "Comma-separated list of strings to uniquely identify the masking algorithm.", 
+            "value-key": "[MASK_ALGO_IDS]", 
+            "type": "String", 
+            "list": true, 
+            "requires-inputs": [
+                "mask_data"
+            ], 
+            "list-separator": ",", 
+            "disables-inputs": [
+                "gi_mask"
+            ], 
+            "optional": true, 
+            "id": "mask_id", 
+            "min-list-entries": 1, 
+            "name": "Masking Algorithm"
+        }, 
+        {
+            "command-line-flag": "-mask_desc", 
+            "description": "Comma-separated list of free form strings to describe the masking algorithm details.", 
+            "value-key": "[MASK_DESC]", 
+            "type": "String", 
+            "list": true, 
+            "requires-inputs": [
+                "mask_id"
+            ], 
+            "list-separator": ",", 
+            "optional": true, 
+            "id": "mask_desc", 
+            "min-list-entries": 1, 
+            "name": "Masking Algorithm Details"
+        }, 
+        {
+            "command-line-flag": "-max_file_sz", 
+            "description": "Maximum file size for BLAST database files.", 
+            "value-key": "[MAX_FILE_SIZE]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "max_file_sz", 
+            "name": "Max database file size"
+        }, 
+        {
+            "command-line-flag": "-logfile", 
+            "description": "File to which the program log should be redirected.", 
+            "value-key": "[LOG_FILE]", 
+            "optional": true, 
+            "type": "File", 
+            "id": "logfile", 
+            "name": "Log file"
+        }, 
+        {
+            "command-line-flag": "-taxid", 
+            "description": "Taxonomy ID to assign to all sequences.", 
+            "value-key": "[TAX_ID]", 
+            "optional": true, 
+            "disables-inputs": [
+                "taxid_map"
+            ], 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "taxid", 
+            "name": "Taxonomy ID"
+        }, 
+        {
+            "command-line-flag": "-taxid_map", 
+            "description": "Text file mapping sequence IDs to taxonomy IDs.", 
+            "value-key": "[TAX_ID_MAP]", 
+            "optional": true, 
+            "requires-inputs": [
+                "parse_seqids"
+            ], 
+            "disables-inputs": [
+                "taxid"
+            ], 
+            "type": "File", 
+            "id": "taxid_map", 
+            "name": "Sequence to taxonomy mapping"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[OUT].phr", 
+            "optional": false, 
+            "id": "outputdbphr", 
+            "name": "Output Database Headers"
+        }, 
+        {
+            "path-template": "[OUT].psq", 
+            "optional": false, 
+            "id": "outputdbpsq", 
+            "name": "Output Database Binary Sequences"
+        }, 
+        {
+            "path-template": "[OUT].pin", 
+            "optional": false, 
+            "id": "outputdbpin", 
+            "name": "Output Database Index File"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 60, 
+        "ram": 1, 
+        "cpu-cores": 1
+    }, 
+    "name": "makeblastdb"
+}

--- a/app/static/pipelines/zenodo-2597643.json
+++ b/app/static/pipelines/zenodo-2597643.json
@@ -1,0 +1,504 @@
+{
+    "name": "FLIRT",
+    "command-line": "flirt [ANGLE_REP] [APPLY_ISOXFM] [APPLY_XFM] [BBRSLOPE] [BBRTYPE] [BGVALUE] [BINS] [COARSE_SEARCH] [COST] [COST_FUNC] [DATATYPE] [DOF] [ECHOSPACING] [FIELDMAP] [FIELDMAPMASK] [FINE_SEARCH] [FORCE_SCALING] [IN_FILE] [IN_MATRIX_FILE] [IN_WEIGHT] [INTERP] [MIN_SAMPLING] [NO_CLAMP] [NO_RESAMPLE] [NO_RESAMPLE_BLUR] [NO_SEARCH] [PADDING_SIZE] [PEDIR] [REF_WEIGHT] [REFERENCE] [RIGID2D] [SCHEDULE] [SEARCHR_X] [SEARCHR_Y] [SEARCHR_Z] [SINC_WIDTH] [SINC_WINDOW] [USES_QFORM] [VERBOSE] [WM_SEG] [WMCOORDS] [WMNORMS] [OUT_FILE] [OUT_MATRIX_FILE]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "FLIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FLIRT).",
+    "inputs": [
+        {
+            "id": "angle_rep",
+            "name": "Angle rep",
+            "type": "String",
+            "value-key": "[ANGLE_REP]",
+            "command-line-flag": "-anglerep",
+            "description": "'quaternion' or 'euler'. Representation of rotation angles.",
+            "optional": true,
+            "value-choices": [
+                "quaternion",
+                "euler"
+            ]
+        },
+        {
+            "id": "apply_isoxfm",
+            "name": "Apply isoxfm",
+            "type": "Number",
+            "value-key": "[APPLY_ISOXFM]",
+            "command-line-flag": "-applyisoxfm",
+            "description": "A float. As applyxfm but forces isotropic resampling.",
+            "optional": true
+        },
+        {
+            "id": "apply_xfm",
+            "name": "Apply xfm",
+            "type": "Flag",
+            "value-key": "[APPLY_XFM]",
+            "command-line-flag": "-applyxfm",
+            "description": "A boolean. Apply transformation supplied by in_matrix_file or uses_qform to use the affine matrix stored in the reference header.",
+            "optional": true
+        },
+        {
+            "id": "bbrslope",
+            "name": "Bbrslope",
+            "type": "Number",
+            "value-key": "[BBRSLOPE]",
+            "command-line-flag": "-bbrslope",
+            "description": "A float. Value of bbr slope.",
+            "optional": true
+        },
+        {
+            "id": "bbrtype",
+            "name": "Bbrtype",
+            "type": "String",
+            "value-key": "[BBRTYPE]",
+            "command-line-flag": "-bbrtype",
+            "description": "'signed' or 'global_abs' or 'local_abs'. Type of bbr cost function: signed [default], global_abs, local_abs.",
+            "optional": true,
+            "value-choices": [
+                "signed",
+                "global_abs",
+                "local_abs"
+            ]
+        },
+        {
+            "id": "bgvalue",
+            "name": "Bgvalue",
+            "type": "Number",
+            "value-key": "[BGVALUE]",
+            "command-line-flag": "-setbackground",
+            "description": "A float. Use specified background value for points outside fov.",
+            "optional": true
+        },
+        {
+            "id": "bins",
+            "name": "Bins",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[BINS]",
+            "command-line-flag": "-bins",
+            "description": "An integer (int or long). Number of histogram bins.",
+            "optional": true
+        },
+        {
+            "id": "coarse_search",
+            "name": "Coarse search",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[COARSE_SEARCH]",
+            "command-line-flag": "-coarsesearch",
+            "description": "An integer (int or long). Coarse search delta angle.",
+            "optional": true
+        },
+        {
+            "id": "cost",
+            "name": "Cost",
+            "type": "String",
+            "value-key": "[COST]",
+            "command-line-flag": "-cost",
+            "description": "'mutualinfo' or 'corratio' or 'normcorr' or 'normmi' or 'leastsq' or 'labeldiff' or 'bbr'. Cost function.",
+            "optional": true,
+            "value-choices": [
+                "mutualinfo",
+                "corratio",
+                "normcorr",
+                "normmi",
+                "leastsq",
+                "labeldiff",
+                "bbr"
+            ]
+        },
+        {
+            "id": "cost_func",
+            "name": "Cost func",
+            "type": "String",
+            "value-key": "[COST_FUNC]",
+            "command-line-flag": "-searchcost",
+            "description": "'mutualinfo' or 'corratio' or 'normcorr' or 'normmi' or 'leastsq' or 'labeldiff' or 'bbr'. Cost function.",
+            "optional": true,
+            "value-choices": [
+                "mutualinfo",
+                "corratio",
+                "normcorr",
+                "normmi",
+                "leastsq",
+                "labeldiff",
+                "bbr"
+            ]
+        },
+        {
+            "id": "datatype",
+            "name": "Datatype",
+            "type": "String",
+            "value-key": "[DATATYPE]",
+            "command-line-flag": "-datatype",
+            "description": "'char' or 'short' or 'int' or 'float' or 'double'. Force output data type.",
+            "optional": true,
+            "value-choices": [
+                "char",
+                "short",
+                "int",
+                "float",
+                "double"
+            ]
+        },
+        {
+            "id": "dof",
+            "name": "Dof",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[DOF]",
+            "command-line-flag": "-dof",
+            "description": "An integer (int or long). Number of transform degrees of freedom.",
+            "optional": true
+        },
+        {
+            "id": "echospacing",
+            "name": "Echospacing",
+            "type": "Number",
+            "value-key": "[ECHOSPACING]",
+            "command-line-flag": "-echospacing",
+            "description": "A float. Value of epi echo spacing - units of seconds.",
+            "optional": true
+        },
+        {
+            "id": "fieldmap",
+            "name": "Fieldmap",
+            "type": "File",
+            "value-key": "[FIELDMAP]",
+            "command-line-flag": "-fieldmap",
+            "description": "A file name. Fieldmap image in rads/s - must be already registered to the reference image.",
+            "optional": true
+        },
+        {
+            "id": "fieldmapmask",
+            "name": "Fieldmapmask",
+            "type": "File",
+            "value-key": "[FIELDMAPMASK]",
+            "command-line-flag": "-fieldmapmask",
+            "description": "A file name. Mask for fieldmap image.",
+            "optional": true
+        },
+        {
+            "id": "fine_search",
+            "name": "Fine search",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[FINE_SEARCH]",
+            "command-line-flag": "-finesearch",
+            "description": "An integer (int or long). Fine search delta angle.",
+            "optional": true
+        },
+        {
+            "id": "force_scaling",
+            "name": "Force scaling",
+            "type": "Flag",
+            "value-key": "[FORCE_SCALING]",
+            "command-line-flag": "-forcescaling",
+            "description": "A boolean. Force rescaling even for low-res images.",
+            "optional": true
+        },
+        {
+            "id": "in_file",
+            "name": "In file",
+            "type": "File",
+            "value-key": "[IN_FILE]",
+            "command-line-flag": "-in",
+            "description": "An existing file name. Input file.",
+            "optional": false
+        },
+        {
+            "id": "in_matrix_file",
+            "name": "In matrix file",
+            "type": "File",
+            "value-key": "[IN_MATRIX_FILE]",
+            "command-line-flag": "-init",
+            "description": "A file name. Input 4x4 affine matrix.",
+            "optional": true
+        },
+        {
+            "id": "in_weight",
+            "name": "In weight",
+            "type": "File",
+            "value-key": "[IN_WEIGHT]",
+            "command-line-flag": "-inweight",
+            "description": "An existing file name. File for input weighting volume.",
+            "optional": true
+        },
+        {
+            "id": "interp",
+            "name": "Interp",
+            "type": "String",
+            "value-key": "[INTERP]",
+            "command-line-flag": "-interp",
+            "description": "'trilinear' or 'nearestneighbour' or 'sinc' or 'spline'. Final interpolation method used in reslicing.",
+            "optional": true,
+            "value-choices": [
+                "trilinear",
+                "nearestneighbour",
+                "sinc",
+                "spline"
+            ]
+        },
+        {
+            "id": "min_sampling",
+            "name": "Min sampling",
+            "type": "Number",
+            "value-key": "[MIN_SAMPLING]",
+            "command-line-flag": "-minsampling",
+            "description": "A float. Set minimum voxel dimension for sampling.",
+            "optional": true
+        },
+        {
+            "id": "no_clamp",
+            "name": "No clamp",
+            "type": "Flag",
+            "value-key": "[NO_CLAMP]",
+            "command-line-flag": "-noclamp",
+            "description": "A boolean. Do not use intensity clamping.",
+            "optional": true
+        },
+        {
+            "id": "no_resample",
+            "name": "No resample",
+            "type": "Flag",
+            "value-key": "[NO_RESAMPLE]",
+            "command-line-flag": "-noresample",
+            "description": "A boolean. Do not change input sampling.",
+            "optional": true
+        },
+        {
+            "id": "no_resample_blur",
+            "name": "No resample blur",
+            "type": "Flag",
+            "value-key": "[NO_RESAMPLE_BLUR]",
+            "command-line-flag": "-noresampblur",
+            "description": "A boolean. Do not use blurring on downsampling.",
+            "optional": true
+        },
+        {
+            "id": "no_search",
+            "name": "No search",
+            "type": "Flag",
+            "value-key": "[NO_SEARCH]",
+            "command-line-flag": "-nosearch",
+            "description": "A boolean. Set all angular searches to ranges 0 to 0.",
+            "optional": true
+        },
+        {
+            "id": "padding_size",
+            "name": "Padding size",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[PADDING_SIZE]",
+            "command-line-flag": "-paddingsize",
+            "description": "An integer (int or long). For applyxfm: interpolates outside image by size.",
+            "optional": true
+        },
+        {
+            "id": "pedir",
+            "name": "Pedir",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[PEDIR]",
+            "command-line-flag": "-pedir",
+            "description": "An integer (int or long). Phase encode direction of epi - 1/2/3=x/y/z & -1/-2/-3=-x/-y/-z.",
+            "optional": true
+        },
+        {
+            "id": "ref_weight",
+            "name": "Ref weight",
+            "type": "File",
+            "value-key": "[REF_WEIGHT]",
+            "command-line-flag": "-refweight",
+            "description": "An existing file name. File for reference weighting volume.",
+            "optional": true
+        },
+        {
+            "id": "reference",
+            "name": "Reference",
+            "type": "File",
+            "value-key": "[REFERENCE]",
+            "command-line-flag": "-ref",
+            "description": "An existing file name. Reference file.",
+            "optional": false
+        },
+        {
+            "id": "rigid2D",
+            "name": "Rigid2d",
+            "type": "Flag",
+            "value-key": "[RIGID2D]",
+            "command-line-flag": "-2D",
+            "description": "A boolean. Use 2d rigid body mode - ignores dof.",
+            "optional": true
+        },
+        {
+            "id": "schedule",
+            "name": "Schedule",
+            "type": "File",
+            "value-key": "[SCHEDULE]",
+            "command-line-flag": "-schedule",
+            "description": "An existing file name. Replaces default schedule.",
+            "optional": true
+        },
+        {
+            "id": "searchr_x",
+            "name": "Searchr x",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "min-list-entries": 2,
+            "max-list-entries": 2,
+            "value-key": "[SEARCHR_X]",
+            "command-line-flag": "-searchrx",
+            "description": "A list of from 2 to 2 items which are an integer (int or long). Search angles along x-axis, in degrees.",
+            "optional": true
+        },
+        {
+            "id": "searchr_y",
+            "name": "Searchr y",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "min-list-entries": 2,
+            "max-list-entries": 2,
+            "value-key": "[SEARCHR_Y]",
+            "command-line-flag": "-searchry",
+            "description": "A list of from 2 to 2 items which are an integer (int or long). Search angles along y-axis, in degrees.",
+            "optional": true
+        },
+        {
+            "id": "searchr_z",
+            "name": "Searchr z",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "min-list-entries": 2,
+            "max-list-entries": 2,
+            "value-key": "[SEARCHR_Z]",
+            "command-line-flag": "-searchrz",
+            "description": "A list of from 2 to 2 items which are an integer (int or long). Search angles along z-axis, in degrees.",
+            "optional": true
+        },
+        {
+            "id": "sinc_width",
+            "name": "Sinc width",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[SINC_WIDTH]",
+            "command-line-flag": "-sincwidth",
+            "description": "An integer (int or long). Full-width in voxels.",
+            "optional": true
+        },
+        {
+            "id": "sinc_window",
+            "name": "Sinc window",
+            "type": "String",
+            "value-key": "[SINC_WINDOW]",
+            "command-line-flag": "-sincwindow",
+            "description": "'rectangular' or 'hanning' or 'blackman'. Sinc window.",
+            "optional": true,
+            "value-choices": [
+                "rectangular",
+                "hanning",
+                "blackman"
+            ]
+        },
+        {
+            "id": "uses_qform",
+            "name": "Uses qform",
+            "type": "Flag",
+            "value-key": "[USES_QFORM]",
+            "command-line-flag": "-usesqform",
+            "description": "A boolean. Initialize using sform or qform.",
+            "optional": true
+        },
+        {
+            "id": "verbose",
+            "name": "Verbose",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[VERBOSE]",
+            "command-line-flag": "-verbose",
+            "description": "An integer (int or long). Verbose mode, 0 is least.",
+            "optional": true
+        },
+        {
+            "id": "wm_seg",
+            "name": "Wm seg",
+            "type": "File",
+            "value-key": "[WM_SEG]",
+            "command-line-flag": "-wmseg",
+            "description": "A file name. White matter segmentation volume needed by bbr cost function.",
+            "optional": true
+        },
+        {
+            "id": "wmcoords",
+            "name": "Wmcoords",
+            "type": "File",
+            "value-key": "[WMCOORDS]",
+            "command-line-flag": "-wmcoords",
+            "description": "A file name. White matter boundary coordinates for bbr cost function.",
+            "optional": true
+        },
+        {
+            "id": "wmnorms",
+            "name": "Wmnorms",
+            "type": "File",
+            "value-key": "[WMNORMS]",
+            "command-line-flag": "-wmnorms",
+            "description": "A file name. White matter boundary normals for bbr cost function.",
+            "optional": true
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Out file",
+            "id": "out_file",
+            "path-template": "[IN_FILE]_flirt",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ],
+            "optional": true,
+            "description": "An existing file name. Path/name of registered file (if generated).",
+            "value-key": "[OUT_FILE]",
+            "command-line-flag": "-out"
+        },
+        {
+            "name": "Out matrix file",
+            "id": "out_matrix_file",
+            "path-template": "[IN_FILE]_flirt.mat",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ],
+            "optional": true,
+            "description": "An existing file name. Path/name of calculated affine transform (if generated).",
+            "value-key": "[OUT_MATRIX_FILE]",
+            "command-line-flag": "-omat"
+        }
+    ],
+    "groups": [
+        {
+            "id": "mutex_group",
+            "name": "Mutex group",
+            "members": [
+                "apply_xfm",
+                "apply_isoxfm"
+            ],
+            "mutually-exclusive": true
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "fmri"
+        ],
+        "source": "nipype-interface"
+    }
+}

--- a/app/static/pipelines/zenodo-2601876.json
+++ b/app/static/pipelines/zenodo-2601876.json
@@ -1,0 +1,262 @@
+{
+    "name": "DTIFit",
+    "command-line": "dtifit [DWI] [BASE_NAME] [MASK] [BVECS] [BVALS] [CNI] [GRADNONLIN] [LITTLE_BIT] [MAX_X] [MAX_Y] [MAX_Z] [MIN_X] [MIN_Y] [MIN_Z] [SAVE_TENSOR] [SSE]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "DTIFit, as implemented in Nipype (module: nipype.interfaces.fsl, interface: DTIFit).",
+    "inputs": [
+        {
+            "id": "base_name",
+            "name": "Base name",
+            "type": "String",
+            "value-key": "[BASE_NAME]",
+            "command-line-flag": "-o",
+            "description": "A unicode string. Base_name that all output files will start with.",
+            "optional": true,
+            "default-value": "dtifit_"
+        },
+        {
+            "id": "bvals",
+            "name": "Bvals",
+            "type": "File",
+            "value-key": "[BVALS]",
+            "command-line-flag": "-b",
+            "description": "An existing file name. B values file.",
+            "optional": false
+        },
+        {
+            "id": "bvecs",
+            "name": "Bvecs",
+            "type": "File",
+            "value-key": "[BVECS]",
+            "command-line-flag": "-r",
+            "description": "An existing file name. B vectors file.",
+            "optional": false
+        },
+        {
+            "id": "cni",
+            "name": "Cni",
+            "type": "File",
+            "value-key": "[CNI]",
+            "command-line-flag": "--cni",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Input confound regressors.",
+            "optional": true
+        },
+        {
+            "id": "dwi",
+            "name": "Dwi",
+            "type": "File",
+            "value-key": "[DWI]",
+            "command-line-flag": "-k",
+            "description": "An existing file name. Diffusion weighted image data file.",
+            "optional": false
+        },
+        {
+            "id": "gradnonlin",
+            "name": "Gradnonlin",
+            "type": "File",
+            "value-key": "[GRADNONLIN]",
+            "command-line-flag": "--gradnonlin",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Gradient non linearities.",
+            "optional": true
+        },
+        {
+            "id": "little_bit",
+            "name": "Little bit",
+            "type": "Flag",
+            "value-key": "[LITTLE_BIT]",
+            "command-line-flag": "--littlebit",
+            "description": "A boolean. Only process small area of brain.",
+            "optional": true
+        },
+        {
+            "id": "mask",
+            "name": "Mask",
+            "type": "File",
+            "value-key": "[MASK]",
+            "command-line-flag": "-m",
+            "description": "An existing file name. Bet binary mask file.",
+            "optional": false
+        },
+        {
+            "id": "max_x",
+            "name": "Max x",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[MAX_X]",
+            "command-line-flag": "-X",
+            "description": "An integer (int or long). Max x.",
+            "optional": true
+        },
+        {
+            "id": "max_y",
+            "name": "Max y",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[MAX_Y]",
+            "command-line-flag": "-Y",
+            "description": "An integer (int or long). Max y.",
+            "optional": true
+        },
+        {
+            "id": "max_z",
+            "name": "Max z",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[MAX_Z]",
+            "command-line-flag": "-Z",
+            "description": "An integer (int or long). Max z.",
+            "optional": true
+        },
+        {
+            "id": "min_x",
+            "name": "Min x",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[MIN_X]",
+            "command-line-flag": "-x",
+            "description": "An integer (int or long). Min x.",
+            "optional": true
+        },
+        {
+            "id": "min_y",
+            "name": "Min y",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[MIN_Y]",
+            "command-line-flag": "-y",
+            "description": "An integer (int or long). Min y.",
+            "optional": true
+        },
+        {
+            "id": "min_z",
+            "name": "Min z",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[MIN_Z]",
+            "command-line-flag": "-z",
+            "description": "An integer (int or long). Min z.",
+            "optional": true
+        },
+        {
+            "id": "save_tensor",
+            "name": "Save tensor",
+            "type": "Flag",
+            "value-key": "[SAVE_TENSOR]",
+            "command-line-flag": "--save_tensor",
+            "description": "A boolean. Save the elements of the tensor.",
+            "optional": true
+        },
+        {
+            "id": "sse",
+            "name": "Sse",
+            "type": "Flag",
+            "value-key": "[SSE]",
+            "command-line-flag": "--sse",
+            "description": "A boolean. Output sum of squared errors.",
+            "optional": true
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Fa",
+            "id": "FA",
+            "path-template": "dtifit__FA.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the fractional anisotropy."
+        },
+        {
+            "name": "L1",
+            "id": "L1",
+            "path-template": "dtifit__L1.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the 1st eigenvalue."
+        },
+        {
+            "name": "L2",
+            "id": "L2",
+            "path-template": "dtifit__L2.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the 2nd eigenvalue."
+        },
+        {
+            "name": "L3",
+            "id": "L3",
+            "path-template": "dtifit__L3.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the 3rd eigenvalue."
+        },
+        {
+            "name": "Md",
+            "id": "MD",
+            "path-template": "dtifit__MD.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the mean diffusivity."
+        },
+        {
+            "name": "Mo",
+            "id": "MO",
+            "path-template": "dtifit__MO.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the mode of anisotropy."
+        },
+        {
+            "name": "S0",
+            "id": "S0",
+            "path-template": "dtifit__S0.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the raw t2 signal with no diffusion weighting."
+        },
+        {
+            "name": "V1",
+            "id": "V1",
+            "path-template": "dtifit__V1.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the 1st eigenvector."
+        },
+        {
+            "name": "V2",
+            "id": "V2",
+            "path-template": "dtifit__V2.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the 2nd eigenvector."
+        },
+        {
+            "name": "V3",
+            "id": "V3",
+            "path-template": "dtifit__V3.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the 3rd eigenvector."
+        },
+        {
+            "name": "Sse",
+            "id": "sse_outfile",
+            "path-template": "dtifit__sse.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the summed squared error."
+        },
+        {
+            "name": "Tensor",
+            "id": "tensor",
+            "path-template": "dtifit__tensor.nii",
+            "optional": true,
+            "description": "An existing file name. Path/name of file with the 4d tensor volume."
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "dmri"
+        ],
+        "source": "nipype-interface"
+    },
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/dti.py"
+}

--- a/app/static/pipelines/zenodo-2602072.json
+++ b/app/static/pipelines/zenodo-2602072.json
@@ -1,0 +1,406 @@
+{
+    "name": "BEDPOSTX5",
+    "command-line": "bedpostx [OUT_DIR] [ALL_ARD] [BURN_IN] [BURN_IN_NO_ARD] [BVALS] [BVECS] [CNLINEAR] [DWI] [F0_ARD] [F0_NOARD] [FORCE_DIR] [FUDGE] [GRAD_DEV] [GRADNONLIN] [LOGDIR] [MASK] [MODEL] [N_FIBRES] [N_JUMPS] [NO_ARD] [NO_SPAT] [NON_LINEAR] [RICIAN] [SAMPLE_EVERY] [SEED] [UPDATE_PROPOSAL_EVERY] [USE_GPU]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "BEDPOSTX5, as implemented in Nipype (module: nipype.interfaces.fsl, interface: BEDPOSTX5).",
+    "inputs": [
+        {
+            "id": "all_ard",
+            "name": "All ard",
+            "type": "Flag",
+            "value-key": "[ALL_ARD]",
+            "command-line-flag": "--allard",
+            "description": "A boolean. Turn ard on on all fibres.",
+            "optional": true
+        },
+        {
+            "id": "burn_in",
+            "name": "Burn in",
+            "type": "Number",
+            "minimum": 0,
+            "value-key": "[BURN_IN]",
+            "command-line-flag": "-b",
+            "description": "A long integer >= 0. Total num of jumps at start of mcmc to be discarded.",
+            "optional": true,
+            "default-value": 0
+        },
+        {
+            "id": "burn_in_no_ard",
+            "name": "Burn in no ard",
+            "type": "Number",
+            "minimum": 0,
+            "value-key": "[BURN_IN_NO_ARD]",
+            "command-line-flag": "--burnin_noard",
+            "command-line-flag-separator": "=",
+            "description": "A long integer >= 0. Num of burnin jumps before the ard is imposed.",
+            "optional": true,
+            "default-value": 0
+        },
+        {
+            "id": "bvals",
+            "name": "Bvals",
+            "type": "File",
+            "value-key": "[BVALS]",
+            "description": "An existing file name. B values file.",
+            "optional": false
+        },
+        {
+            "id": "bvecs",
+            "name": "Bvecs",
+            "type": "File",
+            "value-key": "[BVECS]",
+            "description": "An existing file name. B vectors file.",
+            "optional": false
+        },
+        {
+            "id": "cnlinear",
+            "name": "Cnlinear",
+            "type": "Flag",
+            "value-key": "[CNLINEAR]",
+            "command-line-flag": "--cnonlinear",
+            "description": "A boolean. Initialise with constrained nonlinear fitting.",
+            "optional": true
+        },
+        {
+            "id": "dwi",
+            "name": "Dwi",
+            "type": "File",
+            "value-key": "[DWI]",
+            "description": "An existing file name. Diffusion weighted image data file.",
+            "optional": false
+        },
+        {
+            "id": "f0_ard",
+            "name": "F0 ard",
+            "type": "Flag",
+            "value-key": "[F0_ARD]",
+            "command-line-flag": "--f0 --ardf0",
+            "description": "A boolean. Noise floor model: add to the model an unattenuated signal compartment f0.",
+            "optional": true
+        },
+        {
+            "id": "f0_noard",
+            "name": "F0 noard",
+            "type": "Flag",
+            "value-key": "[F0_NOARD]",
+            "command-line-flag": "--f0",
+            "description": "A boolean. Noise floor model: add to the model an unattenuated signal compartment f0.",
+            "optional": true
+        },
+        {
+            "id": "force_dir",
+            "name": "Force dir",
+            "type": "Flag",
+            "value-key": "[FORCE_DIR]",
+            "command-line-flag": "--forcedir",
+            "description": "A boolean. Use the actual directory name given (do not add + to make a new directory).",
+            "optional": true,
+            "default-value": true
+        },
+        {
+            "id": "fudge",
+            "name": "Fudge",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[FUDGE]",
+            "command-line-flag": "-w",
+            "description": "An integer (int or long). Ard fudge factor.",
+            "optional": true
+        },
+        {
+            "id": "grad_dev",
+            "name": "Grad dev",
+            "type": "File",
+            "value-key": "[GRAD_DEV]",
+            "description": "An existing file name. Grad_dev file, if gradnonlin, -g is true.",
+            "optional": true
+        },
+        {
+            "id": "gradnonlin",
+            "name": "Gradnonlin",
+            "type": "Flag",
+            "value-key": "[GRADNONLIN]",
+            "command-line-flag": "-g",
+            "description": "A boolean. Consider gradient nonlinearities, default off.",
+            "optional": true
+        },
+        {
+            "id": "logdir",
+            "name": "Logdir",
+            "type": "File",
+            "value-key": "[LOGDIR]",
+            "command-line-flag": "--logdir",
+            "command-line-flag-separator": "=",
+            "description": "A directory name. No description provided.",
+            "optional": true
+        },
+        {
+            "id": "mask",
+            "name": "Mask",
+            "type": "File",
+            "value-key": "[MASK]",
+            "description": "An existing file name. Bet binary mask file.",
+            "optional": false
+        },
+        {
+            "id": "model",
+            "name": "Model",
+            "type": "Number",
+            "value-key": "[MODEL]",
+            "command-line-flag": "-model",
+            "description": "1 or 2 or 3. Use monoexponential (1, default, required for single-shell) or multiexponential (2, multi-shell) model.",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "id": "n_fibres",
+            "name": "N fibres",
+            "type": "Number",
+            "minimum": 1,
+            "value-key": "[N_FIBRES]",
+            "command-line-flag": "-n",
+            "description": "A long integer >= 1. Maximum number of fibres to fit in each voxel.",
+            "optional": false,
+            "default-value": 2
+        },
+        {
+            "id": "n_jumps",
+            "name": "N jumps",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[N_JUMPS]",
+            "command-line-flag": "-j",
+            "description": "An integer (int or long). Num of jumps to be made by mcmc.",
+            "optional": true,
+            "default-value": 5000
+        },
+        {
+            "id": "no_ard",
+            "name": "No ard",
+            "type": "Flag",
+            "value-key": "[NO_ARD]",
+            "command-line-flag": "--noard",
+            "description": "A boolean. Turn ard off on all fibres.",
+            "optional": true
+        },
+        {
+            "id": "no_spat",
+            "name": "No spat",
+            "type": "Flag",
+            "value-key": "[NO_SPAT]",
+            "command-line-flag": "--nospat",
+            "description": "A boolean. Initialise with tensor, not spatially.",
+            "optional": true
+        },
+        {
+            "id": "non_linear",
+            "name": "Non linear",
+            "type": "Flag",
+            "value-key": "[NON_LINEAR]",
+            "command-line-flag": "--nonlinear",
+            "description": "A boolean. Initialise with nonlinear fitting.",
+            "optional": true
+        },
+        {
+            "id": "out_dir",
+            "name": "Out dir",
+            "type": "File",
+            "value-key": "[OUT_DIR]",
+            "description": "A directory name. Output directory.",
+            "optional": false,
+            "default-value": "bedpostx"
+        },
+        {
+            "id": "rician",
+            "name": "Rician",
+            "type": "Flag",
+            "value-key": "[RICIAN]",
+            "command-line-flag": "--rician",
+            "description": "A boolean. Use rician noise modeling.",
+            "optional": true
+        },
+        {
+            "id": "sample_every",
+            "name": "Sample every",
+            "type": "Number",
+            "minimum": 0,
+            "value-key": "[SAMPLE_EVERY]",
+            "command-line-flag": "-s",
+            "description": "A long integer >= 0. Num of jumps for each sample (mcmc).",
+            "optional": true,
+            "default-value": 1
+        },
+        {
+            "id": "seed",
+            "name": "Seed",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[SEED]",
+            "command-line-flag": "--seed",
+            "command-line-flag-separator": "=",
+            "description": "An integer (int or long). Seed for pseudo random number generator.",
+            "optional": true
+        },
+        {
+            "id": "update_proposal_every",
+            "name": "Update proposal every",
+            "type": "Number",
+            "minimum": 1,
+            "value-key": "[UPDATE_PROPOSAL_EVERY]",
+            "command-line-flag": "--updateproposalevery",
+            "command-line-flag-separator": "=",
+            "description": "A long integer >= 1. Num of jumps for each update to the proposal density std (mcmc).",
+            "optional": true,
+            "default-value": 40
+        },
+        {
+            "id": "use_gpu",
+            "name": "Use gpu",
+            "type": "Flag",
+            "value-key": "[USE_GPU]",
+            "command-line-flag": "--use_gpu",
+            "description": "A boolean. Use the gpu version of bedpostx.",
+            "optional": true
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Dyads",
+            "id": "dyads",
+            "path-template": "dyads*",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Mean of pdd distribution in vector form.",
+            "list": true
+        },
+        {
+            "name": "Dyads dispersion",
+            "id": "dyads_dispersion",
+            "path-template": "dyads*_dispersion",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Dispersion.",
+            "list": true
+        },
+        {
+            "name": "Mean s0samples",
+            "id": "mean_S0samples",
+            "path-template": "mean_S0samples",
+            "optional": true,
+            "description": "An existing file name. Mean of distribution on t2wbaseline signal intensity s0."
+        },
+        {
+            "name": "Mean dsamples",
+            "id": "mean_dsamples",
+            "path-template": "mean_dsamples",
+            "optional": true,
+            "description": "An existing file name. Mean of distribution on diffusivity d."
+        },
+        {
+            "name": "Mean fsamples",
+            "id": "mean_fsamples",
+            "path-template": "mean_f*samples",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Mean of distribution on f anisotropy.",
+            "list": true
+        },
+        {
+            "name": "Mean phsamples",
+            "id": "mean_phsamples",
+            "path-template": "mean_ph*samples",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Mean of distribution on phi.",
+            "list": true
+        },
+        {
+            "name": "Mean thsamples",
+            "id": "mean_thsamples",
+            "path-template": "mean_th*samples",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Mean of distribution on theta.",
+            "list": true
+        },
+        {
+            "name": "Merged fsamples",
+            "id": "merged_fsamples",
+            "path-template": "merged_f*samples",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Samples from the distribution on anisotropic volume fraction.",
+            "list": true
+        },
+        {
+            "name": "Merged phsamples",
+            "id": "merged_phsamples",
+            "path-template": "merged_ph*samples",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Samples from the distribution on phi.",
+            "list": true
+        },
+        {
+            "name": "Merged thsamples",
+            "id": "merged_thsamples",
+            "path-template": "merged_th*samples",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Samples from the distribution on theta.",
+            "list": true
+        }
+    ],
+    "groups": [
+        {
+            "id": "mutex_group",
+            "name": "Mutex group",
+            "members": [
+                "no_ard",
+                "all_ard"
+            ],
+            "mutually-exclusive": true
+        },
+        {
+            "id": "mutex_group_2",
+            "name": "Mutex group 2",
+            "members": [
+                "non_linear",
+                "no_spat",
+                "cnlinear"
+            ],
+            "mutually-exclusive": true
+        },
+        {
+            "id": "mutex_group_3",
+            "name": "Mutex group 3",
+            "members": [
+                "f0_ard",
+                "f0_noard"
+            ],
+            "mutually-exclusive": true
+        },
+        {
+            "id": "mutex_group_4",
+            "name": "Mutex group 4",
+            "members": [
+                "f0_ard",
+                "f0_noard",
+                "all_ard"
+            ],
+            "mutually-exclusive": true
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "dmri"
+        ],
+        "source": "nipype-interface"
+    },
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/dti.py"
+}

--- a/app/static/pipelines/zenodo-2602109.json
+++ b/app/static/pipelines/zenodo-2602109.json
@@ -1,0 +1,275 @@
+{
+    "name": "MCFLIRT",
+    "command-line": "mcflirt [IN_FILE] [BINS] [COST] [DOF] [INIT] [INTERPOLATION] [MEAN_VOL] [OUT_FILE] [REF_FILE] [REF_VOL] [ROTATION] [SAVE_MATS] [SAVE_PLOTS] [SAVE_RMS] [SCALING] [SMOOTH] [STAGES] [STATS_IMGS] [USE_CONTOUR] [USE_GRADIENT]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "MCFLIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: MCFLIRT).",
+    "inputs": [
+        {
+            "id": "bins",
+            "name": "Bins",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[BINS]",
+            "command-line-flag": "-bins",
+            "description": "An integer (int or long). Number of histogram bins.",
+            "optional": true
+        },
+        {
+            "id": "cost",
+            "name": "Cost",
+            "type": "String",
+            "value-key": "[COST]",
+            "command-line-flag": "-cost",
+            "description": "'mutualinfo' or 'woods' or 'corratio' or 'normcorr' or 'normmi' or 'leastsquares'. Cost function to optimize.",
+            "optional": true,
+            "value-choices": [
+                "mutualinfo",
+                "woods",
+                "corratio",
+                "normcorr",
+                "normmi",
+                "leastsquares"
+            ]
+        },
+        {
+            "id": "dof",
+            "name": "Dof",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[DOF]",
+            "command-line-flag": "-dof",
+            "description": "An integer (int or long). Degrees of freedom for the transformation.",
+            "optional": true
+        },
+        {
+            "id": "in_file",
+            "name": "In file",
+            "type": "File",
+            "value-key": "[IN_FILE]",
+            "command-line-flag": "-in",
+            "description": "An existing file name. Timeseries to motion-correct.",
+            "optional": false
+        },
+        {
+            "id": "init",
+            "name": "Init",
+            "type": "File",
+            "value-key": "[INIT]",
+            "command-line-flag": "-init",
+            "description": "An existing file name. Inital transformation matrix.",
+            "optional": true
+        },
+        {
+            "id": "interpolation",
+            "name": "Interpolation",
+            "type": "String",
+            "value-key": "[INTERPOLATION]",
+            "command-line-flag": "-",
+            "command-line-flag-separator": "",
+            "description": "'spline' or 'nn' or 'sinc'. Interpolation method for transformation.",
+            "optional": true,
+            "value-choices": [
+                "spline_final",
+                "nn_final",
+                "sinc_final"
+            ]
+        },
+        {
+            "id": "mean_vol",
+            "name": "Mean vol",
+            "type": "Flag",
+            "value-key": "[MEAN_VOL]",
+            "command-line-flag": "-meanvol",
+            "description": "A boolean. Register to mean volume.",
+            "optional": true
+        },
+        {
+            "id": "out_file",
+            "name": "Out file",
+            "type": "File",
+            "value-key": "[OUT_FILE]",
+            "command-line-flag": "-out",
+            "description": "A file name. File to write.",
+            "optional": true
+        },
+        {
+            "id": "ref_file",
+            "name": "Ref file",
+            "type": "File",
+            "value-key": "[REF_FILE]",
+            "command-line-flag": "-reffile",
+            "description": "An existing file name. Target image for motion correction.",
+            "optional": true
+        },
+        {
+            "id": "ref_vol",
+            "name": "Ref vol",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[REF_VOL]",
+            "command-line-flag": "-refvol",
+            "description": "An integer (int or long). Volume to align frames to.",
+            "optional": true
+        },
+        {
+            "id": "rotation",
+            "name": "Rotation",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[ROTATION]",
+            "command-line-flag": "-rotation",
+            "description": "An integer (int or long). Scaling factor for rotation tolerances.",
+            "optional": true
+        },
+        {
+            "id": "save_mats",
+            "name": "Save mats",
+            "type": "Flag",
+            "value-key": "[SAVE_MATS]",
+            "command-line-flag": "-mats",
+            "description": "A boolean. Save transformation matrices.",
+            "optional": true
+        },
+        {
+            "id": "save_plots",
+            "name": "Save plots",
+            "type": "Flag",
+            "value-key": "[SAVE_PLOTS]",
+            "command-line-flag": "-plots",
+            "description": "A boolean. Save transformation parameters.",
+            "optional": true
+        },
+        {
+            "id": "save_rms",
+            "name": "Save rms",
+            "type": "Flag",
+            "value-key": "[SAVE_RMS]",
+            "command-line-flag": "-rmsabs -rmsrel",
+            "description": "A boolean. Save rms displacement parameters.",
+            "optional": true
+        },
+        {
+            "id": "scaling",
+            "name": "Scaling",
+            "type": "Number",
+            "value-key": "[SCALING]",
+            "command-line-flag": "-scaling",
+            "description": "A float. Scaling factor to use.",
+            "optional": true
+        },
+        {
+            "id": "smooth",
+            "name": "Smooth",
+            "type": "Number",
+            "value-key": "[SMOOTH]",
+            "command-line-flag": "-smooth",
+            "description": "A float. Smoothing factor for the cost function.",
+            "optional": true
+        },
+        {
+            "id": "stages",
+            "name": "Stages",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[STAGES]",
+            "command-line-flag": "-stages",
+            "description": "An integer (int or long). Stages (if 4, perform final search with sinc interpolation.",
+            "optional": true
+        },
+        {
+            "id": "stats_imgs",
+            "name": "Stats imgs",
+            "type": "Flag",
+            "value-key": "[STATS_IMGS]",
+            "command-line-flag": "-stats",
+            "description": "A boolean. Produce variance and std. dev. images.",
+            "optional": true
+        },
+        {
+            "id": "use_contour",
+            "name": "Use contour",
+            "type": "Flag",
+            "value-key": "[USE_CONTOUR]",
+            "command-line-flag": "-edge",
+            "description": "A boolean. Run search on contour images.",
+            "optional": true
+        },
+        {
+            "id": "use_gradient",
+            "name": "Use gradient",
+            "type": "Flag",
+            "value-key": "[USE_GRADIENT]",
+            "command-line-flag": "-gdt",
+            "description": "A boolean. Run search on gradient images.",
+            "optional": true
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Mat file",
+            "id": "mat_file",
+            "path-template": "MAT_*",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Transformation matrices.",
+            "list": true
+        },
+        {
+            "name": "Mean img",
+            "id": "mean_img",
+            "path-template": "[OUT_FILE]_mean_reg.ext",
+            "optional": true,
+            "description": "An existing file name. Mean timeseries image (if mean_vol=true)."
+        },
+        {
+            "name": "Out file",
+            "id": "out_file_outfile",
+            "path-template": "[OUT_FILE]",
+            "optional": true,
+            "description": "An existing file name. Motion-corrected timeseries."
+        },
+        {
+            "name": "Par file",
+            "id": "par_file",
+            "path-template": "[OUT_FILE].par",
+            "optional": true,
+            "description": "An existing file name. Text-file with motion parameters."
+        },
+        {
+            "name": "Rms files",
+            "id": "rms_files",
+            "path-template": "[OUT_FILE]_*.rms",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Absolute and relative displacement parameters.",
+            "list": true
+        },
+        {
+            "name": "Std img",
+            "id": "std_img",
+            "path-template": "[OUT_FILE]_sigma.ext",
+            "optional": true,
+            "description": "An existing file name. Standard deviation image."
+        },
+        {
+            "name": "Variance img",
+            "id": "variance_img",
+            "path-template": "[OUT_FILE]_variance.ext",
+            "optional": true,
+            "description": "An existing file name. Variance image."
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "mri"
+        ],
+        "source": "nipype-interface"
+    },
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/preprocess.py"
+}

--- a/app/static/pipelines/zenodo-2621482.json
+++ b/app/static/pipelines/zenodo-2621482.json
@@ -1,0 +1,367 @@
+{
+    "name": "TOPUP",
+    "command-line": "topup [CONFIG] [ENCODING_FILE] [ESTMOV] [FWHM] [IN_FILE] [INTERP] [MAX_ITER] [MINMET] [NUMPREC] [OUT_BASE] [OUT_CORRECTED] [OUT_FIELD] [OUT_JAC_PREFIX] [OUT_LOGFILE] [OUT_MAT_PREFIX] [OUT_WARP_PREFIX] [REG_LAMBDA] [REGMOD] [REGRID] [SCALE] [SPLINEORDER] [SSQLAMBDA] [SUBSAMP] [WARP_RES]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "TOPUP, as implemented in Nipype (module: nipype.interfaces.fsl, interface: TOPUP).",
+    "inputs": [
+        {
+            "id": "config",
+            "name": "Config",
+            "type": "String",
+            "value-key": "[CONFIG]",
+            "command-line-flag": "--config",
+            "command-line-flag-separator": "=",
+            "description": "A string. Name of config file specifying command line arguments.",
+            "optional": true,
+            "default-value": "b02b0.cnf"
+        },
+        {
+            "id": "encoding_file",
+            "name": "Encoding file",
+            "type": "File",
+            "value-key": "[ENCODING_FILE]",
+            "command-line-flag": "--datain",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of text file with pe directions/times.",
+            "optional": false
+        },
+        {
+            "id": "estmov",
+            "name": "Estmov",
+            "type": "Number",
+            "value-key": "[ESTMOV]",
+            "command-line-flag": "--estmov",
+            "command-line-flag-separator": "=",
+            "description": "1 or 0. Estimate movements if set.",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                1,
+                0
+            ]
+        },
+        {
+            "id": "fwhm",
+            "name": "Fwhm",
+            "type": "Number",
+            "value-key": "[FWHM]",
+            "command-line-flag": "--fwhm",
+            "command-line-flag-separator": "=",
+            "description": "A float. Fwhm (in mm) of gaussian smoothing kernel.",
+            "optional": true
+        },
+        {
+            "id": "in_file",
+            "name": "In file",
+            "type": "File",
+            "value-key": "[IN_FILE]",
+            "command-line-flag": "--imain",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of 4d file with images.",
+            "optional": false
+        },
+        {
+            "id": "interp",
+            "name": "Interp",
+            "type": "String",
+            "value-key": "[INTERP]",
+            "command-line-flag": "--interp",
+            "command-line-flag-separator": "=",
+            "description": "'spline' or 'linear'. Image interpolation model, linear or spline.",
+            "optional": true,
+            "value-choices": [
+                "spline",
+                "linear"
+            ]
+        },
+        {
+            "id": "max_iter",
+            "name": "Max iter",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[MAX_ITER]",
+            "command-line-flag": "--miter",
+            "command-line-flag-separator": "=",
+            "description": "An integer (int or long). Max # of non-linear iterations.",
+            "optional": true
+        },
+        {
+            "id": "minmet",
+            "name": "Minmet",
+            "type": "Number",
+            "value-key": "[MINMET]",
+            "command-line-flag": "--minmet",
+            "command-line-flag-separator": "=",
+            "description": "0 or 1. Minimisation method 0=levenberg-marquardt, 1=scaled conjugate gradient.",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ]
+        },
+        {
+            "id": "numprec",
+            "name": "Numprec",
+            "type": "String",
+            "value-key": "[NUMPREC]",
+            "command-line-flag": "--numprec",
+            "command-line-flag-separator": "=",
+            "description": "'double' or 'float'. Precision for representing hessian, double or float.",
+            "optional": true,
+            "value-choices": [
+                "double",
+                "float"
+            ]
+        },
+        {
+            "id": "out_jac_prefix",
+            "name": "Out jac prefix",
+            "type": "String",
+            "value-key": "[OUT_JAC_PREFIX]",
+            "command-line-flag": "--jacout",
+            "command-line-flag-separator": "=",
+            "description": "A unicode string. Prefix for the warpfield images.",
+            "optional": true,
+            "default-value": "jac"
+        },
+        {
+            "id": "out_mat_prefix",
+            "name": "Out mat prefix",
+            "type": "String",
+            "value-key": "[OUT_MAT_PREFIX]",
+            "command-line-flag": "--rbmout",
+            "command-line-flag-separator": "=",
+            "description": "A unicode string. Prefix for the realignment matrices.",
+            "optional": true,
+            "default-value": "xfm"
+        },
+        {
+            "id": "out_warp_prefix",
+            "name": "Out warp prefix",
+            "type": "String",
+            "value-key": "[OUT_WARP_PREFIX]",
+            "command-line-flag": "--dfout",
+            "command-line-flag-separator": "=",
+            "description": "A unicode string. Prefix for the warpfield images (in mm).",
+            "optional": true,
+            "default-value": "warpfield"
+        },
+        {
+            "id": "reg_lambda",
+            "name": "Reg lambda",
+            "type": "Number",
+            "value-key": "[REG_LAMBDA]",
+            "command-line-flag": "--lambda",
+            "command-line-flag-separator": "=",
+            "description": "A float. Weight of regularisation, default depending on --ssqlambda and --regmod switches.",
+            "optional": true
+        },
+        {
+            "id": "regmod",
+            "name": "Regmod",
+            "type": "String",
+            "value-key": "[REGMOD]",
+            "command-line-flag": "--regmod",
+            "command-line-flag-separator": "=",
+            "description": "'bending_energy' or 'membrane_energy'. Regularisation term implementation. defaults to bending_energy. note that the two functions have vastly different scales. the membrane energy is based on the first derivatives and the bending energy on the second derivatives. the second derivatives will typically be much smaller than the first derivatives, so input lambda will have to be larger for bending_energy to yield approximately the same level of regularisation.",
+            "optional": true,
+            "value-choices": [
+                "bending_energy",
+                "membrane_energy"
+            ]
+        },
+        {
+            "id": "regrid",
+            "name": "Regrid",
+            "type": "Number",
+            "value-key": "[REGRID]",
+            "command-line-flag": "--regrid",
+            "command-line-flag-separator": "=",
+            "description": "1 or 0. If set (=1), the calculations are done in a different grid.",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                1,
+                0
+            ]
+        },
+        {
+            "id": "scale",
+            "name": "Scale",
+            "type": "Number",
+            "value-key": "[SCALE]",
+            "command-line-flag": "--scale",
+            "command-line-flag-separator": "=",
+            "description": "0 or 1. If set (=1), the images are individually scaled to a common mean.",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ]
+        },
+        {
+            "id": "splineorder",
+            "name": "Splineorder",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[SPLINEORDER]",
+            "command-line-flag": "--splineorder",
+            "command-line-flag-separator": "=",
+            "description": "An integer (int or long). Order of spline, 2->qadratic spline, 3->cubic spline.",
+            "optional": true
+        },
+        {
+            "id": "ssqlambda",
+            "name": "Ssqlambda",
+            "type": "Number",
+            "value-key": "[SSQLAMBDA]",
+            "command-line-flag": "--ssqlambda",
+            "command-line-flag-separator": "=",
+            "description": "1 or 0. Weight lambda by the current value of the ssd. if used (=1), the effective weight of regularisation term becomes higher for the initial iterations, therefore initial steps are a little smoother than they would without weighting. this reduces the risk of finding a local minimum.",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                1,
+                0
+            ]
+        },
+        {
+            "id": "subsamp",
+            "name": "Subsamp",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[SUBSAMP]",
+            "command-line-flag": "--subsamp",
+            "command-line-flag-separator": "=",
+            "description": "An integer (int or long). Sub-sampling scheme.",
+            "optional": true
+        },
+        {
+            "id": "warp_res",
+            "name": "Warp res",
+            "type": "Number",
+            "value-key": "[WARP_RES]",
+            "command-line-flag": "--warpres",
+            "command-line-flag-separator": "=",
+            "description": "A float. (approximate) resolution (in mm) of warp basis for the different sub-sampling levels.",
+            "optional": true
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Out base",
+            "id": "out_base",
+            "optional": true,
+            "description": "A file name. Base-name of output files (spline coefficients (hz) and movement parameters).",
+            "path-template": "[IN_FILE]_base",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ],
+            "value-key": "[OUT_BASE]",
+            "command-line-flag": "--out",
+            "command-line-flag-separator": "="
+        },
+        {
+            "name": "Out corrected",
+            "id": "out_corrected",
+            "path-template": "[IN_FILE]_corrected",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ],
+            "optional": true,
+            "description": "A file name. Name of 4d image file with unwarped images.",
+            "value-key": "[OUT_CORRECTED]",
+            "command-line-flag": "--iout",
+            "command-line-flag-separator": "="
+        },
+        {
+            "name": "Out enc file",
+            "id": "out_enc_file",
+            "path-template": "out_enc_file",
+            "optional": true,
+            "description": "A file name. Encoding directions file output for applytopup."
+        },
+        {
+            "name": "Out field",
+            "id": "out_field",
+            "path-template": "[IN_FILE]_field",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ],
+            "optional": true,
+            "description": "A file name. Name of image file with field (hz).",
+            "value-key": "[OUT_FIELD]",
+            "command-line-flag": "--fout",
+            "command-line-flag-separator": "="
+        },
+        {
+            "name": "Out fieldcoef",
+            "id": "out_fieldcoef",
+            "path-template": "out_fieldcoef",
+            "optional": true,
+            "description": "An existing file name. File containing the field coefficients."
+        },
+        {
+            "name": "Out jacs",
+            "id": "out_jacs",
+            "path-template": "out_jacs",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Jacobian images."
+        },
+        {
+            "name": "Out logfile",
+            "id": "out_logfile",
+            "path-template": "[IN_FILE]_topup.log",
+            "path-template-stripped-extensions": [
+                ".nii.gz",
+                ".nii"
+            ],
+            "optional": true,
+            "description": "A file name. Name of log-file.",
+            "value-key": "[OUT_LOGFILE]",
+            "command-line-flag": "--logout",
+            "command-line-flag-separator": "="
+        },
+        {
+            "name": "Out mats",
+            "id": "out_mats",
+            "path-template": "out_mats",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Realignment matrices."
+        },
+        {
+            "name": "Out movpar",
+            "id": "out_movpar",
+            "path-template": "out_movpar",
+            "optional": true,
+            "description": "An existing file name. Movpar.txt output file."
+        },
+        {
+            "name": "Out warps",
+            "id": "out_warps",
+            "path-template": "out_warps",
+            "optional": true,
+            "description": "A list of items which are an existing file name. Warpfield images."
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "dmri"
+        ],
+        "source": "nipype-interface"
+    },
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/epi.py"
+}

--- a/app/static/pipelines/zenodo-2621487.json
+++ b/app/static/pipelines/zenodo-2621487.json
@@ -1,0 +1,125 @@
+{
+    "name": "ApplyTOPUP",
+    "command-line": "applytopup [DATATYPE] [ENCODING_FILE] [IN_FILES] [IN_INDEX] [IN_TOPUP_FIELDCOEF] [INTERP] [METHOD] [OUT_CORRECTED]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "ApplyTOPUP, as implemented in Nipype (module: nipype.interfaces.fsl, interface: ApplyTOPUP).",
+    "inputs": [
+        {
+            "id": "datatype",
+            "name": "Datatype",
+            "type": "String",
+            "value-key": "[DATATYPE]",
+            "command-line-flag": "--datatype",
+            "command-line-flag-separator": "=",
+            "description": "'char' or 'short' or 'int' or 'float' or 'double'. Force output data type.",
+            "optional": true,
+            "value-choices": [
+                "char",
+                "short",
+                "int",
+                "float",
+                "double"
+            ]
+        },
+        {
+            "id": "encoding_file",
+            "name": "Encoding file",
+            "type": "File",
+            "value-key": "[ENCODING_FILE]",
+            "command-line-flag": "--datain",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of text file with pe directions/times.",
+            "optional": false
+        },
+        {
+            "id": "in_files",
+            "name": "In files",
+            "type": "File",
+            "list": true,
+            "list-separator": ",",
+            "value-key": "[IN_FILES]",
+            "command-line-flag": "--imain",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are an existing file name. Name of file with images.",
+            "optional": false
+        },
+        {
+            "id": "in_index",
+            "name": "In index",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "list-separator": ",",
+            "value-key": "[IN_INDEX]",
+            "command-line-flag": "--inindex",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are an integer (int or long). Comma separated list of indices corresponding to --datain.",
+            "optional": false
+        },
+        {
+            "id": "in_topup_fieldcoef",
+            "name": "In topup fieldcoef",
+            "type": "File",
+            "value-key": "[IN_TOPUP_FIELDCOEF]",
+            "command-line-flag": "--topup",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Topup file containing the field coefficients.",
+            "optional": false
+        },
+        {
+            "id": "interp",
+            "name": "Interp",
+            "type": "String",
+            "value-key": "[INTERP]",
+            "command-line-flag": "--interp",
+            "command-line-flag-separator": "=",
+            "description": "'trilinear' or 'spline'. Interpolation method.",
+            "optional": true,
+            "value-choices": [
+                "trilinear",
+                "spline"
+            ]
+        },
+        {
+            "id": "method",
+            "name": "Method",
+            "type": "String",
+            "value-key": "[METHOD]",
+            "command-line-flag": "--method",
+            "command-line-flag-separator": "=",
+            "description": "'jac' or 'lsr'. Use jacobian modulation (jac) or least-squares resampling (lsr).",
+            "optional": true,
+            "value-choices": [
+                "jac",
+                "lsr"
+            ]
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Out corrected",
+            "id": "out_corrected",
+            "path-template": "out_corrected",
+            "optional": false,
+            "description": "An existing file name. Name of 4d image file with unwarped images.",
+            "value-key": "[OUT_CORRECTED]",
+            "command-line-flag": "--out",
+            "command-line-flag-separator": "="
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "dmri"
+        ],
+        "source": "nipype-interface"
+    },
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/epi.py"
+}

--- a/app/static/pipelines/zenodo-2634608.json
+++ b/app/static/pipelines/zenodo-2634608.json
@@ -1,0 +1,335 @@
+{
+    "inputs": [
+        {
+            "command-line-flag": "-a", 
+            "description": "An existing file name. Structural *intensity* image, typically t1. if more than one anatomical image is specified, subsequently specified images are used during the segmentation process. however, only the first image is used in the registration of priors. our suggestion would be to specify the t1 as the first image.", 
+            "value-key": "[ANATOMICAL_IMAGE]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "anatomical_image", 
+            "name": "Anatomical image"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "description": "A boolean. Use b-spline syn for registrations and b-spline exponential mapping in direct.", 
+            "value-key": "[B_SPLINE_SMOOTHING]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "b_spline_smoothing", 
+            "name": "B spline smoothing"
+        }, 
+        {
+            "command-line-flag": "-m", 
+            "description": "An existing file name. Brain probability mask in template space.", 
+            "value-key": "[BRAIN_PROBABILITY_MASK]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "brain_probability_mask", 
+            "name": "Brain probability mask"
+        }, 
+        {
+            "command-line-flag": "-e", 
+            "description": "An existing file name. Anatomical *intensity* template (possibly created using a population data set with buildtemplateparallel.sh in ants). this template is  *not* skull-stripped.", 
+            "value-key": "[BRAIN_TEMPLATE]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "brain_template", 
+            "name": "Brain template"
+        }, 
+        {
+            "command-line-flag": "-r", 
+            "description": "An existing file name. Cortical roi labels to use as a prior for atith.", 
+            "value-key": "[CORTICAL_LABEL_IMAGE]", 
+            "optional": true, 
+            "type": "File", 
+            "id": "cortical_label_image", 
+            "name": "Cortical label image"
+        }, 
+        {
+            "command-line-flag": "-z 1", 
+            "description": "A boolean. If > 0, runs a faster version of the script. only for testing. implies -u 0. requires single thread computation for complete reproducibility.", 
+            "value-key": "[DEBUG]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "debug", 
+            "name": "Debug"
+        }, 
+        {
+            "command-line-flag": "-d", 
+            "description": "3 or 2. Image dimension (2 or 3).", 
+            "default-value": 3, 
+            "value-key": "[DIMENSION]", 
+            "optional": true, 
+            "value-choices": [
+                3, 
+                2
+            ], 
+            "integer": true, 
+            "type": "Number", 
+            "id": "dimension", 
+            "name": "Dimension"
+        }, 
+        {
+            "command-line-flag": "-f", 
+            "description": "An existing file name. Mask (defined in the template space) used during registration for brain extraction.", 
+            "value-key": "[EXTRACTION_REGISTRATION_MASK]", 
+            "optional": true, 
+            "type": "File", 
+            "id": "extraction_registration_mask", 
+            "name": "Extraction registration mask"
+        }, 
+        {
+            "command-line-flag": "-s", 
+            "description": "A unicode string. Any of standard itk formats, nii.gz is default.", 
+            "default-value": "nii.gz", 
+            "value-key": "[IMAGE_SUFFIX]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "image_suffix", 
+            "name": "Image suffix"
+        }, 
+        {
+            "command-line-flag": "-k", 
+            "name": "Keep temporary files", 
+            "value-key": "[KEEP_TEMPORARY_FILES]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "keep_temporary_files", 
+            "description": "An integer (int or long). Keep brain extraction/segmentation warps, etc (default = 0)."
+        }, 
+        {
+            "command-line-flag": "-l", 
+            "description": "A unicode string. Incorporate a distance prior one the posterior formulation.  should be of the form 'label[lambda,boundaryprobability]' where label is a value of 1,2,3,... denoting label id.  the label probability for anything outside the current label = boundaryprobability * exp( -lambda * distancefromboundary ) intuitively, smaller lambda values will increase the spatial capture range of the distance prior.  to apply to all label values, simply omit specifying the label, i.e. -l [lambda,boundaryprobability].", 
+            "value-key": "[LABEL_PROPAGATION]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "label_propagation", 
+            "name": "Label propagation"
+        }, 
+        {
+            "command-line-flag": "-i", 
+            "name": "Max iterations", 
+            "value-key": "[MAX_ITERATIONS]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "max_iterations", 
+            "description": "An integer (int or long). Ants registration max iterations (default = 100x100x70x20)."
+        }, 
+        {
+            "description": "An integer (int or long). Number of itk threads to use.", 
+            "default-value": 1, 
+            "value-key": "[NUM_THREADS]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "num_threads", 
+            "name": "Num threads"
+        }, 
+        {
+            "command-line-flag": "-o", 
+            "description": "A unicode string. Prefix that is prepended to all output files (default = antsct_).", 
+            "default-value": "antsCT_", 
+            "value-key": "[OUT_PREFIX]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "out_prefix", 
+            "name": "Out prefix"
+        }, 
+        {
+            "command-line-flag": "-b", 
+            "description": "A unicode string. Atropos posterior formulation and whether or not to use mixture model proportions. e.g 'socrates[1]' (default) or 'aristotle[1]'. choose the latter if you want use the distance priors (see also the -l option for label propagation control).", 
+            "value-key": "[POSTERIOR_FORMULATION]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "posterior_formulation", 
+            "name": "Posterior formulation"
+        }, 
+        {
+            "command-line-flag": "-w", 
+            "description": "A float. Atropos spatial prior *probability* weight for the segmentation.", 
+            "value-key": "[PRIOR_SEGMENTATION_WEIGHT]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "prior_segmentation_weight", 
+            "name": "Prior segmentation weight"
+        }, 
+        {
+            "command-line-flag": "-q 1", 
+            "description": "A boolean. If = 1, use antsregistrationsynquick.sh as the basis for registration during brain extraction, brain segmentation, and (optional) normalization to a template. otherwise use antsregistrationsyn.sh (default = 0).", 
+            "value-key": "[QUICK_REGISTRATION]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "quick_registration", 
+            "name": "Quick registration"
+        }, 
+        {
+            "command-line-flag": "-n", 
+            "name": "Segmentation iterations", 
+            "value-key": "[SEGMENTATION_ITERATIONS]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "segmentation_iterations", 
+            "description": "An integer (int or long). N4 -> atropos -> n4 iterations during segmentation (default = 3)."
+        }, 
+        {
+            "command-line-flag": "-p", 
+            "name": "Segmentation priors", 
+            "value-key": "[SEGMENTATION_PRIORS]", 
+            "optional": false, 
+            "list": true, 
+            "type": "File", 
+            "id": "segmentation_priors", 
+            "description": "A list of items which are an existing file name. No description provided."
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "An existing file name. Anatomical *intensity* template (assumed to be skull-stripped). a common case would be where this would be the same template as specified in the -e option which is not skull stripped.", 
+            "value-key": "[T1_REGISTRATION_TEMPLATE]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "t1_registration_template", 
+            "name": "T1 registration template"
+        }, 
+        {
+            "command-line-flag": "-j", 
+            "description": "0 or 1. Use floating point precision in registrations (default = 0).", 
+            "value-key": "[USE_FLOATINGPOINT_PRECISION]", 
+            "optional": true, 
+            "value-choices": [
+                0, 
+                1
+            ], 
+            "integer": true, 
+            "type": "Number", 
+            "id": "use_floatingpoint_precision", 
+            "name": "Use floatingpoint precision"
+        }, 
+        {
+            "command-line-flag": "-u", 
+            "description": "0 or 1. Use random number generated from system clock in atropos (default = 1).", 
+            "value-key": "[USE_RANDOM_SEEDING]", 
+            "optional": true, 
+            "value-choices": [
+                0, 
+                1
+            ], 
+            "integer": true, 
+            "type": "Number", 
+            "id": "use_random_seeding", 
+            "name": "Use random seeding"
+        }
+    ], 
+    "description": "CorticalThickness, as implemented in Nipype (module: nipype.interfaces.ants, interface: CorticalThickness).", 
+    "command-line": "${ANTSPATH}/antsCorticalThickness.sh [ANATOMICAL_IMAGE] [B_SPLINE_SMOOTHING] [BRAIN_PROBABILITY_MASK] [BRAIN_TEMPLATE] [CORTICAL_LABEL_IMAGE] [DEBUG] [DIMENSION] [EXTRACTION_REGISTRATION_MASK] [IMAGE_SUFFIX] [KEEP_TEMPORARY_FILES] [LABEL_PROPAGATION] [MAX_ITERATIONS] [NUM_THREADS] [OUT_PREFIX] [POSTERIOR_FORMULATION] [PRIOR_SEGMENTATION_WEIGHT] [QUICK_REGISTRATION] [SEGMENTATION_ITERATIONS] [SEGMENTATION_PRIORS] [T1_REGISTRATION_TEMPLATE] [USE_FLOATINGPOINT_PRECISION] [USE_RANDOM_SEEDING]", 
+    "author": "Nipype (interface), Brian B. Avants et al. (tool)", 
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/ants/segmentation.py", 
+    "tool-version": "1.0.0", 
+    "tags": {
+        "source": "nipype-interface", 
+        "domain": "neuroinformatics"
+    }, 
+    "container-image": {
+        "index": "index.docker.io", 
+        "image": "bt5e/ants:latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[OUT_PREFIX]BrainExtractionMask.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. Brain extraction mask.", 
+            "optional": true, 
+            "name": "Brainextractionmask", 
+            "id": "BrainExtractionMask"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]BrainSegmentation.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. Brain segmentaion image.", 
+            "optional": true, 
+            "name": "Brainsegmentation", 
+            "id": "BrainSegmentation"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]BrainSegmentation*N4.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. N4 corrected image.", 
+            "optional": true, 
+            "name": "Brainsegmentationn4", 
+            "id": "BrainSegmentationN4"
+        }, 
+        {
+            "description": "A list of items which are an existing file name. Posterior probability images.", 
+            "list": true, 
+            "id": "BrainSegmentationPosteriors", 
+            "optional": true, 
+            "path-template": "[OUT_PREFIX]BrainSegmentationPosteriors*.[IMAGE_SUFFIX]", 
+            "name": "Brainsegmentationposteriors"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]brainvols.csv", 
+            "description": "An existing file name. Brain volumes as text.", 
+            "optional": true, 
+            "name": "Brainvolumes", 
+            "id": "BrainVolumes"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]CorticalThickness.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. Cortical thickness file.", 
+            "optional": true, 
+            "name": "Corticalthickness", 
+            "id": "CorticalThickness"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]NormalizedCorticalThickness.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. Normalized cortical thickness.", 
+            "optional": true, 
+            "name": "Corticalthicknessnormedtotemplate", 
+            "id": "CorticalThicknessNormedToTemplate"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]ExtractedBrain0N4.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. Extracted brain from n4 image.", 
+            "optional": true, 
+            "name": "Extractedbrainn4", 
+            "id": "ExtractedBrainN4"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]SubjectToTemplate0GenericAffine.mat", 
+            "description": "An existing file name. Template to subject inverse affine.", 
+            "optional": true, 
+            "name": "Subjecttotemplate0genericaffine", 
+            "id": "SubjectToTemplate0GenericAffine"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]SubjectToTemplate1Warp.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. Template to subject inverse warp.", 
+            "optional": true, 
+            "name": "Subjecttotemplate1warp", 
+            "id": "SubjectToTemplate1Warp"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]SubjectToTemplateLogJacobian.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. Template to subject log jacobian.", 
+            "optional": true, 
+            "name": "Subjecttotemplatelogjacobian", 
+            "id": "SubjectToTemplateLogJacobian"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]TemplateToSubject0Warp.[IMAGE_SUFFIX]", 
+            "description": "An existing file name. Template to subject warp.", 
+            "optional": true, 
+            "name": "Templatetosubject0warp", 
+            "id": "TemplateToSubject0Warp"
+        }, 
+        {
+            "path-template": "[OUT_PREFIX]TemplateToSubject1GenericAffine.mat", 
+            "description": "An existing file name. Template to subject affine.", 
+            "optional": true, 
+            "name": "Templatetosubject1genericaffine", 
+            "id": "TemplateToSubject1GenericAffine"
+        }
+    ], 
+    "name": "CorticalThickness"
+}

--- a/app/static/pipelines/zenodo-2636973.json
+++ b/app/static/pipelines/zenodo-2636973.json
@@ -1,0 +1,266 @@
+{
+    "name": "BrainExtraction",
+    "command-line": "${ANTSPATH}/antsBrainExtraction.sh [ANATOMICAL_IMAGE] [BRAIN_PROBABILITY_MASK] [BRAIN_TEMPLATE] [DEBUG] [DIMENSION] [EXTRACTION_REGISTRATION_MASK] [IMAGE_SUFFIX] [KEEP_TEMPORARY_FILES] [OUT_PREFIX] [USE_FLOATINGPOINT_PRECISION] [USE_RANDOM_SEEDING]",
+    "author": "Nipype (interface), Brian B. Avants et al. (tool)",
+    "description": "BrainExtraction, as implemented in Nipype (module: nipype.interfaces.ants, interface: BrainExtraction).",
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/ants/segmentation.py",
+    "inputs": [
+        {
+            "id": "anatomical_image",
+            "name": "Anatomical image",
+            "type": "File",
+            "value-key": "[ANATOMICAL_IMAGE]",
+            "command-line-flag": "-a",
+            "description": "An existing file name. Structural image, typically t1.  if more than one anatomical image is specified, subsequently specified images are used during the segmentation process.  however, only the first image is used in the registration of priors. our suggestion would be to specify the t1 as the first image. anatomical template created using e.g. lpba40 data set with buildtemplateparallel.sh in ants.",
+            "optional": false
+        },
+        {
+            "id": "brain_probability_mask",
+            "name": "Brain probability mask",
+            "type": "File",
+            "value-key": "[BRAIN_PROBABILITY_MASK]",
+            "command-line-flag": "-m",
+            "description": "An existing file name. Brain probability mask created using e.g. lpba40 data set which have brain masks defined, and warped to anatomical template and averaged resulting in a probability image.",
+            "optional": false
+        },
+        {
+            "id": "brain_template",
+            "name": "Brain template",
+            "type": "File",
+            "value-key": "[BRAIN_TEMPLATE]",
+            "command-line-flag": "-e",
+            "description": "An existing file name. Anatomical template created using e.g. lpba40 data set with buildtemplateparallel.sh in ants.",
+            "optional": false
+        },
+        {
+            "id": "debug",
+            "name": "Debug",
+            "type": "Flag",
+            "value-key": "[DEBUG]",
+            "command-line-flag": "-z 1",
+            "description": "A boolean. If > 0, runs a faster version of the script. only for testing. implies -u 0. requires single thread computation for complete reproducibility.",
+            "optional": true
+        },
+        {
+            "id": "dimension",
+            "name": "Dimension",
+            "type": "Number",
+            "value-key": "[DIMENSION]",
+            "command-line-flag": "-d",
+            "description": "3 or 2. Image dimension (2 or 3).",
+            "optional": true,
+            "default-value": 3,
+            "integer": true,
+            "value-choices": [
+                3,
+                2
+            ]
+        },
+        {
+            "id": "extraction_registration_mask",
+            "name": "Extraction registration mask",
+            "type": "File",
+            "value-key": "[EXTRACTION_REGISTRATION_MASK]",
+            "command-line-flag": "-f",
+            "description": "An existing file name. Mask (defined in the template space) used during registration for brain extraction. to limit the metric computation to a specific region.",
+            "optional": true
+        },
+        {
+            "id": "image_suffix",
+            "name": "Image suffix",
+            "type": "String",
+            "value-key": "[IMAGE_SUFFIX]",
+            "command-line-flag": "-s",
+            "description": "A unicode string. Any of standard itk formats, nii.gz is default.",
+            "optional": true,
+            "default-value": "nii.gz"
+        },
+        {
+            "id": "keep_temporary_files",
+            "name": "Keep temporary files",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[KEEP_TEMPORARY_FILES]",
+            "command-line-flag": "-k",
+            "description": "An integer (int or long). Keep brain extraction/segmentation warps, etc (default = 0).",
+            "optional": true
+        },
+        {
+            "id": "out_prefix",
+            "name": "Out prefix",
+            "type": "String",
+            "value-key": "[OUT_PREFIX]",
+            "command-line-flag": "-o",
+            "description": "A unicode string. Prefix that is prepended to all output files (default = highress001_).",
+            "optional": true,
+            "default-value": "highres001_"
+        },
+        {
+            "id": "use_floatingpoint_precision",
+            "name": "Use floatingpoint precision",
+            "type": "Number",
+            "value-key": "[USE_FLOATINGPOINT_PRECISION]",
+            "command-line-flag": "-q",
+            "description": "0 or 1. Use floating point precision in registrations (default = 0).",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ]
+        },
+        {
+            "id": "use_random_seeding",
+            "name": "Use random seeding",
+            "type": "Number",
+            "value-key": "[USE_RANDOM_SEEDING]",
+            "command-line-flag": "-u",
+            "description": "0 or 1. Use random number generated from system clock in atropos (default = 1).",
+            "optional": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ]
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Brainextractionbrain",
+            "id": "BrainExtractionBrain",
+            "path-template": "[OUT_PREFIX]BrainExtractionBrain.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. Brain extraction image."
+        },
+        {
+            "name": "Brainextractioncsf",
+            "id": "BrainExtractionCSF",
+            "path-template": "[OUT_PREFIX]BrainExtractionCSF.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. Segmentation mask with only csf."
+        },
+        {
+            "name": "Brainextractiongm",
+            "id": "BrainExtractionGM",
+            "path-template": "[OUT_PREFIX]BrainExtractionGM.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. Segmentation mask with only grey matter."
+        },
+        {
+            "name": "Brainextractioninitialaffine",
+            "id": "BrainExtractionInitialAffine",
+            "path-template": "[OUT_PREFIX]BrainExtractionInitialAffine.mat",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractioninitialaffinefixed",
+            "id": "BrainExtractionInitialAffineFixed",
+            "path-template": "[OUT_PREFIX]BrainExtractionInitialAffineFixed.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractioninitialaffinemoving",
+            "id": "BrainExtractionInitialAffineMoving",
+            "path-template": "[OUT_PREFIX]BrainExtractionInitialAffineMoving.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractionlaplacian",
+            "id": "BrainExtractionLaplacian",
+            "path-template": "[OUT_PREFIX]BrainExtractionLaplacian.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractionmask",
+            "id": "BrainExtractionMask",
+            "path-template": "[OUT_PREFIX]BrainExtractionMask.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. Brain extraction mask."
+        },
+        {
+            "name": "Brainextractionprior0genericaffine",
+            "id": "BrainExtractionPrior0GenericAffine",
+            "path-template": "[OUT_PREFIX]BrainExtractionPrior0GenericAffine.mat",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractionprior1inversewarp",
+            "id": "BrainExtractionPrior1InverseWarp",
+            "path-template": "[OUT_PREFIX]BrainExtractionPrior1InverseWarp.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractionprior1warp",
+            "id": "BrainExtractionPrior1Warp",
+            "path-template": "[OUT_PREFIX]BrainExtractionPrior1Warp.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractionpriorwarped",
+            "id": "BrainExtractionPriorWarped",
+            "path-template": "[OUT_PREFIX]BrainExtractionPriorWarped.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractionsegmentation",
+            "id": "BrainExtractionSegmentation",
+            "path-template": "[OUT_PREFIX]BrainExtractionSegmentation.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. Segmentation mask with csf, gm, and wm."
+        },
+        {
+            "name": "Brainextractiontemplatelaplacian",
+            "id": "BrainExtractionTemplateLaplacian",
+            "path-template": "[OUT_PREFIX]BrainExtractionTemplateLaplacian.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractiontmp",
+            "id": "BrainExtractionTmp",
+            "path-template": "[OUT_PREFIX]BrainExtractionTmp.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        },
+        {
+            "name": "Brainextractionwm",
+            "id": "BrainExtractionWM",
+            "path-template": "[OUT_PREFIX]BrainExtractionWM.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. Segmenration mask with only white matter."
+        },
+        {
+            "name": "N4corrected0",
+            "id": "N4Corrected0",
+            "path-template": "[OUT_PREFIX]N4Corrected0.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. N4 bias field corrected image."
+        },
+        {
+            "name": "N4truncated0",
+            "id": "N4Truncated0",
+            "path-template": "[OUT_PREFIX]N4Truncated0.[IMAGE_SUFFIX]",
+            "optional": true,
+            "description": "An existing file name. No description provided."
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "bt5e/ants:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tags": {
+        "domain": "neuroinformatics",
+        "source": "nipype-interface"
+    }
+}

--- a/app/static/pipelines/zenodo-2639849.json
+++ b/app/static/pipelines/zenodo-2639849.json
@@ -1,0 +1,610 @@
+{
+    "name": "FNIRT",
+    "command-line": "fnirt [AFFINE_FILE] [APPLY_INMASK] [APPLY_INTENSITY_MAPPING] [APPLY_REFMASK] [BIAS_REGULARIZATION_LAMBDA] [BIASFIELD_RESOLUTION] [CONFIG_FILE] [DERIVE_FROM_REF] [FIELD_FILE] [FIELDCOEFF_FILE] [HESSIAN_PRECISION] [IN_FILE] [IN_FWHM] [IN_INTENSITYMAP_FILE] [INMASK_FILE] [INMASK_VAL] [INTENSITY_MAPPING_MODEL] [INTENSITY_MAPPING_ORDER] [INWARP_FILE] [JACOBIAN_FILE] [JACOBIAN_RANGE] [LOG_FILE] [MAX_NONLIN_ITER] [MODULATEDREF_FILE] [OUT_INTENSITYMAP_FILE] [REF_FILE] [REF_FWHM] [REFMASK_FILE] [REFMASK_VAL] [REGULARIZATION_LAMBDA] [REGULARIZATION_MODEL] [SKIP_IMPLICIT_IN_MASKING] [SKIP_IMPLICIT_REF_MASKING] [SKIP_INMASK] [SKIP_INTENSITY_MAPPING] [SKIP_LAMBDA_SSQ] [SKIP_REFMASK] [SPLINE_ORDER] [SUBSAMPLING_SCHEME] [WARP_RESOLUTION] [WARPED_FILE]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "FNIRT, as implemented in Nipype (module: nipype.interfaces.fsl, interface: FNIRT).",
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/preprocess.py",
+    "inputs": [
+        {
+            "id": "affine_file",
+            "name": "Affine file",
+            "type": "File",
+            "value-key": "[AFFINE_FILE]",
+            "command-line-flag": "--aff",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of file containing affine transform.",
+            "optional": true
+        },
+        {
+            "id": "apply_inmask",
+            "name": "Apply inmask",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ],
+            "list-separator": ",",
+            "value-key": "[APPLY_INMASK]",
+            "command-line-flag": "--applyinmask",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are 0 or 1. List of iterations to use input mask on (1 to use, 0 to skip).",
+            "optional": true
+        },
+        {
+            "id": "apply_intensity_mapping",
+            "name": "Apply intensity mapping",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ],
+            "list-separator": ",",
+            "value-key": "[APPLY_INTENSITY_MAPPING]",
+            "command-line-flag": "--estint",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are 0 or 1. List of subsampling levels to apply intensity mapping for (0 to skip, 1 to apply).",
+            "optional": true
+        },
+        {
+            "id": "apply_refmask",
+            "name": "Apply refmask",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "value-choices": [
+                0,
+                1
+            ],
+            "list-separator": ",",
+            "value-key": "[APPLY_REFMASK]",
+            "command-line-flag": "--applyrefmask",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are 0 or 1. List of iterations to use reference mask on (1 to use, 0 to skip).",
+            "optional": true
+        },
+        {
+            "id": "bias_regularization_lambda",
+            "name": "Bias regularization lambda",
+            "type": "Number",
+            "value-key": "[BIAS_REGULARIZATION_LAMBDA]",
+            "command-line-flag": "--biaslambda",
+            "command-line-flag-separator": "=",
+            "description": "A float. Weight of regularisation for bias-field, default 10000.",
+            "optional": true
+        },
+        {
+            "id": "biasfield_resolution",
+            "name": "Biasfield resolution",
+            "type": "Number",
+            "list": true,
+            "list-separator": ",",
+            "min-list-entries": 3,
+            "max-list-entries": 3,
+            "integer": true,
+            "value-key": "[BIASFIELD_RESOLUTION]",
+            "command-line-flag": "--biasres",
+            "command-line-flag-separator": "=",
+            "description": "A tuple of the form: (an integer (int or long), an integer (int or long), an integer (int or long)). Resolution (in mm) of bias-field modelling local intensities, default 50, 50, 50.",
+            "optional": true
+        },
+        {
+            "id": "config_file_choices",
+            "name": "Config file",
+            "type": "String",
+            "value-key": "[CONFIG_FILE]",
+            "command-line-flag": "--config",
+            "command-line-flag-separator": "=",
+            "description": "'t1_2_mni152_2mm' or 'fa_2_fmrib58_1mm' or an existing file name. Name of config file specifying command line arguments.",
+            "optional": true,
+            "value-choices": [
+                "T1_2_MNI152_2mm",
+                "FA_2_FMRIB58_1mm"
+            ]
+        },
+        {
+            "id": "config_file",
+            "name": "Config file",
+            "type": "File",
+            "value-key": "[CONFIG_FILE]",
+            "command-line-flag": "--config",
+            "command-line-flag-separator": "=",
+            "description": "'t1_2_mni152_2mm' or 'fa_2_fmrib58_1mm' or an existing file name. Name of config file specifying command line arguments.",
+            "optional": true
+        },
+        {
+            "id": "derive_from_ref",
+            "name": "Derive from ref",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[DERIVE_FROM_REF]",
+            "command-line-flag": "--refderiv",
+            "command-line-flag-separator": "=",
+            "description": "A boolean. If true, ref image is used to calculate derivatives. default false.",
+            "optional": true,
+            "value-choices": [
+                0,
+                1
+            ]
+        },
+        {
+            "id": "field_file",
+            "name": "Field file",
+            "type": "File",
+            "value-key": "[FIELD_FILE]",
+            "command-line-flag": "--fout",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Name of output file with field.",
+            "optional": true
+        },
+        {
+            "id": "fieldcoeff_file",
+            "name": "Fieldcoeff file",
+            "type": "File",
+            "value-key": "[FIELDCOEFF_FILE]",
+            "command-line-flag": "--cout",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Name of output file with field coefficients.",
+            "optional": true
+        },
+        {
+            "id": "hessian_precision",
+            "name": "Hessian precision",
+            "type": "String",
+            "value-key": "[HESSIAN_PRECISION]",
+            "command-line-flag": "--numprec",
+            "command-line-flag-separator": "=",
+            "description": "'double' or 'float'. Precision for representing hessian, double or float. default double.",
+            "optional": true,
+            "value-choices": [
+                "double",
+                "float"
+            ]
+        },
+        {
+            "id": "in_file",
+            "name": "In file",
+            "type": "File",
+            "value-key": "[IN_FILE]",
+            "command-line-flag": "--in",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of input image.",
+            "optional": false
+        },
+        {
+            "id": "in_fwhm",
+            "name": "In fwhm",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "list-separator": ",",
+            "value-key": "[IN_FWHM]",
+            "command-line-flag": "--infwhm",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are an integer (int or long). Fwhm (in mm) of gaussian smoothing kernel for input volume, default [6, 4, 2, 2].",
+            "optional": true
+        },
+        {
+            "id": "in_intensitymap_file",
+            "name": "In intensitymap file",
+            "type": "File",
+            "list": true,
+            "min-list-entries": 1,
+            "max-list-entries": 2,
+            "value-key": "[IN_INTENSITYMAP_FILE]",
+            "command-line-flag": "--intin",
+            "command-line-flag-separator": "=",
+            "description": "A list of from 1 to 2 items which are an existing file name. Name of file/files containing initial intensity mapping usually generated by previous fnirt run.",
+            "optional": true
+        },
+        {
+            "id": "inmask_file",
+            "name": "Inmask file",
+            "type": "File",
+            "value-key": "[INMASK_FILE]",
+            "command-line-flag": "--inmask",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of file with mask in input image space.",
+            "optional": true
+        },
+        {
+            "id": "inmask_val",
+            "name": "Inmask val",
+            "type": "Number",
+            "value-key": "[INMASK_VAL]",
+            "command-line-flag": "--impinval",
+            "command-line-flag-separator": "=",
+            "description": "A float. Value to mask out in --in image. default =0.0.",
+            "optional": true
+        },
+        {
+            "id": "intensity_mapping_model",
+            "name": "Intensity mapping model",
+            "type": "String",
+            "value-key": "[INTENSITY_MAPPING_MODEL]",
+            "command-line-flag": "--intmod",
+            "command-line-flag-separator": "=",
+            "description": "'none' or 'global_linear' or 'global_non_linear' or 'local_linear' or 'global_non_linear_with_bias' or 'local_non_linear'. Model for intensity-mapping.",
+            "optional": true,
+            "value-choices": [
+                "none",
+                "global_linear",
+                "global_non_linear",
+                "local_linear",
+                "global_non_linear_with_bias",
+                "local_non_linear"
+            ]
+        },
+        {
+            "id": "intensity_mapping_order",
+            "name": "Intensity mapping order",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[INTENSITY_MAPPING_ORDER]",
+            "command-line-flag": "--intorder",
+            "command-line-flag-separator": "=",
+            "description": "An integer (int or long). Order of poynomial for mapping intensities, default 5.",
+            "optional": true
+        },
+        {
+            "id": "inwarp_file",
+            "name": "Inwarp file",
+            "type": "File",
+            "value-key": "[INWARP_FILE]",
+            "command-line-flag": "--inwarp",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of file containing initial non-linear warps.",
+            "optional": true
+        },
+        {
+            "id": "jacobian_file",
+            "name": "Jacobian file",
+            "type": "File",
+            "value-key": "[JACOBIAN_FILE]",
+            "command-line-flag": "--jout",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Name of file for writing out the jacobian of the field (for diagnostic or vbm purposes).",
+            "optional": true
+        },
+        {
+            "id": "jacobian_range",
+            "name": "Jacobian range",
+            "type": "Number",
+            "list": true,
+            "list-separator": ",",
+            "min-list-entries": 2,
+            "max-list-entries": 2,
+            "value-key": "[JACOBIAN_RANGE]",
+            "command-line-flag": "--jacrange",
+            "command-line-flag-separator": "=",
+            "description": "A tuple of the form: (a float, a float). Allowed range of jacobian determinants, default 0.01, 100.0.",
+            "optional": true
+        },
+        {
+            "id": "log_file",
+            "name": "Log file",
+            "type": "File",
+            "value-key": "[LOG_FILE]",
+            "command-line-flag": "--logout",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Name of log-file.",
+            "optional": true
+        },
+        {
+            "id": "max_nonlin_iter",
+            "name": "Max nonlin iter",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "list-separator": ",",
+            "value-key": "[MAX_NONLIN_ITER]",
+            "command-line-flag": "--miter",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are an integer (int or long). Max # of non-linear iterations list, default [5, 5, 5, 5].",
+            "optional": true
+        },
+        {
+            "id": "modulatedref_file",
+            "name": "Modulatedref file",
+            "type": "File",
+            "value-key": "[MODULATEDREF_FILE]",
+            "command-line-flag": "--refout",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Name of file for writing out intensity modulated --ref (for diagnostic purposes).",
+            "optional": true
+        },
+        {
+            "id": "out_intensitymap_file",
+            "name": "Out intensitymap file",
+            "type": "File",
+            "value-key": "[OUT_INTENSITYMAP_FILE]",
+            "command-line-flag": "--intout",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Name of files for writing information pertaining to intensity mapping.",
+            "optional": true
+        },
+        {
+            "id": "ref_file",
+            "name": "Ref file",
+            "type": "File",
+            "value-key": "[REF_FILE]",
+            "command-line-flag": "--ref",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of reference image.",
+            "optional": false
+        },
+        {
+            "id": "ref_fwhm",
+            "name": "Ref fwhm",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "list-separator": ",",
+            "value-key": "[REF_FWHM]",
+            "command-line-flag": "--reffwhm",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are an integer (int or long). Fwhm (in mm) of gaussian smoothing kernel for ref volume, default [4, 2, 0, 0].",
+            "optional": true
+        },
+        {
+            "id": "refmask_file",
+            "name": "Refmask file",
+            "type": "File",
+            "value-key": "[REFMASK_FILE]",
+            "command-line-flag": "--refmask",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Name of file with mask in reference space.",
+            "optional": true
+        },
+        {
+            "id": "refmask_val",
+            "name": "Refmask val",
+            "type": "Number",
+            "value-key": "[REFMASK_VAL]",
+            "command-line-flag": "--imprefval",
+            "command-line-flag-separator": "=",
+            "description": "A float. Value to mask out in --ref image. default =0.0.",
+            "optional": true
+        },
+        {
+            "id": "regularization_lambda",
+            "name": "Regularization lambda",
+            "type": "Number",
+            "list": true,
+            "list-separator": ",",
+            "value-key": "[REGULARIZATION_LAMBDA]",
+            "command-line-flag": "--lambda",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are a float. Weight of regularisation, default depending on --ssqlambda and --regmod switches. see user documetation.",
+            "optional": true
+        },
+        {
+            "id": "regularization_model",
+            "name": "Regularization model",
+            "type": "String",
+            "value-key": "[REGULARIZATION_MODEL]",
+            "command-line-flag": "--regmod",
+            "command-line-flag-separator": "=",
+            "description": "'membrane_energy' or 'bending_energy'. Model for regularisation of warp-field [membrane_energy bending_energy], default bending_energy.",
+            "optional": true,
+            "value-choices": [
+                "membrane_energy",
+                "bending_energy"
+            ]
+        },
+        {
+            "id": "skip_implicit_in_masking",
+            "name": "Skip implicit in masking",
+            "type": "Flag",
+            "value-key": "[SKIP_IMPLICIT_IN_MASKING]",
+            "command-line-flag": "--impinm=0",
+            "description": "A boolean. Skip implicit masking  based on value in --in image. default = 0.",
+            "optional": true
+        },
+        {
+            "id": "skip_implicit_ref_masking",
+            "name": "Skip implicit ref masking",
+            "type": "Flag",
+            "value-key": "[SKIP_IMPLICIT_REF_MASKING]",
+            "command-line-flag": "--imprefm=0",
+            "description": "A boolean. Skip implicit masking  based on value in --ref image. default = 0.",
+            "optional": true
+        },
+        {
+            "id": "skip_inmask",
+            "name": "Skip inmask",
+            "type": "Flag",
+            "value-key": "[SKIP_INMASK]",
+            "command-line-flag": "--applyinmask=0",
+            "description": "A boolean. Skip specified inmask if set, default false.",
+            "optional": true
+        },
+        {
+            "id": "skip_intensity_mapping",
+            "name": "Skip intensity mapping",
+            "type": "Flag",
+            "value-key": "[SKIP_INTENSITY_MAPPING]",
+            "command-line-flag": "--estint=0",
+            "description": "A boolean. Skip estimate intensity-mapping default false.",
+            "optional": true
+        },
+        {
+            "id": "skip_lambda_ssq",
+            "name": "Skip lambda ssq",
+            "type": "Flag",
+            "value-key": "[SKIP_LAMBDA_SSQ]",
+            "command-line-flag": "--ssqlambda=0",
+            "description": "A boolean. If true, lambda is not weighted by current ssq, default false.",
+            "optional": true
+        },
+        {
+            "id": "skip_refmask",
+            "name": "Skip refmask",
+            "type": "Flag",
+            "value-key": "[SKIP_REFMASK]",
+            "command-line-flag": "--applyrefmask=0",
+            "description": "A boolean. Skip specified refmask if set, default false.",
+            "optional": true
+        },
+        {
+            "id": "spline_order",
+            "name": "Spline order",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[SPLINE_ORDER]",
+            "command-line-flag": "--splineorder",
+            "command-line-flag-separator": "=",
+            "description": "An integer (int or long). Order of spline, 2->quadratic spline, 3->cubic spline. default=3.",
+            "optional": true,
+            "value-choices": [
+                2,
+                3
+            ]
+        },
+        {
+            "id": "subsampling_scheme",
+            "name": "Subsampling scheme",
+            "type": "Number",
+            "list": true,
+            "integer": true,
+            "list-separator": ",",
+            "value-key": "[SUBSAMPLING_SCHEME]",
+            "command-line-flag": "--subsamp",
+            "command-line-flag-separator": "=",
+            "description": "A list of items which are an integer (int or long). Sub-sampling scheme, list, default [4, 2, 1, 1].",
+            "optional": true
+        },
+        {
+            "id": "warp_resolution",
+            "name": "Warp resolution",
+            "type": "Number",
+            "list": true,
+            "list-separator": ",",
+            "min-list-entries": 3,
+            "max-list-entries": 3,
+            "integer": true,
+            "value-key": "[WARP_RESOLUTION]",
+            "command-line-flag": "--warpres",
+            "command-line-flag-separator": "=",
+            "description": "A tuple of the form: (an integer (int or long), an integer (int or long), an integer (int or long)). (approximate) resolution (in mm) of warp basis in x-, y- and z-direction, default 10, 10, 10.",
+            "optional": true
+        },
+        {
+            "id": "warped_file",
+            "name": "Warped file",
+            "type": "File",
+            "value-key": "[WARPED_FILE]",
+            "command-line-flag": "--iout",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Name of output image.",
+            "optional": true
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Field file",
+            "id": "field_file_outfile",
+            "path-template": "[FIELD_FILE]",
+            "optional": true,
+            "description": "A file name. File with warp field."
+        },
+        {
+            "name": "Fieldcoeff file",
+            "id": "fieldcoeff_file_outfile",
+            "path-template": "[FIELDCOEFF_FILE]",
+            "optional": true,
+            "description": "An existing file name. File with field coefficients."
+        },
+        {
+            "name": "Jacobian file",
+            "id": "jacobian_file_outfile",
+            "path-template": "[JACOBIAN_FILE]",
+            "optional": true,
+            "description": "A file name. File containing jacobian of the field."
+        },
+        {
+            "name": "Log file",
+            "id": "log_file_outfile",
+            "path-template": "[LOG_FILE]",
+            "optional": true,
+            "description": "A file name. Name of log-file."
+        },
+        {
+            "name": "Modulatedref file",
+            "id": "modulatedref_file_outfile",
+            "path-template": "[MODULATEDREF_FILE]",
+            "optional": true,
+            "description": "A file name. File containing intensity modulated --ref."
+        },
+        {
+            "name": "Out intensitymap file",
+            "id": "out_intensitymap_file_outfile",
+            "path-template": "[OUT_INTENSITYMAP_FILE]",
+            "optional": true,
+            "description": "A list of from 2 to 2 items which are a file name. Files containing info pertaining to intensity mapping.",
+            "list": true
+        },
+        {
+            "name": "Warped file",
+            "id": "warped_file_outfile",
+            "path-template": "[WARPED_FILE]",
+            "optional": true,
+            "description": "An existing file name. Warped image."
+        }
+    ],
+    "groups": [
+        {
+            "id": "config_file_group",
+            "name": "Config file group",
+            "members": [
+                "config_file",
+                "config_file_choices"
+            ],
+            "mutually-exclusive": true
+        },
+        {
+            "id": "mutex_group",
+            "name": "Mutex group",
+            "members": [
+                "apply_refmask",
+                "skip_refmask"
+            ],
+            "mutually-exclusive": true
+        },
+        {
+            "id": "mutex_group_2",
+            "name": "Mutex group 2",
+            "members": [
+                "apply_inmask",
+                "skip_inmask"
+            ],
+            "mutually-exclusive": true
+        },
+        {
+            "id": "mutex_group_3",
+            "name": "Mutex group 3",
+            "members": [
+                "skip_intensity_mapping",
+                "apply_intensity_mapping"
+            ],
+            "mutually-exclusive": true
+        }
+    ],
+    "tool-version": "1.0.1",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "fmri"
+        ],
+        "source": "nipype-interface"
+    }
+}

--- a/app/static/pipelines/zenodo-2640953.json
+++ b/app/static/pipelines/zenodo-2640953.json
@@ -1,0 +1,48 @@
+{
+    "tool-version": "1.0.0", 
+    "description": "Concatenate multiple ANTs warping fields using ComposeMultiTransform.\n\nFor instance if you have\n- Warping field: anatomical to MNI template\n- Affine matrix: Diffusion to anatomical\nYou can obtain the transform diffusion to MNI template\n\n\nComposeMultiTransform ImageDimension output_field [-R reference_image] {[deformation_field | [-i] affine_transform_txt ]}\n  Usage has the same form as WarpImageMultiTransform\n For Example:\n\nComposeMultiTransform Dimension  outwarp.nii   -R template.nii   ExistingWarp.nii  ExistingAffine.nii\n or for an inverse mapping :\nComposeMultiTransform Dimension  outwarp.nii   -R template.nii   -i ExistingAffine.nii ExistingInverseWarp.nii\n recalling that the -i option takes the inverse of the affine mapping\n\nOr: to compose multiple affine text file into one:\nComposeMultiTransform ImageDimension output_affine_txt [-R reference_affine_txt] {[-i] affine_transform_txt}\nThis will be evoked if a text file is given as the second parameter. In this case reference_affine_txt is used to define the center of the output affine.  The default reference is the first given affine text file. This ignores all non-txt files among the following parameters.\n\n", 
+    "command-line": "ComposeMultiTransform 3 [OUPUT_WARPING_FIELD] -R [REFERENCE_IMAGE] [1ST_WARPING_FIELD__OR_AFFINE_MATRIX_] [2ND_WARPING_FIELD]", 
+    "author": "TONIC", 
+    "container-image": {
+        "image": "bids/mrtrix3_connectome", 
+        "type": "docker"
+    }, 
+    "inputs": [
+        {
+            "description": "Reference Image", 
+            "value-key": "[REFERENCE_IMAGE]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "reference_image", 
+            "name": "Reference Image"
+        }, 
+        {
+            "description": "1st warping field (or affine matrix)", 
+            "value-key": "[1ST_WARPING_FIELD__OR_AFFINE_MATRIX_]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "1st_warping_field__or_affine_matrix_", 
+            "name": "1st warping field (or affine matrix)"
+        }, 
+        {
+            "description": "2nd warping field", 
+            "value-key": "[2ND_WARPING_FIELD]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "2nd_warping_field", 
+            "name": "2nd warping field"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "description": "Ouput warping field", 
+            "value-key": "[OUPUT_WARPING_FIELD]", 
+            "path-template": "./", 
+            "optional": false, 
+            "id": "ouput_warping_field", 
+            "name": "Ouput warping field"
+        }
+    ], 
+    "name": "ConcatTransfo"
+}

--- a/app/static/pipelines/zenodo-2644621.json
+++ b/app/static/pipelines/zenodo-2644621.json
@@ -1,0 +1,189 @@
+{
+    "author": "Test author",
+    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FILE_LIST_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [LOG] [INT_LIST_INPUT]",
+    "container-image": {
+        "container-opts": [
+            "-e",
+            "HOME=$PWD"
+        ],
+        "image": "boutiques/example1:test",
+        "type": "docker"
+    },
+    "deprecated": true,
+    "description": "This property describes the tool or application",
+    "descriptor-url": "https://github.com/boutiques/boutiques/blob/master/tools/python/boutiques/schema/examples/example1/example1_docker.json",
+    "environment-variables": [
+        {
+            "name": "ENVAR",
+            "value": "theValue"
+        }
+    ],
+    "error-codes": [
+        {
+            "code": 2,
+            "description": "File does not exist!"
+        }
+    ],
+    "groups": [
+        {
+            "description": "This group forces us to choose exactly one of the file or the enum input to use.",
+            "id": "an_example_group",
+            "members": [
+                "num_input",
+                "enum_input"
+            ],
+            "mutually-exclusive": true,
+            "name": "Example group 1",
+            "one-is-required": true
+        }
+    ],
+    "inputs": [
+        {
+            "command-line-flag": "-i",
+            "default-value": [
+                "aStringValue"
+            ],
+            "description": "Describe the use and meaning of the parameter",
+            "id": "str_input_list",
+            "list": true,
+            "max-list-entries": 3,
+            "min-list-entries": 1,
+            "name": "A list of string inputs",
+            "type": "String",
+            "value-key": "[STRING_INPUT_LIST]"
+        },
+        {
+            "command-line-flag": "-s",
+            "default-value": "aStringValue",
+            "description": "Describe the use and meaning of the parameter",
+            "id": "str_input",
+            "name": "A string input",
+            "type": "String",
+            "value-key": "[STRING_INPUT]"
+        },
+        {
+            "command-line-flag": "-l",
+            "description": "Describe the use and meaning of the parameter",
+            "id": "list_int_input",
+            "integer": true,
+            "list": true,
+            "min-list-entries": 1,
+            "name": "A list of ints",
+            "type": "Number",
+            "value-key": "[INT_LIST_INPUT]"
+        },
+        {
+            "id": "config_num",
+            "name": "A number put in the configuration file",
+            "type": "Number",
+            "value-choices": [
+                4
+            ],
+            "value-key": "[CONFIG_NUMBER]"
+        },
+        {
+            "command-line-flag": "-n",
+            "command-line-flag-separator": "=",
+            "exclusive-minimum": true,
+            "id": "num_input",
+            "maximum": 1,
+            "minimum": 0,
+            "name": "A number input",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[NUMBER_INPUT]"
+        },
+        {
+            "id": "file_input",
+            "name": "A file input",
+            "optional": true,
+            "type": "File",
+            "value-key": "[FILE_INPUT]"
+        },
+        {
+            "command-line-flag": "-t",
+            "id": "file_list_input",
+            "list": true,
+            "name": "A file list input",
+            "optional": true,
+            "type": "File",
+            "value-key": "[FILE_LIST_INPUT]"
+        },
+        {
+            "command-line-flag": "-e",
+            "id": "enum_input",
+            "name": "An enum input",
+            "optional": true,
+            "type": "String",
+            "value-choices": [
+                "val1",
+                "val2",
+                "val3"
+            ],
+            "value-key": "[ENUM_INPUT]"
+        },
+        {
+            "command-line-flag": "-f",
+            "disables-inputs": [
+                "num_input"
+            ],
+            "id": "flag_input",
+            "name": "A flag input",
+            "optional": true,
+            "requires-inputs": [
+                "file_input"
+            ],
+            "type": "Flag",
+            "value-key": "[FLAG_INPUT]"
+        }
+    ],
+    "name": "Example Boutiques Tool",
+    "online-platform-urls": [
+        "http://somewhere.org/good_tool",
+        "https://someplace.com/bad_tool"
+    ],
+    "output-files": [
+        {
+            "description": "The output log file from the example tool",
+            "id": "logfile",
+            "name": "Log file",
+            "path-template": "log-[CONFIG_NUMBER]-[STRING_INPUT].txt",
+            "path-template-stripped-extensions": [
+                ".txt",
+                ".csv"
+            ],
+            "value-key": "[LOG]"
+        },
+        {
+            "id": "output_files",
+            "list": true,
+            "name": "outfiles",
+            "optional": true,
+            "path-template": "output/*_exampleOutputTag.resultType"
+        },
+        {
+            "command-line-flag": "-c",
+            "file-template": [
+                "# This is a demo configuration file",
+                "numInput=[CONFIG_NUMBER]",
+                "strInput=[STRING_INPUT]"
+            ],
+            "id": "config_file",
+            "name": "Configuration file",
+            "path-template": "./config.txt",
+            "value-key": "[CONFIG_FILE]"
+        }
+    ],
+    "schema-version": "0.5",
+    "tags": {
+        "domain": "testing",
+        "foo": [
+            "bar1",
+            "bar2"
+        ],
+        "programming-language": "Python"
+    },
+    "tool-doi": "00.0000/example.0000000",
+    "tool-version": "0.0.1",
+    "url": "http://example.com"
+}

--- a/app/static/pipelines/zenodo-2646555.json
+++ b/app/static/pipelines/zenodo-2646555.json
@@ -1,0 +1,97 @@
+{
+    "name": "LaplacianThickness",
+    "command-line": "${ANTSPATH}/LaplacianThickness [INPUT_WM] [INPUT_GM] [OUTPUT_IMAGE] [SMOOTH_PARAM] [PRIOR_THICKNESS] [DT] [SULCUS_PRIOR] [TOLERANCE]",
+    "author": "Nipype (interface), Brian B. Avants et al. (tool)",
+    "description": "LaplacianThickness, as implemented in Nipype (module: nipype.interfaces.ants, interface: LaplacianThickness).",
+    "inputs": [
+        {
+            "id": "dT",
+            "name": "Dt",
+            "type": "Number",
+            "value-key": "[DT]",
+            "description": "A float. Time delta used during integration (defaults to 0.01).",
+            "optional": true,
+            "requires-inputs": [
+                "prior_thickness"
+            ]
+        },
+        {
+            "id": "input_gm",
+            "name": "Input gm",
+            "type": "File",
+            "value-key": "[INPUT_GM]",
+            "description": "A file name. Gray matter segmentation image.",
+            "optional": false
+        },
+        {
+            "id": "input_wm",
+            "name": "Input wm",
+            "type": "File",
+            "value-key": "[INPUT_WM]",
+            "description": "A file name. White matter segmentation image.",
+            "optional": false
+        },
+        {
+            "id": "prior_thickness",
+            "name": "Prior thickness",
+            "type": "Number",
+            "value-key": "[PRIOR_THICKNESS]",
+            "description": "A float. Prior thickness (defaults to 500).",
+            "optional": true,
+            "requires-inputs": [
+                "smooth_param"
+            ]
+        },
+        {
+            "id": "smooth_param",
+            "name": "Smooth param",
+            "type": "Number",
+            "value-key": "[SMOOTH_PARAM]",
+            "description": "A float. Sigma of the laplacian recursive image filter (defaults to 1).",
+            "optional": true
+        },
+        {
+            "id": "sulcus_prior",
+            "name": "Sulcus prior",
+            "type": "Number",
+            "value-key": "[SULCUS_PRIOR]",
+            "description": "A float. Positive floating point number for sulcus prior. Authors said that 0.15 might be a reasonable value.",
+            "optional": true,
+            "requires-inputs": [
+                "dT"
+            ]
+        },
+        {
+            "id": "tolerance",
+            "name": "Tolerance",
+            "type": "Number",
+            "value-key": "[TOLERANCE]",
+            "description": "A float. Tolerance to reach during optimization (defaults to 0.001).",
+            "optional": true,
+            "requires-inputs": [
+                "sulcus_prior"
+            ]
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Output image",
+            "id": "output_image",
+            "optional": true,
+            "description": "An existing file name. Cortical thickness.",
+            "path-template": "[INPUT_WM]_thickness",
+            "value-key": "[OUTPUT_IMAGE]"
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "bt5e/ants:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tags": {
+        "domain": "neuroinformatics",
+        "source": "nipype-interface"
+    }
+}

--- a/app/static/pipelines/zenodo-2648761.json
+++ b/app/static/pipelines/zenodo-2648761.json
@@ -1,0 +1,92 @@
+{
+    "name": "CompositeTransformUtil",
+    "command-line": "${ANTSPATH}/CompositeTransformUtil [PROCESS] [OUT_FILE] [IN_FILE] [OUTPUT_PREFIX]",
+    "author": "Nipype (interface), Brian B. Avants et al. (tool)",
+    "description": "CompositeTransformUtil, as implemented in Nipype (module: nipype.interfaces.ants, interface: CompositeTransformUtil).",
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/ants/registration.py",
+    "inputs": [
+        {
+            "id": "in_file",
+            "name": "In file",
+            "type": "File",
+            "list": true,
+            "value-key": "[IN_FILE]",
+            "description": "A list of items which are an existing file name. Input transform file(s).",
+            "optional": false
+        },
+        {
+            "id": "out_file",
+            "name": "Out file",
+            "type": "File",
+            "value-key": "[OUT_FILE]",
+            "description": "A file name. Output file path (only used for assembly).",
+            "optional": true
+        },
+        {
+            "id": "output_prefix",
+            "name": "Output prefix",
+            "type": "String",
+            "value-key": "[OUTPUT_PREFIX]",
+            "description": "A unicode string. A prefix that is prepended to all output files (only used for disassembly).",
+            "optional": true,
+            "default-value": "transform"
+        },
+        {
+            "id": "process",
+            "name": "Process",
+            "type": "String",
+            "value-key": "[PROCESS]",
+            "command-line-flag": "--",
+            "command-line-flag-separator": "",
+            "description": "'assemble' or 'disassemble'. What to do with the transform inputs (assemble or disassemble).",
+            "optional": true,
+            "default-value": "assemble",
+            "value-choices": [
+                "assemble",
+                "disassemble"
+            ],
+            "value-disables": {
+                "assemble": [
+                    "output_prefix"
+                ],
+                "disassemble": [
+                    "out_file"
+                ]
+            }
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Affine transform",
+            "id": "affine_transform",
+            "path-template": "00_[OUTPUT_PREFIX]_AffineTransform.mat",
+            "optional": true,
+            "description": "A file name. Affine transform component."
+        },
+        {
+            "name": "Displacement field",
+            "id": "displacement_field",
+            "path-template": "01_[OUTPUT_PREFIX]_DisplacementFieldTransform.nii.gz",
+            "optional": true,
+            "description": "A file name. Displacement field component."
+        },
+        {
+            "name": "Out file",
+            "id": "out_file_outfile",
+            "path-template": "[OUT_FILE]",
+            "optional": true,
+            "description": "A file name. Compound transformation file."
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "bt5e/ants:latest",
+        "index": "index.docker.io",
+        "type": "docker"
+    },
+    "tags": {
+        "domain": "neuroinformatics",
+        "source": "nipype-interface"
+    }
+}

--- a/app/static/pipelines/zenodo-2650440.json
+++ b/app/static/pipelines/zenodo-2650440.json
@@ -1,0 +1,206 @@
+{
+    "name": "ApplyWarp",
+    "command-line": "applywarp [INTERP] [IN_FILE] [REF_FILE] [OUT_FILE] [RELWARP] [ABSWARP] [DATATYPE] [FIELD_FILE] [MASK_FILE] [POSTMAT] [PREMAT] [SUPERLEVEL] [SUPERSAMPLE]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "ApplyWarp, as implemented in Nipype (module: nipype.interfaces.fsl, interface: ApplyWarp).",
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/preprocess.py",
+    "inputs": [
+        {
+            "id": "abswarp",
+            "name": "Abswarp",
+            "type": "Flag",
+            "value-key": "[ABSWARP]",
+            "command-line-flag": "--abs",
+            "description": "A boolean. Treat warp field as absolute: x' = w(x).",
+            "optional": true
+        },
+        {
+            "id": "datatype",
+            "name": "Datatype",
+            "type": "String",
+            "value-key": "[DATATYPE]",
+            "command-line-flag": "--datatype",
+            "command-line-flag-separator": "=",
+            "description": "'char' or 'short' or 'int' or 'float' or 'double'. Force output data type [char short int float double].",
+            "optional": true,
+            "value-choices": [
+                "char",
+                "short",
+                "int",
+                "float",
+                "double"
+            ]
+        },
+        {
+            "id": "field_file",
+            "name": "Field file",
+            "type": "File",
+            "value-key": "[FIELD_FILE]",
+            "command-line-flag": "--warp",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. File containing warp field.",
+            "optional": true
+        },
+        {
+            "id": "in_file",
+            "name": "In file",
+            "type": "File",
+            "value-key": "[IN_FILE]",
+            "command-line-flag": "--in",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Image to be warped.",
+            "optional": false
+        },
+        {
+            "id": "interp",
+            "name": "Interp",
+            "type": "String",
+            "value-key": "[INTERP]",
+            "command-line-flag": "--interp",
+            "command-line-flag-separator": "=",
+            "description": "'nn' or 'trilinear' or 'sinc' or 'spline'. Interpolation method.",
+            "optional": true,
+            "value-choices": [
+                "nn",
+                "trilinear",
+                "sinc",
+                "spline"
+            ]
+        },
+        {
+            "id": "mask_file",
+            "name": "Mask file",
+            "type": "File",
+            "value-key": "[MASK_FILE]",
+            "command-line-flag": "--mask",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Filename for mask image (in reference space).",
+            "optional": true
+        },
+        {
+            "id": "out_file",
+            "name": "Out file",
+            "type": "File",
+            "value-key": "[OUT_FILE]",
+            "command-line-flag": "--out",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Output filename.",
+            "optional": false
+        },
+        {
+            "id": "postmat",
+            "name": "Postmat",
+            "type": "File",
+            "value-key": "[POSTMAT]",
+            "command-line-flag": "--postmat",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Filename for post-transform (affine matrix).",
+            "optional": true
+        },
+        {
+            "id": "premat",
+            "name": "Premat",
+            "type": "File",
+            "value-key": "[PREMAT]",
+            "command-line-flag": "--premat",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Filename for pre-transform (affine matrix).",
+            "optional": true
+        },
+        {
+            "id": "ref_file",
+            "name": "Ref file",
+            "type": "File",
+            "value-key": "[REF_FILE]",
+            "command-line-flag": "--ref",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Reference image.",
+            "optional": false
+        },
+        {
+            "id": "relwarp",
+            "name": "Relwarp",
+            "type": "Flag",
+            "value-key": "[RELWARP]",
+            "command-line-flag": "--rel",
+            "description": "A boolean. Treat warp field as relative: x' = x + w(x).",
+            "optional": true
+        },
+        {
+            "id": "superlevel",
+            "name": "Superlevel",
+            "type": "String",
+            "value-key": "[SUPERLEVEL]",
+            "command-line-flag": "--superlevel",
+            "command-line-flag-separator": "=",
+            "description": "'a' or an integer (int or long). Level of intermediary supersampling, a for 'automatic' or integer level. default = 2.",
+            "optional": true,
+            "value-choices": [
+                "a"
+            ]
+        },
+        {
+            "id": "superlevel_int",
+            "name": "Superlevel",
+            "type": "Number",
+            "integer": true,
+            "value-key": "[SUPERLEVEL]",
+            "command-line-flag": "--superlevel",
+            "command-line-flag-separator": "=",
+            "description": "'a' or an integer (int or long). Level of intermediary supersampling, a for 'automatic' or integer level. default = 2.",
+            "optional": true
+        },
+        {
+            "id": "supersample",
+            "name": "Supersample",
+            "type": "Flag",
+            "value-key": "[SUPERSAMPLE]",
+            "command-line-flag": "--super",
+            "description": "A boolean. Intermediary supersampling of output, default is off.",
+            "optional": true
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Out file",
+            "id": "out_file_outfile",
+            "path-template": "[OUT_FILE]",
+            "optional": true,
+            "description": "An existing file name. Warped output file."
+        }
+    ],
+    "groups": [
+        {
+            "id": "superlevel_group",
+            "name": "Superlevel group",
+            "members": [
+                "superlevel",
+                "superlevel_int"
+            ],
+            "mutually-exclusive": true
+        },
+        {
+            "id": "mutex_group",
+            "name": "Mutex group",
+            "members": [
+                "relwarp",
+                "abswarp"
+            ],
+            "mutually-exclusive": true
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "mri"
+        ],
+        "source": "nipype-interface"
+    }
+}

--- a/app/static/pipelines/zenodo-2650465.json
+++ b/app/static/pipelines/zenodo-2650465.json
@@ -1,0 +1,88 @@
+{
+    "name": "DistanceMap",
+    "command-line": "distancemap  [DISTANCE_MAP] [IN_FILE] [INVERT_INPUT] [LOCAL_MAX_FILE] [MASK_FILE]",
+    "author": "Nipype (interface), Oxford Centre for Functional MRI of the Brain (FMRIB) (tool)",
+    "description": "DistanceMap, as implemented in Nipype (module: nipype.interfaces.fsl, interface: DistanceMap).",
+    "url": "https://github.com/nipy/nipype/blob/master/nipype/interfaces/fsl/dti.py",
+    "inputs": [
+        {
+            "id": "distance_map",
+            "name": "Distance map",
+            "type": "File",
+            "value-key": "[DISTANCE_MAP]",
+            "command-line-flag": "--out",
+            "command-line-flag-separator": "=",
+            "description": "A file name. Distance map to write.",
+            "optional": false
+        },
+        {
+            "id": "in_file",
+            "name": "In file",
+            "type": "File",
+            "value-key": "[IN_FILE]",
+            "command-line-flag": "--in",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Image to calculate distance values for.",
+            "optional": false
+        },
+        {
+            "id": "invert_input",
+            "name": "Invert input",
+            "type": "Flag",
+            "value-key": "[INVERT_INPUT]",
+            "command-line-flag": "--invert",
+            "description": "A boolean. Invert input image.",
+            "optional": true
+        },
+        {
+            "id": "local_max_file",
+            "name": "Local max file",
+            "type": "File",
+            "value-key": "[LOCAL_MAX_FILE]",
+            "command-line-flag": "--localmax",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Write an image of the local maxima.",
+            "optional": true
+        },
+        {
+            "id": "mask_file",
+            "name": "Mask file",
+            "type": "File",
+            "value-key": "[MASK_FILE]",
+            "command-line-flag": "--mask",
+            "command-line-flag-separator": "=",
+            "description": "An existing file name. Binary mask to contrain calculations.",
+            "optional": true
+        }
+    ],
+    "output-files": [
+        {
+            "name": "Distance map",
+            "id": "distance_map_outfile",
+            "path-template": "[DISTANCE_MAP]",
+            "optional": true,
+            "description": "An existing file name. Value is distance to nearest nonzero voxels."
+        },
+        {
+            "name": "Local max file",
+            "id": "local_max_file_outfile",
+            "path-template": "[LOCAL_MAX_FILE]",
+            "optional": true,
+            "description": "A file name. Image of local maxima."
+        }
+    ],
+    "tool-version": "1.0.0",
+    "schema-version": "0.5",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker",
+        "index": "index.docker.io"
+    },
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "mri"
+        ],
+        "source": "nipype-interface"
+    }
+}

--- a/app/static/pipelines/zenodo-3235835.json
+++ b/app/static/pipelines/zenodo-3235835.json
@@ -1,0 +1,292 @@
+{
+    "error-codes": [
+        {
+            "code": 1, 
+            "description": "failed"
+        }
+    ], 
+    "tool-version": "v1", 
+    "tests": [
+        {
+            "invocation": {
+                "5c0c0020f0a53c004bd7ae7c_M": "mean", 
+                "5c0a8a9df0a53c004bd79c82_lmax": null, 
+                "5bfebb5d80ce40002a62cdfc_eddyCorrect": "1", 
+                "5c0a8a9df0a53c004bd79c82_fibers": 500000, 
+                "5bfebb5d80ce40002a62cdfc_resolution": "default", 
+                "5c0bea9cf0a53c004bd7ae07_useinterhemisphericsplit": false, 
+                "5c0c0020f0a53c004bd7ae7c_maxlen": 4, 
+                "5bfebb5d80ce40002a62cdfc_phaseEncodeDir": "2", 
+                "5c0a8a9df0a53c004bd79c82_fibers_max": 1000000, 
+                "5bfebb5d80ce40002a62cdfc_noDwiAlignment": false, 
+                "5bfebb5d80ce40002a62cdfc_rotateBvecsWithCanXform": true, 
+                "5c0c0020f0a53c004bd7ae7c_numnodes": 100, 
+                "5bfebb5d80ce40002a62cdfc_rotateBvecsWithRx": true, 
+                "5c0c0020f0a53c004bd7ae7c_maxdist": 4, 
+                "5c0c0020f0a53c004bd7ae7c_maxiter": 5
+            }, 
+            "name": "test1", 
+            "assertions": {
+                "output-files": [
+                    {
+                        "id": "output"
+                    }
+                ], 
+                "exit-code": 0
+            }
+        }
+    ], 
+    "description": "from acpc_aligned t1 and singleshell b2000 dwi, generate afq output", 
+    "command-line": "bash run.sh", 
+    "author": "Soichi Hayashi", 
+    "tags": {
+        "source": "brainlife", 
+        "dataset_id": "5c0c06e6f6f108004b490e2a"
+    }, 
+    "inputs": [
+        {
+            "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n phaseEncodeDir", 
+            "default-value": "2", 
+            "value-key": "[task.5bfebb5d80ce40002a62cdfc.phaseEncodeDir]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "5bfebb5d80ce40002a62cdfc_phaseEncodeDir"
+        }, 
+        {
+            "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n resolution", 
+            "default-value": "default", 
+            "value-key": "[task.5bfebb5d80ce40002a62cdfc.resolution]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "5bfebb5d80ce40002a62cdfc_resolution"
+        }, 
+        {
+            "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n rotateBvecsWithCanXform", 
+            "default-value": "true", 
+            "value-key": "[task.5bfebb5d80ce40002a62cdfc.rotateBvecsWithCanXform]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "5bfebb5d80ce40002a62cdfc_rotateBvecsWithCanXform"
+        }, 
+        {
+            "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n rotateBvecsWithRx", 
+            "default-value": "true", 
+            "value-key": "[task.5bfebb5d80ce40002a62cdfc.rotateBvecsWithRx]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "5bfebb5d80ce40002a62cdfc_rotateBvecsWithRx"
+        }, 
+        {
+            "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n eddyCorrect", 
+            "default-value": "1", 
+            "value-key": "[task.5bfebb5d80ce40002a62cdfc.eddyCorrect]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "5bfebb5d80ce40002a62cdfc_eddyCorrect"
+        }, 
+        {
+            "name": "brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n noDwiAlignment", 
+            "default-value": "false", 
+            "value-key": "[task.5bfebb5d80ce40002a62cdfc.noDwiAlignment]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "5bfebb5d80ce40002a62cdfc_noDwiAlignment"
+        }, 
+        {
+            "name": "brain-life/app-tracking(1.5)\nlmax:(null)\nfibers:500000\nfibers_max:1000000\n lmax", 
+            "default-value": null, 
+            "value-key": "[task.5c0a8a9df0a53c004bd79c82.lmax]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "5c0a8a9df0a53c004bd79c82_lmax"
+        }, 
+        {
+            "name": "brain-life/app-tracking(1.5)\nlmax:(null)\nfibers:500000\nfibers_max:1000000\n fibers", 
+            "default-value": 500000, 
+            "value-key": "[task.5c0a8a9df0a53c004bd79c82.fibers]", 
+            "type": "Number", 
+            "optional": true, 
+            "id": "5c0a8a9df0a53c004bd79c82_fibers"
+        }, 
+        {
+            "name": "brain-life/app-tracking(1.5)\nlmax:(null)\nfibers:500000\nfibers_max:1000000\n fibers_max", 
+            "default-value": 1000000, 
+            "value-key": "[task.5c0a8a9df0a53c004bd79c82.fibers_max]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "5c0a8a9df0a53c004bd79c82_fibers_max"
+        }, 
+        {
+            "name": "brain-life/app-tractclassification(1.2)\nuseinterhemisphericsplit:(null)\n useinterhemisphericsplit", 
+            "default-value": "false", 
+            "value-key": "[task.5c0bea9cf0a53c004bd7ae07.useinterhemisphericsplit]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "5c0bea9cf0a53c004bd7ae07_useinterhemisphericsplit"
+        }, 
+        {
+            "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n maxiter", 
+            "default-value": 5, 
+            "value-key": "[task.5c0c0020f0a53c004bd7ae7c.maxiter]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "5c0c0020f0a53c004bd7ae7c_maxiter"
+        }, 
+        {
+            "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n numnodes", 
+            "default-value": 100, 
+            "value-key": "[task.5c0c0020f0a53c004bd7ae7c.numnodes]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "5c0c0020f0a53c004bd7ae7c_numnodes"
+        }, 
+        {
+            "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n maxlen", 
+            "default-value": 4, 
+            "value-key": "[task.5c0c0020f0a53c004bd7ae7c.maxlen]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "5c0c0020f0a53c004bd7ae7c_maxlen"
+        }, 
+        {
+            "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n maxdist", 
+            "default-value": 4, 
+            "value-key": "[task.5c0c0020f0a53c004bd7ae7c.maxdist]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "5c0c0020f0a53c004bd7ae7c_maxdist"
+        }, 
+        {
+            "name": "brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n M", 
+            "default-value": "mean", 
+            "value-key": "[task.5c0c0020f0a53c004bd7ae7c.M]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "5c0c0020f0a53c004bd7ae7c_M"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "task.5a05e7ad2767f30030bcf433/config.json", 
+            "file-template": [
+                "{    \"t1\": \"../5a05e7a82767f30030bcf431/5a050966eec2b300611abff2/t1.nii.gz\"}"
+            ], 
+            "id": "5a05e7ad2767f30030bcf433_config", 
+            "name": "config.json for brain-life/app-freesurfer\n"
+        }, 
+        {
+            "path-template": "task.5bfebb5d80ce40002a62cdfc/config.json", 
+            "file-template": [
+                "{    \"phaseEncodeDir\": \"[task.5bfebb5d80ce40002a62cdfc.phaseEncodeDir]\",    \"resolution\": \"[task.5bfebb5d80ce40002a62cdfc.resolution]\",    \"rotateBvecsWithCanXform\": [task.5bfebb5d80ce40002a62cdfc.rotateBvecsWithCanXform],    \"rotateBvecsWithRx\": [task.5bfebb5d80ce40002a62cdfc.rotateBvecsWithRx],    \"eddyCorrect\": \"[task.5bfebb5d80ce40002a62cdfc.eddyCorrect]\",    \"noDwiAlignment\": [task.5bfebb5d80ce40002a62cdfc.noDwiAlignment],    \"dwi\": \"../5bfebb5d80ce40002a62cdfa/5a050a00eec2b300611abff3/dwi.nii.gz\",    \"bvecs\": \"../5bfebb5d80ce40002a62cdfa/5a050a00eec2b300611abff3/dwi.bvecs\",    \"bvals\": \"../5bfebb5d80ce40002a62cdfa/5a050a00eec2b300611abff3/dwi.bvals\",    \"t1\": \"../5bfebb5d80ce40002a62cdfa/5a050966eec2b300611abff2/t1.nii.gz\"}"
+            ], 
+            "id": "5bfebb5d80ce40002a62cdfc_config", 
+            "name": "config.json for brain-life/app-dtiinit(1.6)\nphaseEncodeDir:2\nresolution:default\nrotateBvecsWithCanXform:(null)\nrotateBvecsWithRx:(null)\neddyCorrect:-1\nnoDwiAlignment:true\n"
+        }, 
+        {
+            "path-template": "task.5c0a8a9df0a53c004bd79c82/config.json", 
+            "file-template": [
+                "{    \"lmax\": \"[task.5c0a8a9df0a53c004bd79c82.lmax]\",    \"fibers\": \"[task.5c0a8a9df0a53c004bd79c82.fibers]\",    \"fibers_max\": \"[task.5c0a8a9df0a53c004bd79c82.fibers_max]\",    \"dwi\": \"../5c098457f0a53c004bd79131/5bfee5acc203920043d43ddd/dwi.nii.gz\",    \"bvecs\": \"../5c098457f0a53c004bd79131/5bfee5acc203920043d43ddd/dwi.bvecs\",    \"bvals\": \"../5c098457f0a53c004bd79131/5bfee5acc203920043d43ddd/dwi.bvals\",    \"freesurfer\": \"../5c098457f0a53c004bd79131/5a065cc75ab38300be518f51/output\"}"
+            ], 
+            "id": "5c0a8a9df0a53c004bd79c82_config", 
+            "name": "config.json for brain-life/app-tracking(1.5)\nlmax:(null)\nfibers:500000\nfibers_max:1000000\n"
+        }, 
+        {
+            "path-template": "task.5c0bea9cf0a53c004bd7ae07/config.json", 
+            "file-template": [
+                "{    \"useinterhemisphericsplit\": [task.5c0bea9cf0a53c004bd7ae07.useinterhemisphericsplit],    \"track\": \"../5c0a8a9df0a53c004bd79c82/output.DT_STREAM.tck\",    \"dtiinit\": \"../5c093a2af0a53c004bd78b69/5bfee5abc203920043d43ddc/.\"}"
+            ], 
+            "id": "5c0bea9cf0a53c004bd7ae07_config", 
+            "name": "config.json for brain-life/app-tractclassification(1.2)\nuseinterhemisphericsplit:(null)\n"
+        }, 
+        {
+            "path-template": "task.5c0c0020f0a53c004bd7ae7c/config.json", 
+            "file-template": [
+                "{    \"maxiter\": \"[task.5c0c0020f0a53c004bd7ae7c.maxiter]\",    \"numnodes\": \"[task.5c0c0020f0a53c004bd7ae7c.numnodes]\",    \"maxlen\": \"[task.5c0c0020f0a53c004bd7ae7c.maxlen]\",    \"maxdist\": \"[task.5c0c0020f0a53c004bd7ae7c.maxdist]\",    \"M\": \"[task.5c0c0020f0a53c004bd7ae7c.M]\",    \"afq_fg\": \"../5c0bea9cf0a53c004bd7ae07/output.mat\"}"
+            ], 
+            "id": "5c0c0020f0a53c004bd7ae7c_config", 
+            "name": "config.json for brain-life/app-AFQclean(1.2)\nmaxiter:5\nnumnodes:100\nmaxlen:4\nmaxdist:4\nM:mean\n"
+        }, 
+        {
+            "path-template": "run.sh", 
+            "file-template": [
+                "#!/bin/bash", 
+                "echo \"staging task.5a05e7ad2767f30030bcf433 (brain-life/app-freesurfer)\"", 
+                "[ ! -d task.5a05e7ad2767f30030bcf433 ] && curl -L https://github.com/brain-life/app-freesurfer/archive/undefined.zip > task.5a05e7ad2767f30030bcf433.zip && unzip task.5a05e7ad2767f30030bcf433.zip && mv *undefined task.5a05e7ad2767f30030bcf433 && rm task.5a05e7ad2767f30030bcf433.zip", 
+                "", 
+                "echo \"running task task.5a05e7ad2767f30030bcf433 (brain-life/app-freesurfer)\"", 
+                "(", 
+                "\tcd task.5a05e7ad2767f30030bcf433", 
+                "\ttime ./main", 
+                ")", 
+                "", 
+                "echo \"staging task.5bfebb5d80ce40002a62cdfc (brain-life/app-dtiinit)\"", 
+                "[ ! -d task.5bfebb5d80ce40002a62cdfc ] && curl -L https://github.com/brain-life/app-dtiinit/archive/c4dcc5667c51e31f032e5148b72b236b3ff81900.zip > task.5bfebb5d80ce40002a62cdfc.zip && unzip task.5bfebb5d80ce40002a62cdfc.zip && mv *c4dcc5667c51e31f032e5148b72b236b3ff81900 task.5bfebb5d80ce40002a62cdfc && rm task.5bfebb5d80ce40002a62cdfc.zip", 
+                "", 
+                "echo \"running task task.5bfebb5d80ce40002a62cdfc (brain-life/app-dtiinit)\"", 
+                "(", 
+                "\tcd task.5bfebb5d80ce40002a62cdfc", 
+                "\ttime ./main", 
+                ")", 
+                "", 
+                "echo \"staging task.5c0a8a9df0a53c004bd79c82 (brain-life/app-tracking)\"", 
+                "[ ! -d task.5c0a8a9df0a53c004bd79c82 ] && curl -L https://github.com/brain-life/app-tracking/archive/44ff601ee2f2fd35c2a2bdb95426d828143692c6.zip > task.5c0a8a9df0a53c004bd79c82.zip && unzip task.5c0a8a9df0a53c004bd79c82.zip && mv *44ff601ee2f2fd35c2a2bdb95426d828143692c6 task.5c0a8a9df0a53c004bd79c82 && rm task.5c0a8a9df0a53c004bd79c82.zip", 
+                "", 
+                "echo \"running task task.5c0a8a9df0a53c004bd79c82 (brain-life/app-tracking)\"", 
+                "(", 
+                "\tcd task.5c0a8a9df0a53c004bd79c82", 
+                "\ttime ./main", 
+                ")", 
+                "", 
+                "echo \"staging task.5c0bea9cf0a53c004bd7ae07 (brain-life/app-tractclassification)\"", 
+                "[ ! -d task.5c0bea9cf0a53c004bd7ae07 ] && curl -L https://github.com/brain-life/app-tractclassification/archive/1ee98655908ee4a815f5da6970e18ea73bae6490.zip > task.5c0bea9cf0a53c004bd7ae07.zip && unzip task.5c0bea9cf0a53c004bd7ae07.zip && mv *1ee98655908ee4a815f5da6970e18ea73bae6490 task.5c0bea9cf0a53c004bd7ae07 && rm task.5c0bea9cf0a53c004bd7ae07.zip", 
+                "", 
+                "echo \"running task task.5c0bea9cf0a53c004bd7ae07 (brain-life/app-tractclassification)\"", 
+                "(", 
+                "\tcd task.5c0bea9cf0a53c004bd7ae07", 
+                "\ttime ./main", 
+                ")", 
+                "", 
+                "echo \"staging task.5c0c0020f0a53c004bd7ae7c (brain-life/app-AFQclean)\"", 
+                "[ ! -d task.5c0c0020f0a53c004bd7ae7c ] && curl -L https://github.com/brain-life/app-AFQclean/archive/6eb386469d5274df073ee2629d4f04e8a2d22fb2.zip > task.5c0c0020f0a53c004bd7ae7c.zip && unzip task.5c0c0020f0a53c004bd7ae7c.zip && mv *6eb386469d5274df073ee2629d4f04e8a2d22fb2 task.5c0c0020f0a53c004bd7ae7c && rm task.5c0c0020f0a53c004bd7ae7c.zip", 
+                "", 
+                "echo \"running task task.5c0c0020f0a53c004bd7ae7c (brain-life/app-AFQclean)\"", 
+                "(", 
+                "\tcd task.5c0c0020f0a53c004bd7ae7c", 
+                "\ttime ./main", 
+                ")", 
+                "", 
+                ""
+            ], 
+            "id": "run", 
+            "name": "run.sh"
+        }, 
+        {
+            "path-template": "task.5c0c0020f0a53c004bd7ae7c", 
+            "id": "output", 
+            "name": "Dataset output5c0c06e6f6f108004b490e2a"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 120, 
+        "ram": 16, 
+        "cpu-cores": 8
+    }, 
+    "name": "workflow generated from dataset:5c0c06e6f6f108004b490e2a"
+}

--- a/app/static/pipelines/zenodo-3239451.json
+++ b/app/static/pipelines/zenodo-3239451.json
@@ -1,0 +1,684 @@
+{
+    "tool-version": "v2.7.1", 
+    "tests": [
+        {
+            "invocation": {
+                "outfmt": "5", 
+                "evalue": 0.001, 
+                "db": "uniprotmini.fasta", 
+                "query": "test1_query.fasta", 
+                "max_target_seqs": 10, 
+                "out": "blastp.out"
+            }, 
+            "name": "test1", 
+            "assertions": {
+                "output-files": [
+                    {
+                        "id": "output", 
+                        "md5-reference": "049ea2f2b7e3fbe9a0c7d36a8e1c749c"
+                    }
+                ], 
+                "exit-code": 0
+            }
+        }
+    ], 
+    "description": "Protein-Protein BLAST 2.7.1+", 
+    "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ cp -R [DB_DIR]/* . 2> /dev/null \\; /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/blastp [IMPORT_SEARCH_STRATEGY] [EXPORT_SEARCH_STRATEGY] [TASK] [DB] [DBSIZE] [GILIST] [SEQIDLIST] [NEGATIVE_GILIST] [NEGATIVE_SEQIDLIST] [ENTREZ_QUERY] [DB_SOFT_MASK] [DB_HARD_MASK] [SUBJECT] [SUBJECT_LOC] [QUERY] [OUT] [EVALUE] [WORD_SIZE] [GAPOPEN] [GAPEXTEND] [QCOV_HSP_PERC] [MAX_HSPS] [XDROP_UNGAP] [XDROP_GAP] [XDROP_GAP_FINAL] [SEARCHSP] [SUM_STATS] [SEG] [SOFT_MASKING] [MATRIX] [THRESHOLD] [CULLING_LIMIT] [BEST_HIT_OVERHANG] [BEST_HIT_SCORE_EDGE] [WINDOW_SIZE] [fLCASE_MASKING] [QUERY_LOC] [fPARSE_DEFLINES] [OUTFMT] [fSHOW_GIS] [NUM_DESCRIPTIONS] [NUM_ALIGNMENTS] [LINE_LENGTH] [fHTML] [MAX_TARGET_SEQS] [NUM_THREADS] [fUNGAPPED] [fREMOTE] [COMP_BASED_STATS] [fUSE_SW_TBACK]", 
+    "author": "Altschul et al.", 
+    "tags": {
+        "domain": [
+            "bioinformatics", 
+            "blast"
+        ]
+    }, 
+    "container-image": {
+        "index": "docker://", 
+        "image": "c3genomics/genpipes", 
+        "type": "singularity"
+    }, 
+    "inputs": [
+        {
+            "command-line-flag": "-db", 
+            "description": "BLAST database name", 
+            "disables-inputs": [
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[DB]", 
+            "type": "String", 
+            "id": "db", 
+            "name": "BLAST database name"
+        }, 
+        {
+            "description": "directory containing BLAST Archive format in ASN.1 (i.e.: output format 11) and all needed db files", 
+            "default-value": ".", 
+            "value-key": "[DB_DIR]", 
+            "optional": true, 
+            "requires-inputs": [
+                "db"
+            ], 
+            "type": "File", 
+            "id": "archive_dir", 
+            "name": "Blast Database Directory"
+        }, 
+        {
+            "command-line-flag": "-query_loc", 
+            "description": "Location on the query sequence in 1-based offsets (Format: start-stop)", 
+            "value-key": "[QUERY_LOC]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "query_loc", 
+            "name": "query location"
+        }, 
+        {
+            "command-line-flag": "-subject_loc", 
+            "description": "Location on the query sequence in 1-based offsets (Format: start-stop)", 
+            "disables-inputs": [
+                "db", 
+                "gilist", 
+                "seqidlist", 
+                "negative_gilist", 
+                "negative_seqidlist", 
+                "db_soft_mask", 
+                "db_hard_mask"
+            ], 
+            "optional": true, 
+            "value-key": "[SUBJECT_LOC]", 
+            "type": "String", 
+            "id": "subject_loc", 
+            "name": "Subject Sequence Location"
+        }, 
+        {
+            "command-line-flag": "-task", 
+            "description": "Task to execute", 
+            "value-key": "[TASK]", 
+            "optional": true, 
+            "value-choices": [
+                "blastp", 
+                "blastp-fast", 
+                "blastp-short"
+            ], 
+            "type": "String", 
+            "id": "task", 
+            "name": "Task Name"
+        }, 
+        {
+            "command-line-flag": "-matrix", 
+            "description": "Scoring matrix name (normally BLOSUM62)", 
+            "value-key": "[MATRIX]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "matrix", 
+            "name": "Scoring matrix name"
+        }, 
+        {
+            "command-line-flag": "-comp_based_stats", 
+            "description": "Use composition-based statistics:\n       D or d: default (equivalent to 2 )\n       0 or F or f: No composition-based statistics\n       1: Composition-based statistics as in NAR 29:2994-3005, 2001\n       2 or T or t : Composition-based score adjustment as in Bioinformatics\n   21:902-911, 2005, conditioned on sequence properties\n       3: Composition-based score adjustment as in Bioinformatics 21:902-911,\n 2005, unconditionally\nDefault = `2'", 
+            "value-key": "[COMP_BASED_STATS]", 
+            "optional": true, 
+            "value-choices": [
+                "D", 
+                "d", 
+                "0", 
+                "F", 
+                "f", 
+                "1", 
+                "2", 
+                "T", 
+                "t", 
+                "3"
+            ], 
+            "type": "String", 
+            "id": "comp_based_stats", 
+            "name": "Composition-based statistics mode"
+        }, 
+        {
+            "command-line-flag": "-seg", 
+            "description": "Filter query sequence with SEG", 
+            "value-key": "[SEG]", 
+            "optional": true, 
+            "value-choices": [
+                "yes", 
+                "window locut hicut", 
+                "no"
+            ], 
+            "type": "String", 
+            "id": "seg", 
+            "name": "SEG Options"
+        }, 
+        {
+            "command-line-flag": "-gilist", 
+            "description": "Restrict search of database to list of GI's", 
+            "disables-inputs": [
+                "negative_gilist", 
+                "seqidlist", 
+                "negative_seqidlist", 
+                "remote", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[GILIST]", 
+            "type": "String", 
+            "id": "gilist", 
+            "name": "Restrictive GI List"
+        }, 
+        {
+            "command-line-flag": "-seqidlist", 
+            "description": "Restrict search of database to list of SeqId's", 
+            "disables-inputs": [
+                "gilist", 
+                "negative_gilist", 
+                "negative_seqidlist", 
+                "remote", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[SEQIDLIST]", 
+            "type": "String", 
+            "id": "seqidlist", 
+            "name": "Restrictive Sequence Id List"
+        }, 
+        {
+            "command-line-flag": "-negative_gilist", 
+            "description": "Restrict search of database to everything except the listed GIs", 
+            "disables-inputs": [
+                "gilist", 
+                "seqidlist", 
+                "remote", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[NEGATIVE_GILIST]", 
+            "type": "String", 
+            "id": "negative_gilist", 
+            "name": "Exclusive GI List"
+        }, 
+        {
+            "command-line-flag": "-negative_seqidlist", 
+            "description": "Restrict search of database to everything except the listed SeqIDs", 
+            "disables-inputs": [
+                "gilist", 
+                "seqidlist", 
+                "remote", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[NEGATIVE_SEQIDLIST]", 
+            "type": "String", 
+            "id": "negative_seqidlist", 
+            "name": "Exclusive Sequence Id List"
+        }, 
+        {
+            "command-line-flag": "-entrez_query", 
+            "description": "Restrict search with the given Entrez query", 
+            "value-key": "[ENTREZ_QUERY]", 
+            "optional": true, 
+            "requires-inputs": [
+                "remote"
+            ], 
+            "type": "String", 
+            "id": "entrez_query", 
+            "name": "Exclusive Sequence Id List"
+        }, 
+        {
+            "command-line-flag": "-db_soft_mask", 
+            "description": "Filtering algorithm ID to apply to the BLAST database as soft masking", 
+            "disables-inputs": [
+                "db_hard_mask", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[DB_SOFT_MASK]", 
+            "type": "String", 
+            "id": "db_soft_mask", 
+            "name": "Soft Mask ID"
+        }, 
+        {
+            "command-line-flag": "-db_hard_mask", 
+            "description": "Filtering algorithm ID to apply to the BLAST database as hard masking", 
+            "disables-inputs": [
+                "db_soft_mask", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[DB_HARD_MASK]", 
+            "type": "String", 
+            "id": "db_hard_mask", 
+            "name": "Hard Mask ID"
+        }, 
+        {
+            "command-line-flag": "-lcase_masking", 
+            "description": "Use lower case filtering in query and subject sequence(s)?", 
+            "value-key": "[fLCASE_MASKING]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "lcase_masking", 
+            "name": "Lowercase Filtering"
+        }, 
+        {
+            "command-line-flag": "-ungapped", 
+            "description": "Perform ungapped alignment only?", 
+            "value-key": "[fUNGAPPED]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "ungapped", 
+            "name": "Ungapped Alignment"
+        }, 
+        {
+            "command-line-flag": "-parse_deflines", 
+            "description": "Should the query and subject defline(s) be parsed?", 
+            "value-key": "[fPARSE_DEFLINES]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "parse_deflines", 
+            "name": "Parse Deflines"
+        }, 
+        {
+            "command-line-flag": "-remote", 
+            "description": "Execute search remotely?", 
+            "disables-inputs": [
+                "gilist", 
+                "seqidlist", 
+                "negative_gilist", 
+                "negative_seqidlist", 
+                "subject_loc", 
+                "num_threads"
+            ], 
+            "optional": true, 
+            "value-key": "[fREMOTE]", 
+            "type": "Flag", 
+            "id": "remote", 
+            "name": "Remote Search"
+        }, 
+        {
+            "command-line-flag": "-use_sw_tback", 
+            "description": "Compute locally optimal Smith-Waterman alignments?", 
+            "value-key": "[fUSE_SW_TBACK]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "use_sw_tback", 
+            "name": "Locally Optimal Smith-Waterman Alignments"
+        }, 
+        {
+            "command-line-flag": "-soft_masking", 
+            "description": "Apply filtering locations as soft masks", 
+            "value-key": "[SOFT_MASKING]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "soft_masking", 
+            "name": "Filtering Locations As Soft Masks"
+        }, 
+        {
+            "command-line-flag": "-sum_stats", 
+            "description": "Use sum statistics", 
+            "value-key": "[SUM_STATS]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "sum_stats", 
+            "name": "Sum Statistics"
+        }, 
+        {
+            "command-line-flag": "-word_size", 
+            "description": "Word size for wordfinder algorithm", 
+            "value-key": "[WORD_SIZE]", 
+            "optional": true, 
+            "minimum": 2, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "word_size", 
+            "name": "Word Size"
+        }, 
+        {
+            "command-line-flag": "-gapopen", 
+            "description": "Cost to open a gap", 
+            "value-key": "[GAPOPEN]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "gapopen", 
+            "name": "Gap Open Penalty"
+        }, 
+        {
+            "command-line-flag": "-gapextend", 
+            "description": "Cost to extend a gap", 
+            "value-key": "[GAPEXTEND]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "gapextend", 
+            "name": "Gap Extend Penalty"
+        }, 
+        {
+            "command-line-flag": "-max_hsps", 
+            "description": "Set maximum number of HSPs per subject sequence to save for each query", 
+            "value-key": "[MAX_HSPS]", 
+            "optional": true, 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "max_hsps", 
+            "name": "Max HSPs Per Subject"
+        }, 
+        {
+            "command-line-flag": "-culling_limit", 
+            "description": "   If the query range of a hit is enveloped by that of at least this many\n   higher-scoring hits, delete the hit", 
+            "value-key": "[CULLING_LIMIT]", 
+            "optional": true, 
+            "disables-inputs": [
+                "best_hit_overhang", 
+                "best_hit_score_edge"
+            ], 
+            "minimum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "culling_limit", 
+            "name": "Higher Scoring Hit Culling Limit"
+        }, 
+        {
+            "command-line-flag": "-max_target_seqs", 
+            "description": "   Maximum number of aligned sequences to keep\n   Not applicable for outfmt <= 4\n   Default = `500'", 
+            "value-key": "[MAX_TARGET_SEQS]", 
+            "optional": true, 
+            "disables-inputs": [
+                "num_descriptions", 
+                "num_alignments"
+            ], 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "max_target_seqs", 
+            "name": "Maximum Target Sequence"
+        }, 
+        {
+            "command-line-flag": "-dbsize", 
+            "description": "Effective length of the database", 
+            "value-key": "[DBSIZE]", 
+            "optional": true, 
+            "maximum": 255, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "dbsize", 
+            "name": "Database Size"
+        }, 
+        {
+            "command-line-flag": "-searchsp", 
+            "description": "Effective length of the search space", 
+            "value-key": "[SEARCHSP]", 
+            "optional": true, 
+            "maximum": 255, 
+            "minimum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "searchsp", 
+            "name": "Search Space Length"
+        }, 
+        {
+            "command-line-flag": "-window_size", 
+            "description": "Multiple hits window size, use 0 to specify 1-hit algorithm", 
+            "value-key": "[WINDOW_SIZE]", 
+            "optional": true, 
+            "minimum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "window_size", 
+            "name": "Multiple Hits Window Size"
+        }, 
+        {
+            "command-line-flag": "-num_threads", 
+            "description": "   Number of threads (CPUs) to use in the BLAST search\n   Default = `1'", 
+            "value-key": "[NUM_THREADS]", 
+            "optional": true, 
+            "maximum": 12, 
+            "disables-inputs": [
+                "remote"
+            ], 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "num_threads", 
+            "name": "Maximum Target Sequence"
+        }, 
+        {
+            "command-line-flag": "-evalue", 
+            "description": "  Expectation value (E) threshold for saving hits\n  Default = `10'", 
+            "value-key": "[EVALUE]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "evalue", 
+            "name": "Expectation Value"
+        }, 
+        {
+            "command-line-flag": "-threshold", 
+            "description": "Minimum word score such that the word is added to the BLAST lookup table", 
+            "value-key": "[THRESHOLD]", 
+            "optional": true, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "threshold", 
+            "name": "Minimum word score threshold"
+        }, 
+        {
+            "command-line-flag": "-qcov_hsp_perc", 
+            "description": "Percent query coverage per hsp", 
+            "value-key": "[QCOV_HSP_PERC]", 
+            "optional": true, 
+            "maximum": 100, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "qcov_hsp_perc", 
+            "name": "Percentage Query Coverage"
+        }, 
+        {
+            "command-line-flag": "-best_hit_overhang", 
+            "description": "Best Hit algorithm overhang value (recommended value: 0.1)", 
+            "value-key": "[BEST_HIT_OVERHANG]", 
+            "optional": true, 
+            "exclusive-maximum": true, 
+            "maximum": 0.5, 
+            "disables-inputs": [
+                "culling_limit"
+            ], 
+            "minimum": 0, 
+            "exclusive-minimum": true, 
+            "type": "Number", 
+            "id": "best_hit_overhang", 
+            "name": "Best Hit Algorithm Overhang"
+        }, 
+        {
+            "command-line-flag": "-best_hit_score_edge", 
+            "description": "Best Hit algorithm score edge value (recommended value: 0.1)", 
+            "value-key": "[BEST_HIT_SCORE_EDGE]", 
+            "optional": true, 
+            "exclusive-maximum": true, 
+            "maximum": 0.5, 
+            "disables-inputs": [
+                "culling_limit"
+            ], 
+            "minimum": 0, 
+            "exclusive-minimum": true, 
+            "type": "Number", 
+            "id": "best_hit_score_edge", 
+            "name": "Best Hit Algorithm Score Edge Value"
+        }, 
+        {
+            "command-line-flag": "-xdrop_ungap", 
+            "description": "X-dropoff value (in bits) for ungapped extensions", 
+            "value-key": "[XDROP_UNGAP]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "xdrop_ungap", 
+            "name": "Ungapped Extensions X-dropoff Value"
+        }, 
+        {
+            "command-line-flag": "-xdrop_gap", 
+            "description": "X-dropoff value (in bits) for preliminary gapped extensions", 
+            "value-key": "[XDROP_GAP]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "xdrop_gap", 
+            "name": "Preiliminary Gapped Extensions X-dropoff Value"
+        }, 
+        {
+            "command-line-flag": "-xdrop_gap_final", 
+            "description": "X-dropoff value (in bits) for final gapped alignment", 
+            "value-key": "[XDROP_GAP_FINAL]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "xdrop_gap_final", 
+            "name": "Final Gapped Extensions X-dropoff Value"
+        }, 
+        {
+            "command-line-flag": "-query", 
+            "description": "Input file name", 
+            "value-key": "[QUERY]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "query", 
+            "name": "Query"
+        }, 
+        {
+            "command-line-flag": "-subject", 
+            "description": "Subject sequence(s) to search", 
+            "value-key": "[SUBJECT]", 
+            "optional": true, 
+            "disables-inputs": [
+                "db", 
+                "gilist", 
+                "seqidlist", 
+                "negative_gilist", 
+                "negative_seqidlist", 
+                "db_soft_mask", 
+                "db_hard_mask"
+            ], 
+            "type": "File", 
+            "id": "subject", 
+            "name": "Subject"
+        }, 
+        {
+            "command-line-flag": "-import_search_strategy", 
+            "description": "Search strategy to use", 
+            "value-key": "[IMPORT_SEARCH_STRATEGY]", 
+            "optional": true, 
+            "disables-inputs": [
+                "export_search_strategy"
+            ], 
+            "type": "File", 
+            "id": "import_search_strategy", 
+            "name": "Search Strategy File"
+        }, 
+        {
+            "command-line-flag": "-export_search_strategy", 
+            "description": "File name to record the search strategy used", 
+            "value-key": "[EXPORT_SEARCH_STRATEGY]", 
+            "optional": true, 
+            "disables-inputs": [
+                "import_search_strategy"
+            ], 
+            "type": "File", 
+            "id": "export_search_strategy", 
+            "name": "Search Strategy Record Filename"
+        }, 
+        {
+            "command-line-flag": "-show_gis", 
+            "description": "Show NCBI GIs in deflines?", 
+            "value-key": "[fSHOW_GIS]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "show_gis", 
+            "name": "Show NCBI GIs"
+        }, 
+        {
+            "command-line-flag": "-html", 
+            "description": "Produce HTML Output", 
+            "value-key": "[fHTML]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "html", 
+            "name": "Show HTML"
+        }, 
+        {
+            "command-line-flag": "-outfmt", 
+            "description": "   alignment view options:\n     0 = Pairwise,\n     1 = Query-anchored showing identities,\n     2 = Query-anchored no identities,\n     3 = Flat query-anchored showing identities,\n     4 = Flat query-anchored no identities,\n     5 = BLAST XML,\n     6 = Tabular,\n     7 = Tabular with comment lines,\n     8 = Seqalign (Text ASN.1),\n     9 = Seqalign (Binary ASN.1),\n    10 = Comma-separated values,\n    11 = BLAST archive (ASN.1),\n    12 = Seqalign (JSON),\n    13 = Multiple-file BLAST JSON,\n    14 = Multiple-file BLAST XML2,\n    15 = Single-file BLAST JSON,\n    16 = Single-file BLAST XML2,\n    17 = Sequence Alignment/Map (SAM),\n    18 = Organism Report\n\n   Options 6, 7, 10 and 17 can be additionally configured to produce\n   a custom format specified by space delimited format specifiers.\n   The supported format specifiers for options 6, 7 and 10 are:\n            qseqid means Query Seq-id\n               qgi means Query GI\n              qacc means Query accesion\n           qaccver means Query accesion.version\n              qlen means Query sequence length\n            sseqid means Subject Seq-id\n         sallseqid means All subject Seq-id(s), separated by a ';'\n               sgi means Subject GI\n            sallgi means All subject GIs\n              sacc means Subject accession\n           saccver means Subject accession.version\n           sallacc means All subject accessions\n              slen means Subject sequence length\n            qstart means Start of alignment in query\n              qend means End of alignment in query\n            sstart means Start of alignment in subject\n              send means End of alignment in subject\n              qseq means Aligned part of query sequence\n              sseq means Aligned part of subject sequence\n            evalue means Expect value\n          bitscore means Bit score\n             score means Raw score\n            length means Alignment length\n            pident means Percentage of identical matches\n            nident means Number of identical matches\n          mismatch means Number of mismatches\n          positive means Number of positive-scoring matches\n           gapopen means Number of gap openings\n              gaps means Total number of gaps\n              ppos means Percentage of positive-scoring matches\n            frames means Query and subject frames separated by a '/'\n            qframe means Query frame\n            sframe means Subject frame\n              btop means Blast traceback operations (BTOP)\n            staxid means Subject Taxonomy ID\n          ssciname means Subject Scientific Name\n          scomname means Subject Common Name\n        sblastname means Subject Blast Name\n         sskingdom means Subject Super Kingdom\n           staxids means unique Subject Taxonomy ID(s), separated by a ';'\n                         (in numerical order)\n         sscinames means unique Subject Scientific Name(s), separated by a ';'\n         scomnames means unique Subject Common Name(s), separated by a ';'\n        sblastnames means unique Subject Blast Name(s), separated by a ';'\n                         (in alphabetical order)\n        sskingdoms means unique Subject Super Kingdom(s), separated by a ';'\n                         (in alphabetical order)\n            stitle means Subject Title\n        salltitles means All Subject Title(s), separated by a '<>'\n           sstrand means Subject Strand\n             qcovs means Query Coverage Per Subject\n           qcovhsp means Query Coverage Per HSP\n            qcovus means Query Coverage Per Unique Subject (blastn only)\n   When not provided, the default value is:\n   'qaccver saccver pident length mismatch gapopen qstart qend sstart send\n   evalue bitscore', which is equivalent to the keyword 'std'\n   The supported format specifier for option 17 is:\n                SQ means Include Sequence Data\n                SR means Subject as Reference Seq\n  Default = `0'", 
+            "value-key": "[OUTFMT]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "outfmt", 
+            "name": "Alignment View Options"
+        }, 
+        {
+            "command-line-flag": "-num_descriptions", 
+            "description": "   Number of database sequences to show one-line descriptions for\n   Not applicable for outfmt > 4\n   Default = `500'", 
+            "value-key": "[NUM_DESCRIPTIONS]", 
+            "optional": true, 
+            "disables-inputs": [
+                "max_target_seqs"
+            ], 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "num_descriptions", 
+            "name": "Number of Sequence Descriptions to Show"
+        }, 
+        {
+            "command-line-flag": "-num_alignments", 
+            "description": "   Number of database sequences to show alignments for\n   Default = `250'", 
+            "value-key": "[NUM_ALIGNMENTS]", 
+            "optional": true, 
+            "disables-inputs": [
+                "max_target_seqs"
+            ], 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "num_alignments", 
+            "name": "Number of Sequence Alignments to Show"
+        }, 
+        {
+            "command-line-flag": "-line_length", 
+            "description": "   Line length for formatting alignments\n   Not applicable for outfmt > 4\n   Default = `60'", 
+            "value-key": "[LINE_LENGTH]", 
+            "optional": true, 
+            "minimum": 1, 
+            "type": "Number", 
+            "id": "line_length", 
+            "name": "Line Length"
+        }, 
+        {
+            "command-line-flag": "-out", 
+            "description": "   Output file name", 
+            "value-key": "[OUT]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "out", 
+            "name": "Output file name"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[OUT]", 
+            "optional": false, 
+            "id": "output", 
+            "name": "Output File"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 60, 
+        "ram": 1, 
+        "cpu-cores": 1
+    }, 
+    "name": "blastp"
+}

--- a/app/static/pipelines/zenodo-3240521.json
+++ b/app/static/pipelines/zenodo-3240521.json
@@ -1,0 +1,311 @@
+{
+    "tool-version": "mcin/docker-fsl:latest",
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_stats.json",
+    "command-line": "fslstats [t] [INPUT_FILE] [l] [u] [r] [R] [e] [E] [v] [V] [m] [M] [s] [S] [w] [x] [X] [c] [C] [p] [P] [a] [n] [k] [d] [h] [H] > [OUTPUT_FILE]",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest",
+        "type": "docker"
+    },
+    "description": "Descriptor of fslstats from the FSL toolbox. Computes various statistics on nifti images.",
+    "inputs": [
+        {
+            "id": "t",
+            "name": "t",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[t]",
+            "description": "give a separate output line for each 3D volume of a 4D timeseries",
+            "command-line-flag": "-t"
+        },
+        {
+            "id": "input_file",
+            "name": "Input file",
+            "optional": false,
+            "type": "File",
+            "value-key": "[INPUT_FILE]"
+        },
+        {
+            "id": "l",
+            "name": "lower threshold",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[l]",
+            "description": "set lower threshold",
+            "command-line-flag": "-l"
+        },
+        {
+            "id": "u",
+            "name": "upper threshold",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[u]",
+            "description": "set upper threshold",
+            "command-line-flag": "-u"
+        },
+        {
+            "id": "r",
+            "name": "r",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[r]",
+            "description": " output <robust min intensity> <robust max intensity>",
+            "command-line-flag": "-r"
+        },
+        {
+            "id": "R",
+            "name": "R",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[R]",
+            "description": " output <min intensity> <max intensity>",
+            "command-line-flag": "-R"
+        },
+        {
+            "id": "e",
+            "name": "e",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[e]",
+            "description": " output mean entropy ; mean(-i*ln(i))",
+            "command-line-flag": "-e"
+        },
+        {
+            "id": "E",
+            "name": "E",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[E]",
+            "description": " output mean entropy (of nonzero voxels)",
+            "command-line-flag": "-E"
+        },
+        {
+            "id": "v",
+            "name": "v",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[v]",
+            "description": " output <voxels> <volume>",
+            "command-line-flag": "-v"
+        },
+        {
+            "id": "V",
+            "name": "V",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[V]",
+            "description": " output <voxels> <volume> (for nonzero voxels)",
+            "command-line-flag": "-V"
+        },
+        {
+            "id": "m",
+            "name": "m",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[m]",
+            "description": " output mean",
+            "command-line-flag": "-m"
+        },
+        {
+            "id": "M",
+            "name": "M",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[M]",
+            "description": " output mean (for nonzero voxels)",
+            "command-line-flag": "-M"
+        },
+        {
+            "id": "s",
+            "name": "s",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[s]",
+            "description": " output standard deviation",
+            "command-line-flag": "-s"
+        },
+        {
+            "id": "S",
+            "name": "S",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[S]",
+            "description": " output standard deviation (for nonzero voxels)",
+            "command-line-flag": "-S"
+        },
+        {
+            "id": "w",
+            "name": "w",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[w]",
+            "description": " output smallest ROI <xmin> <xsize> <ymin> <ysize> <zmin> <zsize> <tmin> <tsize> containing nonzero voxels",
+            "command-line-flag": "-w"
+        },
+        {
+            "id": "x",
+            "name": "x",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[x]",
+            "description": " output co-ordinates of maximum voxel",
+            "command-line-flag": "-x"
+        },
+        {
+            "id": "X",
+            "name": "X",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[X]",
+            "description": " output co-ordinates of minimum voxel",
+            "command-line-flag": "-X"
+        },
+        {
+            "id": "c",
+            "name": "c",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[c]",
+            "description": " output centre-of-gravity (cog) in mm coordinates",
+            "command-line-flag": "-c"
+        },
+        {
+            "id": "C",
+            "name": "C",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[C]",
+            "description": " output centre-of-gravity (cog) in voxel coordinates",
+            "command-line-flag": "-C"
+        },
+        {
+            "id": "p",
+            "name": "p",
+            "optional": true,
+            "type": "Number",
+            "integer": true,
+            "minimum": 0,
+            "maximum": 100,
+            "value-key": "[p]",
+            "description": " output nth percentile (n between 0 and 100)",
+            "command-line-flag": "-p"
+        },
+        {
+            "id": "P",
+            "name": "P",
+            "optional": true,
+            "type": "Number",
+            "integer": true,
+            "minimum": 0,
+            "maximum": 100,
+            "value-key": "[P]",
+            "description": " output nth percentile (for nonzero voxels)",
+            "command-line-flag": "-P"
+        },
+        {
+            "id": "a",
+            "name": "a",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[a]",
+            "description": " use absolute values of all image intensities",
+            "command-line-flag": "-a"
+        },
+        {
+            "id": "n",
+            "name": "n",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[n]",
+            "description": " treat NaN or Inf as zero for subsequent stats",
+            "command-line-flag": "-n"
+        },
+        {
+            "id": "k",
+            "name": "k",
+            "optional": true,
+            "type": "File",
+            "value-key": "[k]",
+            "description": " use the specified image (filename) for masking - overrides lower and upper thresholds",
+            "command-line-flag": "-k"
+        },
+        {
+            "id": "d",
+            "name": "d",
+            "optional": true,
+            "type": "File",
+            "value-key": "[d]",
+            "description": " take the difference between the base image and the image specified here",
+            "command-line-flag": "-d"
+        },
+        {
+            "id": "h",
+            "name": "h",
+            "optional": true,
+            "type": "Number",
+            "integer": true,
+            "value-key": "[h]",
+            "description": " output a histogram (for the thresholded/masked voxels only) with nbins",
+            "command-line-flag": "-h"
+        },
+        {
+            "id": "H",
+            "name": "H",
+            "optional": true,
+            "type": "Number",
+            "list": true,
+            "min-list-entries": 3,
+            "max-list-entries": 3,
+            "list-separator": " ",
+            "value-key": "[H]",
+            "description": " output a histogram (for the thresholded/masked voxels only) with nbins and histogram limits of min and max",
+            "command-line-flag": "-H"
+        }
+    ],
+    "groups": [
+        {
+            "one-is-required": true,
+            "id": "output_type",
+            "name": "output type",
+            "members": [
+                "r",
+                "R",
+                "e",
+                "E",
+                "v",
+                "V",
+                "m",
+                "M",
+                "s",
+                "S",
+                "w",
+                "x",
+                "X",
+                "c",
+                "C",
+                "p",
+                "P",
+                "h",
+                "H"
+            ]
+        }
+    ],
+    "name": "fslstats",
+    "output-files": [
+        {
+            "id": "output",
+            "name": "Output",
+            "optional": false,
+            "path-template": "output.txt",
+            "value-key": "[OUTPUT_FILE]"
+        }
+    ],
+    "schema-version": "0.5",
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "mri"
+        ],
+        "toolbox": "FSL"
+    }
+}

--- a/app/static/pipelines/zenodo-3240577.json
+++ b/app/static/pipelines/zenodo-3240577.json
@@ -1,0 +1,793 @@
+{
+    "tool-version": "v2.7.1", 
+    "tests": [
+        {
+            "invocation": {
+                "query": "test1_query.fasta", 
+                "outfmt": "5", 
+                "db": "sample", 
+                "max_target_seqs": 5, 
+                "out": "blastn.out"
+            }, 
+            "name": "test1", 
+            "assertions": {
+                "output-files": [
+                    {
+                        "id": "output", 
+                        "md5-reference": "eb917a2e0723ee9cca9d86db85e83b69"
+                    }
+                ], 
+                "exit-code": 0
+            }
+        }
+    ], 
+    "description": "Nucleotide-Nucleotide BLAST 2.7.1+", 
+    "command-line": "init_genpipes -a /tmp/$USER/cvmfs-cache -c /etc/parrot/ cp -R [DB_DIR]/* . 2> /dev/null \\;  /cvmfs/soft.mugqic/CentOS6/software/blast/ncbi-blast-2.7.1+/bin/blastn [IMPORT_SEARCH_STRATEGY] [EXPORT_SEARCH_STRATEGY] [TASK] [DB] [DBSIZE] [GILIST] [SEQIDLIST] [NEGATIVE_GILIST] [NEGATIVE_SEQIDLIST] [ENTREZ_QUERY] [DB_SOFT_MASK] [DB_HARD_MASK] [SUBJECT] [SUBJECT_LOC] [QUERY] [OUT] [EVALUE] [WORD_SIZE] [GAPOPEN] [GAPEXTEND] [PERC_IDENTITY] [QCOV_HSP_PERC] [MAX_HSPS] [XDROP_UNGAP] [XDROP_GAP] [XDROP_GAP_FINAL] [SEARCHSP] [SUM_STATS] [PENALTY] [REWARD] [fNO_GREEDY] [MIN_RAW_GAPPED_SCORE] [TEMPLATE_TYPE] [TEMPLATE_LENGTH] [DUST] [FILTERING_DB] [WINDOW_MASKER_TAXID] [WINDOW_MASKER_DB] [SOFT_MASKING] [fUNGAPPED] [CULLING_LIMIT] [BEST_HIT_OVERHANG] [BEST_HIT_SCORE_EDGE] [WINDOW_SIZE] [OFF_DIAGONAL_RANGE] [USE_INDEX] [INDEX_NAME] [fLCASE_MASKING] [QUERY_LOC] [STRAND] [fPARSE_DEFLINES] [OUTFMT] [fSHOW_GIS] [NUM_DESCRIPTIONS] [NUM_ALIGNMENTS] [LINE_LENGTH] [fHTML] [MAX_TARGET_SEQS] [NUM_THREADS] [fREMOTE]", 
+    "author": "Altschul et al.", 
+    "tags": {
+        "domain": [
+            "bioinformatics", 
+            "blast"
+        ]
+    }, 
+    "container-image": {
+        "index": "docker://", 
+        "image": "c3genomics/genpipes", 
+        "type": "singularity"
+    }, 
+    "inputs": [
+        {
+            "command-line-flag": "-db", 
+            "description": "BLAST database name", 
+            "disables-inputs": [
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[DB]", 
+            "type": "String", 
+            "id": "db", 
+            "name": "BLAST database name"
+        }, 
+        {
+            "description": "directory containing BLAST Archive format in ASN.1 (i.e.: output format 11) and all needed db files", 
+            "default-value": ".", 
+            "value-key": "[DB_DIR]", 
+            "optional": true, 
+            "requires-inputs": [
+                "db"
+            ], 
+            "type": "File", 
+            "id": "archive_dir", 
+            "name": "Blast Database Directory"
+        }, 
+        {
+            "command-line-flag": "-query_loc", 
+            "description": "Location on the query sequence in 1-based offsets (Format: start-stop)", 
+            "value-key": "[QUERY_LOC]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "query_loc", 
+            "name": "query location"
+        }, 
+        {
+            "command-line-flag": "-strand", 
+            "description": "   Query strand(s) to search against database/subject\n   Default = `both'", 
+            "value-key": "[STRAND]", 
+            "optional": true, 
+            "value-choices": [
+                "both", 
+                "minus", 
+                "plus"
+            ], 
+            "type": "String", 
+            "id": "strand", 
+            "name": "Query Strand to Search"
+        }, 
+        {
+            "command-line-flag": "-subject_loc", 
+            "description": "Location on the query sequence in 1-based offsets (Format: start-stop)", 
+            "disables-inputs": [
+                "db", 
+                "gilist", 
+                "seqidlist", 
+                "negative_gilist", 
+                "negative_seqidlist", 
+                "db_soft_mask", 
+                "db_hard_mask"
+            ], 
+            "optional": true, 
+            "value-key": "[SUBJECT_LOC]", 
+            "type": "String", 
+            "id": "subject_loc", 
+            "name": "Subject Sequence Location"
+        }, 
+        {
+            "command-line-flag": "-task", 
+            "description": "Task to execute", 
+            "value-key": "[TASK]", 
+            "optional": true, 
+            "value-choices": [
+                "blastn", 
+                "blastn-short", 
+                "dc-megablast", 
+                "megablast", 
+                "rmblastn"
+            ], 
+            "type": "String", 
+            "id": "task", 
+            "name": "Task Name"
+        }, 
+        {
+            "command-line-flag": "-dust", 
+            "description": "Filter query sequence with DUST\n  (Format: 'yes', 'level window linker', or   'no' to disable)\n   Default = '20 64 1')", 
+            "value-key": "[DUST]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "dust", 
+            "name": "DUST Options"
+        }, 
+        {
+            "command-line-flag": "-gilist", 
+            "description": "Restrict search of database to list of GI's", 
+            "disables-inputs": [
+                "negative_gilist", 
+                "seqidlist", 
+                "negative_seqidlist", 
+                "remote", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[GILIST]", 
+            "type": "String", 
+            "id": "gilist", 
+            "name": "Restrictive GI List"
+        }, 
+        {
+            "command-line-flag": "-seqidlist", 
+            "description": "Restrict search of database to list of SeqId's", 
+            "disables-inputs": [
+                "gilist", 
+                "negative_gilist", 
+                "negative_seqidlist", 
+                "remote", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[SEQIDLIST]", 
+            "type": "String", 
+            "id": "seqidlist", 
+            "name": "Restrictive Sequence Id List"
+        }, 
+        {
+            "command-line-flag": "-negative_gilist", 
+            "description": "Restrict search of database to everything except the listed GIs", 
+            "disables-inputs": [
+                "gilist", 
+                "seqidlist", 
+                "remote", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[NEGATIVE_GILIST]", 
+            "type": "String", 
+            "id": "negative_gilist", 
+            "name": "Exclusive GI List"
+        }, 
+        {
+            "command-line-flag": "-negative_seqidlist", 
+            "description": "Restrict search of database to everything except the listed SeqIDs", 
+            "disables-inputs": [
+                "gilist", 
+                "seqidlist", 
+                "remote", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[NEGATIVE_SEQIDLIST]", 
+            "type": "String", 
+            "id": "negative_seqidlist", 
+            "name": "Exclusive Sequence Id List"
+        }, 
+        {
+            "command-line-flag": "-entrez_query", 
+            "description": "Restrict search with the given Entrez query", 
+            "value-key": "[ENTREZ_QUERY]", 
+            "optional": true, 
+            "requires-inputs": [
+                "remote"
+            ], 
+            "type": "String", 
+            "id": "entrez_query", 
+            "name": "Exclusive Sequence Id List"
+        }, 
+        {
+            "command-line-flag": "-db_soft_mask", 
+            "description": "Filtering algorithm ID to apply to the BLAST database as soft masking", 
+            "disables-inputs": [
+                "db_hard_mask", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[DB_SOFT_MASK]", 
+            "type": "String", 
+            "id": "db_soft_mask", 
+            "name": "Soft Mask ID"
+        }, 
+        {
+            "command-line-flag": "-db_hard_mask", 
+            "description": "Filtering algorithm ID to apply to the BLAST database as hard masking", 
+            "disables-inputs": [
+                "db_soft_mask", 
+                "subject", 
+                "subject_loc"
+            ], 
+            "optional": true, 
+            "value-key": "[DB_HARD_MASK]", 
+            "type": "String", 
+            "id": "db_hard_mask", 
+            "name": "Hard Mask ID"
+        }, 
+        {
+            "command-line-flag": "-index_name", 
+            "description": "MegaBLAST database index name (deprecated; use only for old style indices)", 
+            "value-key": "[INDEX_NAME]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "index_name", 
+            "name": "MegaBLAST database index name"
+        }, 
+        {
+            "command-line-flag": "-filtering_db", 
+            "description": "BLAST database containing filtering elements (i.e.: repeats)", 
+            "value-key": "[FILTERING_DB]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "filtering_db", 
+            "name": "BLAST filtering database"
+        }, 
+        {
+            "command-line-flag": "-window_masker_db", 
+            "description": "Enable WindowMasker filtering using this repeats database.", 
+            "value-key": "[WINDOW_MASKER_DB]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "window_masker_db", 
+            "name": "Window Masker DB"
+        }, 
+        {
+            "command-line-flag": "-template_type", 
+            "description": "Discontiguous MegaBLAST template type", 
+            "value-key": "[TEMPLATE_TYPE]", 
+            "optional": true, 
+            "requires-inputs": [
+                "template_length"
+            ], 
+            "value-choices": [
+                "coding", 
+                "coding_and_optimal", 
+                "optimal"
+            ], 
+            "type": "String", 
+            "id": "template_type", 
+            "name": "Discontiguous MegaBLAST template type"
+        }, 
+        {
+            "command-line-flag": "-lcase_masking", 
+            "description": "Use lower case filtering in query and subject sequence(s)?", 
+            "value-key": "[fLCASE_MASKING]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "lcase_masking", 
+            "name": "Lowercase Filtering"
+        }, 
+        {
+            "command-line-flag": "-ungapped", 
+            "description": "Perform ungapped alignment only?", 
+            "value-key": "[fUNGAPPED]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "ungapped", 
+            "name": "Ungapped Alignment"
+        }, 
+        {
+            "command-line-flag": "-parse_deflines", 
+            "description": "Should the query and subject defline(s) be parsed?", 
+            "value-key": "[fPARSE_DEFLINES]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "parse_deflines", 
+            "name": "Parse Deflines"
+        }, 
+        {
+            "command-line-flag": "-remote", 
+            "description": "Execute search remotely?", 
+            "disables-inputs": [
+                "gilist", 
+                "seqidlist", 
+                "negative_gilist", 
+                "negative_seqidlist", 
+                "subject_loc", 
+                "num_threads"
+            ], 
+            "optional": true, 
+            "value-key": "[fREMOTE]", 
+            "type": "Flag", 
+            "id": "remote", 
+            "name": "Remote Search"
+        }, 
+        {
+            "command-line-flag": "-no_greedy", 
+            "description": "Use non-greedy dynamic programming extension", 
+            "value-key": "[fNO_GREEDY]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "no_greedy", 
+            "name": "Non-Greedy Dynamic Programming Extension"
+        }, 
+        {
+            "command-line-flag": "-use_index", 
+            "description": "Use MegaBLAST database index\n  Default 'false'", 
+            "value-key": "[USE_INDEX]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "use_index", 
+            "name": "MegaBLAST Database Index Usage"
+        }, 
+        {
+            "command-line-flag": "-soft_masking", 
+            "description": "Apply filtering locations as soft masks\n  Default 'true'", 
+            "value-key": "[SOFT_MASKING]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "soft_masking", 
+            "name": "Filtering Locations As Soft Masks"
+        }, 
+        {
+            "command-line-flag": "-sum_stats", 
+            "description": "Use sum statistics", 
+            "value-key": "[SUM_STATS]", 
+            "optional": true, 
+            "value-choices": [
+                "true", 
+                "false"
+            ], 
+            "type": "String", 
+            "id": "sum_stats", 
+            "name": "Sum Statistics"
+        }, 
+        {
+            "command-line-flag": "-word_size", 
+            "description": "Word size for wordfinder algorithm (length of best perfect match)", 
+            "value-key": "[WORD_SIZE]", 
+            "optional": true, 
+            "minimum": 4, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "word_size", 
+            "name": "Word Size"
+        }, 
+        {
+            "command-line-flag": "-gapopen", 
+            "description": "Cost to open a gap", 
+            "value-key": "[GAPOPEN]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "gapopen", 
+            "name": "Gap Open Penalty"
+        }, 
+        {
+            "command-line-flag": "-gapextend", 
+            "description": "Cost to extend a gap", 
+            "value-key": "[GAPEXTEND]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "gapextend", 
+            "name": "Gap Extend Penalty"
+        }, 
+        {
+            "command-line-flag": "-max_hsps", 
+            "description": "Set maximum number of HSPs per subject sequence to save for each query", 
+            "value-key": "[MAX_HSPS]", 
+            "optional": true, 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "max_hsps", 
+            "name": "Max HSPs Per Subject"
+        }, 
+        {
+            "command-line-flag": "-culling_limit", 
+            "description": "   If the query range of a hit is enveloped by that of at least this many\n   higher-scoring hits, delete the hit", 
+            "value-key": "[CULLING_LIMIT]", 
+            "optional": true, 
+            "disables-inputs": [
+                "best_hit_overhang", 
+                "best_hit_score_edge"
+            ], 
+            "minimum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "culling_limit", 
+            "name": "Higher Scoring Hit Culling Limit"
+        }, 
+        {
+            "command-line-flag": "-max_target_seqs", 
+            "description": "   Maximum number of aligned sequences to keep\n   Not applicable for outfmt <= 4\n   Default = `500'", 
+            "value-key": "[MAX_TARGET_SEQS]", 
+            "optional": true, 
+            "disables-inputs": [
+                "num_descriptions", 
+                "num_alignments"
+            ], 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "max_target_seqs", 
+            "name": "Maximum Target Sequence"
+        }, 
+        {
+            "command-line-flag": "-dbsize", 
+            "description": "Effective length of the database", 
+            "value-key": "[DBSIZE]", 
+            "optional": true, 
+            "maximum": 255, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "dbsize", 
+            "name": "Database Size"
+        }, 
+        {
+            "command-line-flag": "-searchsp", 
+            "description": "Effective length of the search space", 
+            "value-key": "[SEARCHSP]", 
+            "optional": true, 
+            "maximum": 255, 
+            "minimum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "searchsp", 
+            "name": "Search Space Length"
+        }, 
+        {
+            "command-line-flag": "-window_size", 
+            "description": "Multiple hits window size, use 0 to specify 1-hit algorithm", 
+            "value-key": "[WINDOW_SIZE]", 
+            "optional": true, 
+            "minimum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "window_size", 
+            "name": "Multiple Hits Window Size"
+        }, 
+        {
+            "command-line-flag": "-num_threads", 
+            "description": "   Number of threads (CPUs) to use in the BLAST search\n   Default = `1'", 
+            "value-key": "[NUM_THREADS]", 
+            "optional": true, 
+            "maximum": 12, 
+            "disables-inputs": [
+                "remote"
+            ], 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "num_threads", 
+            "name": "Maximum Target Sequence"
+        }, 
+        {
+            "command-line-flag": "-penalty", 
+            "description": "Penalty for a nucleotide mismatch", 
+            "value-key": "[PENALTY]", 
+            "optional": true, 
+            "maximum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "penalty", 
+            "name": "Nucleotide Mismatch Penalty"
+        }, 
+        {
+            "command-line-flag": "-reward", 
+            "description": "Reward for a nucleotide match", 
+            "value-key": "[REWARD]", 
+            "optional": true, 
+            "minimum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "reward", 
+            "name": "Nucleotide Match Reward"
+        }, 
+        {
+            "command-line-flag": "-window_masker_taxid", 
+            "description": "Enable WindowMasker filtering using a Taxonomic ID", 
+            "value-key": "[WINDOW_MASKER_TAXID]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "window_masker_taxid", 
+            "name": "Taxonomic ID for WindowMasker Filtering"
+        }, 
+        {
+            "command-line-flag": "-template_length", 
+            "description": "Discontiguous MegaBLAST template length", 
+            "value-key": "[TEMPLATE_LENGTH]", 
+            "optional": true, 
+            "requires-inputs": [
+                "template_type"
+            ], 
+            "value-choices": [
+                16, 
+                18, 
+                21
+            ], 
+            "integer": true, 
+            "type": "Number", 
+            "id": "template_length", 
+            "name": "Discontiguous MegaBLAST Template Length"
+        }, 
+        {
+            "command-line-flag": "-min_raw_gapped_score", 
+            "description": "Minimum raw gapped score to keep an alignment in the preliminary gapped and traceback stages", 
+            "value-key": "[MIN_RAW_GAPPED_SCORE]", 
+            "optional": true, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "min_raw_gapped_score", 
+            "name": "Minumum Raw Gapped Score"
+        }, 
+        {
+            "command-line-flag": "-off_diagonal_range", 
+            "description": "   Number of off-diagonals to search for the 2nd hit, use 0 to turn off\n   Default = `0'", 
+            "value-key": "[OFF_DIAGONAL_RANGE]", 
+            "optional": true, 
+            "minimum": 0, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "off_diagonal_range", 
+            "name": "Off-Diagonal Range"
+        }, 
+        {
+            "command-line-flag": "-evalue", 
+            "description": "  Expectation value (E) threshold for saving hits\n  Default = `10'", 
+            "value-key": "[EVALUE]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "evalue", 
+            "name": "Expectation Value"
+        }, 
+        {
+            "command-line-flag": "-perc_identity", 
+            "description": "Percent identity", 
+            "value-key": "[PERC_IDENTITY]", 
+            "optional": true, 
+            "maximum": 100, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "perc_identity", 
+            "name": "Percent identity"
+        }, 
+        {
+            "command-line-flag": "-qcov_hsp_perc", 
+            "description": "Percent query coverage per hsp", 
+            "value-key": "[QCOV_HSP_PERC]", 
+            "optional": true, 
+            "maximum": 100, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "qcov_hsp_perc", 
+            "name": "Percentage Query Coverage"
+        }, 
+        {
+            "command-line-flag": "-best_hit_overhang", 
+            "description": "Best Hit algorithm overhang value (recommended value: 0.1)", 
+            "value-key": "[BEST_HIT_OVERHANG]", 
+            "optional": true, 
+            "exclusive-maximum": true, 
+            "maximum": 0.5, 
+            "disables-inputs": [
+                "culling_limit"
+            ], 
+            "minimum": 0, 
+            "exclusive-minimum": true, 
+            "type": "Number", 
+            "id": "best_hit_overhang", 
+            "name": "Best Hit Algorithm Overhang"
+        }, 
+        {
+            "command-line-flag": "-best_hit_score_edge", 
+            "description": "Best Hit algorithm score edge value (recommended value: 0.1)", 
+            "value-key": "[BEST_HIT_SCORE_EDGE]", 
+            "optional": true, 
+            "exclusive-maximum": true, 
+            "maximum": 0.5, 
+            "disables-inputs": [
+                "culling_limit"
+            ], 
+            "minimum": 0, 
+            "exclusive-minimum": true, 
+            "type": "Number", 
+            "id": "best_hit_score_edge", 
+            "name": "Best Hit Algorithm Score Edge Value"
+        }, 
+        {
+            "command-line-flag": "-xdrop_ungap", 
+            "description": "X-dropoff value (in bits) for ungapped extensions", 
+            "value-key": "[XDROP_UNGAP]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "xdrop_ungap", 
+            "name": "Ungapped Extensions X-dropoff Value"
+        }, 
+        {
+            "command-line-flag": "-xdrop_gap", 
+            "description": "X-dropoff value (in bits) for preliminary gapped extensions", 
+            "value-key": "[XDROP_GAP]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "xdrop_gap", 
+            "name": "Preiliminary Gapped Extensions X-dropoff Value"
+        }, 
+        {
+            "command-line-flag": "-xdrop_gap_final", 
+            "description": "X-dropoff value (in bits) for final gapped alignment", 
+            "value-key": "[XDROP_GAP_FINAL]", 
+            "optional": true, 
+            "type": "Number", 
+            "id": "xdrop_gap_final", 
+            "name": "Final Gapped Extensions X-dropoff Value"
+        }, 
+        {
+            "command-line-flag": "-query", 
+            "description": "Input file name", 
+            "value-key": "[QUERY]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "query", 
+            "name": "Query"
+        }, 
+        {
+            "command-line-flag": "-subject", 
+            "description": "Subject sequence(s) to search", 
+            "value-key": "[SUBJECT]", 
+            "optional": true, 
+            "disables-inputs": [
+                "db", 
+                "gilist", 
+                "seqidlist", 
+                "negative_gilist", 
+                "negative_seqidlist", 
+                "db_soft_mask", 
+                "db_hard_mask"
+            ], 
+            "type": "File", 
+            "id": "subject", 
+            "name": "Subject"
+        }, 
+        {
+            "command-line-flag": "-import_search_strategy", 
+            "description": "Search strategy to use", 
+            "value-key": "[IMPORT_SEARCH_STRATEGY]", 
+            "optional": true, 
+            "disables-inputs": [
+                "export_search_strategy"
+            ], 
+            "type": "File", 
+            "id": "import_search_strategy", 
+            "name": "Search Strategy File"
+        }, 
+        {
+            "command-line-flag": "-export_search_strategy", 
+            "description": "File name to record the search strategy used", 
+            "value-key": "[EXPORT_SEARCH_STRATEGY]", 
+            "optional": true, 
+            "disables-inputs": [
+                "import_search_strategy"
+            ], 
+            "type": "File", 
+            "id": "export_search_strategy", 
+            "name": "Search Strategy Record Filename"
+        }, 
+        {
+            "command-line-flag": "-show_gis", 
+            "description": "Show NCBI GIs in deflines?", 
+            "value-key": "[fSHOW_GIS]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "show_gis", 
+            "name": "Show NCBI GIs"
+        }, 
+        {
+            "command-line-flag": "-html", 
+            "description": "Produce HTML Output", 
+            "value-key": "[fHTML]", 
+            "optional": true, 
+            "type": "Flag", 
+            "id": "html", 
+            "name": "Show HTML"
+        }, 
+        {
+            "command-line-flag": "-outfmt", 
+            "description": "   alignment view options:\n     0 = Pairwise,\n     1 = Query-anchored showing identities,\n     2 = Query-anchored no identities,\n     3 = Flat query-anchored showing identities,\n     4 = Flat query-anchored no identities,\n     5 = BLAST XML,\n     6 = Tabular,\n     7 = Tabular with comment lines,\n     8 = Seqalign (Text ASN.1),\n     9 = Seqalign (Binary ASN.1),\n    10 = Comma-separated values,\n    11 = BLAST archive (ASN.1),\n    12 = Seqalign (JSON),\n    13 = Multiple-file BLAST JSON,\n    14 = Multiple-file BLAST XML2,\n    15 = Single-file BLAST JSON,\n    16 = Single-file BLAST XML2,\n    17 = Sequence Alignment/Map (SAM),\n    18 = Organism Report\n\n   Options 6, 7, 10 and 17 can be additionally configured to produce\n   a custom format specified by space delimited format specifiers.\n   The supported format specifiers for options 6, 7 and 10 are:\n            qseqid means Query Seq-id\n               qgi means Query GI\n              qacc means Query accesion\n           qaccver means Query accesion.version\n              qlen means Query sequence length\n            sseqid means Subject Seq-id\n         sallseqid means All subject Seq-id(s), separated by a ';'\n               sgi means Subject GI\n            sallgi means All subject GIs\n              sacc means Subject accession\n           saccver means Subject accession.version\n           sallacc means All subject accessions\n              slen means Subject sequence length\n            qstart means Start of alignment in query\n              qend means End of alignment in query\n            sstart means Start of alignment in subject\n              send means End of alignment in subject\n              qseq means Aligned part of query sequence\n              sseq means Aligned part of subject sequence\n            evalue means Expect value\n          bitscore means Bit score\n             score means Raw score\n            length means Alignment length\n            pident means Percentage of identical matches\n            nident means Number of identical matches\n          mismatch means Number of mismatches\n          positive means Number of positive-scoring matches\n           gapopen means Number of gap openings\n              gaps means Total number of gaps\n              ppos means Percentage of positive-scoring matches\n            frames means Query and subject frames separated by a '/'\n            qframe means Query frame\n            sframe means Subject frame\n              btop means Blast traceback operations (BTOP)\n            staxid means Subject Taxonomy ID\n          ssciname means Subject Scientific Name\n          scomname means Subject Common Name\n        sblastname means Subject Blast Name\n         sskingdom means Subject Super Kingdom\n           staxids means unique Subject Taxonomy ID(s), separated by a ';'\n                         (in numerical order)\n         sscinames means unique Subject Scientific Name(s), separated by a ';'\n         scomnames means unique Subject Common Name(s), separated by a ';'\n        sblastnames means unique Subject Blast Name(s), separated by a ';'\n                         (in alphabetical order)\n        sskingdoms means unique Subject Super Kingdom(s), separated by a ';'\n                         (in alphabetical order)\n            stitle means Subject Title\n        salltitles means All Subject Title(s), separated by a '<>'\n           sstrand means Subject Strand\n             qcovs means Query Coverage Per Subject\n           qcovhsp means Query Coverage Per HSP\n            qcovus means Query Coverage Per Unique Subject (blastn only)\n   When not provided, the default value is:\n   'qaccver saccver pident length mismatch gapopen qstart qend sstart send\n   evalue bitscore', which is equivalent to the keyword 'std'\n   The supported format specifier for option 17 is:\n                SQ means Include Sequence Data\n                SR means Subject as Reference Seq\n  Default = `0'", 
+            "value-key": "[OUTFMT]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "outfmt", 
+            "name": "Alignment View Options"
+        }, 
+        {
+            "command-line-flag": "-num_descriptions", 
+            "description": "   Number of database sequences to show one-line descriptions for\n   Not applicable for outfmt > 4\n   Default = `500'", 
+            "value-key": "[NUM_DESCRIPTIONS]", 
+            "optional": true, 
+            "disables-inputs": [
+                "max_target_seqs"
+            ], 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "num_descriptions", 
+            "name": "Number of Sequence Descriptions to Show"
+        }, 
+        {
+            "command-line-flag": "-num_alignments", 
+            "description": "   Number of database sequences to show alignments for\n   Default = `250'", 
+            "value-key": "[NUM_ALIGNMENTS]", 
+            "optional": true, 
+            "disables-inputs": [
+                "max_target_seqs"
+            ], 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "num_alignments", 
+            "name": "Number of Sequence Alignments to Show"
+        }, 
+        {
+            "command-line-flag": "-line_length", 
+            "description": "   Line length for formatting alignments\n   Not applicable for outfmt > 4\n   Default = `60'", 
+            "value-key": "[LINE_LENGTH]", 
+            "optional": true, 
+            "minimum": 1, 
+            "type": "Number", 
+            "id": "line_length", 
+            "name": "Line Length"
+        }, 
+        {
+            "command-line-flag": "-out", 
+            "description": "   Output file name", 
+            "value-key": "[OUT]", 
+            "optional": true, 
+            "type": "String", 
+            "id": "out", 
+            "name": "Output file name"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[OUT]", 
+            "optional": false, 
+            "id": "output", 
+            "name": "Output File"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 60, 
+        "ram": 1, 
+        "cpu-cores": 1
+    }, 
+    "name": "blastn"
+}

--- a/app/static/pipelines/zenodo-3242714.json
+++ b/app/static/pipelines/zenodo-3242714.json
@@ -1,0 +1,467 @@
+{
+    "author": "Plodrack lab",
+    "command-line": "mriqc_run.py [BIDS_DIR] [OUTPUT_DIR] [ANALYSIS_LEVEL] [VERSION] [PARTICIPANT_LABEL] [SESSION_ID] [RUN_ID] [TASK_ID] [MODALITIES] [DSNAME] [WORK_DIR] [VERBOSE_REPORTS] [WRITE_GRAPH] [DRY_RUN] [PROFILE] [USE_PLUGIN] [NO_SUB] [EMAIL] [VERBOSE_COUNT] [WEBAPI_URL] [WEBAPI_PORT] [UPLOAD_STRICT] [N_PROCS] [MEM_GB] [TESTING] [FLOAT32] [ICA] [HMC_AFNI] [HMC_FSL] [FFT_SPIKES_DETECTOR] [FD_THRES] [ANTS_NTHREADS] [ANTS_FLOAT] [ANTS_SETTINGS] [DEOBLIQUE] [DESPIKE] [START_IDX] [STOP_IDX] [CORRECT_SLICE_TIMING]",
+    "description": "tool description",
+    "inputs": [
+        {
+            "description": "The directory with the input dataset formatted according to the BIDS standard.",
+            "id": "bids_dir",
+            "name": "bids_dir",
+            "optional": false,
+            "type": "File",
+            "value-key": "[BIDS_DIR]"
+        },
+        {
+            "description": "The directory where the output files should be stored. If you are running group level analysis this folder should be prepopulated with the results of theparticipant level analysis.",
+            "id": "output_dir_name",
+            "name": "output_dir_name",
+            "optional": false,
+            "type": "String",
+            "value-key": "[OUTPUT_DIR]"
+        },
+        {
+            "description": "Level of the analysis that will be performed. Multiple participant level analyses can be run independently (in parallel) using the same output_dir.",
+            "id": "analysis_level",
+            "list": true,
+            "name": "analysis_level",
+            "optional": false,
+            "type": "String",
+            "value-choices": [
+                "participant",
+                "group"
+            ],
+            "value-key": "[ANALYSIS_LEVEL]"
+        },
+        {
+            "command-line-flag": "--version",
+            "default-value": false,
+            "description": "show program's version number and exit",
+            "id": "version",
+            "name": "version",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERSION]"
+        },
+        {
+            "command-line-flag": "--participant_label",
+            "description": "one or more participant identifiers (the sub- prefix can be removed)",
+            "id": "participant_label",
+            "name": "participant_label",
+            "optional": true,
+            "type": "String",
+            "value-key": "[PARTICIPANT_LABEL]"
+        },
+        {
+            "command-line-flag": "--session-id",
+            "description": "filter input dataset by session id",
+            "id": "session_id",
+            "name": "session_id",
+            "optional": true,
+            "type": "String",
+            "value-key": "[SESSION_ID]"
+        },
+        {
+            "command-line-flag": "--run-id",
+            "description": "filter input dataset by run id (only integer run ids are valid)",
+            "id": "run_id",
+            "name": "run_id",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[RUN_ID]"
+        },
+        {
+            "command-line-flag": "--task-id",
+            "description": "filter input dataset by task id",
+            "id": "task_id",
+            "name": "task_id",
+            "optional": true,
+            "type": "String",
+            "value-key": "[TASK_ID]"
+        },
+        {
+            "command-line-flag": "-m",
+            "description": "filter input dataset by MRI type (\"T1w\", \"T2w\", or \"bold\")",
+            "id": "modalities",
+            "name": "modalities",
+            "optional": true,
+            "list": true,
+            "type": "String",
+            "value-choices": [
+                "T1w",
+                "bold",
+                "T2w"
+            ],
+            "value-key": "[MODALITIES]"
+        },
+        {
+            "command-line-flag": "--dsname",
+            "description": "a dataset name",
+            "id": "dsname",
+            "name": "dsname",
+            "optional": true,
+            "type": "String",
+            "value-key": "[DSNAME]"
+        },
+        {
+            "command-line-flag": "-w",
+            "default-value": "work",
+            "description": "The folder used to store intermediate results",
+            "id": "work_dir",
+            "name": "work_dir",
+            "optional": true,
+            "type": "String",
+            "value-key": "[WORK_DIR]"
+        },
+        {
+            "command-line-flag": "--verbose-reports",
+            "description": "Should MRIQC print verbose reports",
+            "id": "verbose_reports",
+            "name": "verbose_reports",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[VERBOSE_REPORTS]"
+        },
+        {
+            "command-line-flag": "--write-graph",
+            "description": "Write workflow graph.",
+            "id": "write_graph",
+            "name": "write_graph",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[WRITE_GRAPH]"
+        },
+        {
+            "command-line-flag": "--dry-run",
+            "description": "Do not run the workflow.",
+            "id": "dry_run",
+            "name": "dry_run",
+            "optional": true,
+            "type": "Flag",
+            "default-value":false,
+            "value-key": "[DRY_RUN]"
+        },
+        {
+            "command-line-flag": "--profile",
+            "description": "hook up the resource profiler callback to nipype",
+            "id": "profile",
+            "name": "profile",
+            "optional": true,
+            "type": "Flag",
+            "default-value":false,
+            "value-key": "[PROFILE]"
+        },
+        {
+            "command-line-flag": "--use-plugin",
+            "description": "Path to nipype plugin configuration file",
+            "id": "use_plugin",
+            "name": "use_plugin",
+            "optional": true,
+            "type": "String",
+            "value-key": "[USE_PLUGIN]"
+        },
+        {
+            "command-line-flag": "--no-sub",
+            "description": "Turn off submission of anonymized quality metrics to MRIQC's metrics repository.",
+            "id": "no_sub",
+            "name": "no_sub",
+            "optional": true,
+            "type": "Flag",
+            "default-value": false,
+            "value-key": "[NO_SUB]"
+        },
+        {
+            "command-line-flag": "--email",
+            "description": "Email address to include with quality metric submission.",
+            "id": "email",
+            "name": "email",
+            "optional": true,
+            "type": "String",
+            "value-key": "[EMAIL]"
+        },
+        {
+            "command-line-flag": "-v",
+            "description": "increases log verbosity for each occurence, debug level is -vvv",
+            "id": "verbose_count",
+            "name": "verbose_count",
+            "optional": true,
+            "type": "String",
+            "value-key": "[VERBOSE_COUNT]"
+        },
+        {
+            "command-line-flag": "--webapi-url",
+            "default-value": "https://mriqc.nimh.nih.gov/api/v1",
+            "description": "IP address where the MRIQC WebAPI is listening",
+            "id": "webapi_url",
+            "name": "webapi_url",
+            "optional": true,
+            "type": "String",
+            "value-key": "[WEBAPI_URL]"
+        },
+        {
+            "command-line-flag": "--webapi-port",
+            "description": "port where the MRIQC WebAPI is listening",
+            "id": "webapi_port",
+            "name": "webapi_port",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[WEBAPI_PORT]"
+        },
+        {
+            "command-line-flag": "--upload-strict",
+            "description": "upload will fail if if upload is strict",
+            "id": "upload_strict",
+            "name": "upload_strict",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[UPLOAD_STRICT]"
+        },
+        {
+            "command-line-flag": "--n_procs",
+            "description": "number of threads",
+            "id": "n_procs",
+            "name": "n_procs",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[N_PROCS]"
+        },
+        {
+            "command-line-flag": "--mem_gb",
+            "description": "available total memory",
+            "id": "mem_gb",
+            "name": "mem_gb",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[MEM_GB]"
+        },
+        {
+            "command-line-flag": "--testing",
+            "description": "use testing settings for a minimal footprint",
+            "id": "testing",
+            "name": "testing",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[TESTING]"
+        },
+        {
+            "command-line-flag": "-f",
+            "description": "Cast the input data to float32 if it's represented in higher precision (saves space and improves perfomance)",
+            "id": "float32",
+            "name": "float32",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FLOAT32]"
+        },
+        {
+            "command-line-flag": "--ica",
+            "description": "Run ICA on the raw data and include the componentsin the individual reports (slow but potentially very insightful)",
+            "id": "ica",
+            "name": "ica",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[ICA]"
+        },
+        {
+            "command-line-flag": "--hmc-afni",
+            "default-value": true,
+            "description": "Use ANFI 3dvolreg for head motion correction (HMC) - default",
+            "id": "hmc_afni",
+            "name": "hmc_afni",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HMC_AFNI]"
+        },
+        {
+            "command-line-flag": "--hmc-fsl",
+            "description": "Use FSL MCFLIRT instead of AFNI for head motion correction (HMC)",
+            "id": "hmc_fsl",
+            "name": "hmc_fsl",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[HMC_FSL]"
+        },
+        {
+            "command-line-flag": "--fft-spikes-detector",
+            "description": "Turn on FFT based spike detector (slow).",
+            "id": "fft_spikes_detector",
+            "name": "fft_spikes_detector",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FFT_SPIKES_DETECTOR]"
+        },
+        {
+            "command-line-flag": "--fd_thres",
+            "default-value": 0.2,
+            "description": "motion threshold for FD computation",
+            "id": "fd_thres",
+            "name": "fd_thres",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[FD_THRES]"
+        },
+        {
+            "command-line-flag": "--ants-nthreads",
+            "default-value": 1,
+            "description": "number of threads that will be set in ANTs processes",
+            "id": "ants_nthreads",
+            "name": "ants_nthreads",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[ANTS_NTHREADS]"
+        },
+        {
+            "command-line-flag": "--ants-float",
+            "description": "use float number precision on ANTs computations",
+            "id": "ants_float",
+            "name": "ants_float",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[ANTS_FLOAT]"
+        },
+        {
+            "command-line-flag": "--ants-settings",
+            "description": "path to JSON file with settings for ANTS",
+            "id": "ants_settings",
+            "name": "ants_settings",
+            "optional": true,
+            "type": "String",
+            "value-key": "[ANTS_SETTINGS]"
+        },
+        {
+            "command-line-flag": "--deoblique",
+            "description": "Deoblique the functional scans during head motion correction preprocessing",
+            "id": "deoblique",
+            "name": "deoblique",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DEOBLIQUE]"
+        },
+        {
+            "command-line-flag": "--despike",
+            "description": "Despike the functional scans during head motion correction preprocessing",
+            "id": "despike",
+            "name": "despike",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[DESPIKE]"
+        },
+        {
+            "command-line-flag": "--start-idx",
+            "description": "Initial volume in functional timeseries that should be considered for preprocessing",
+            "id": "start_idx",
+            "name": "start_idx",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[START_IDX]"
+        },
+        {
+            "command-line-flag": "--stop-idx",
+            "description": "Final volume in functional timeseries that should be considered for preprocessing",
+            "id": "stop_idx",
+            "name": "stop_idx",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[STOP_IDX]"
+        },
+        {
+            "command-line-flag": "--correct-slice-timing",
+            "description": "Perform slice timing correction",
+            "id": "correct_slice_timing",
+            "name": "correct_slice_timing",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[CORRECT_SLICE_TIMING]"
+        }
+    ],
+    "output-files": [
+        {
+            "description": "This is the directory where the overall outputs are to be stored.",
+            "id": "output_directory",
+            "name": "Output Directory",
+            "optional": false,
+            "path-template": "[OUTPUT_DIR]"
+        }
+    ],
+    "groups": [
+        {
+            "name": "Instrumentation Options",
+            "description": "Instrumental Options",
+            "id":"instrument_options",
+            "members": [
+                "work_dir",
+                "verbose_reports",
+                "write_graph",
+                "dry_run",
+                "profile",
+                "use_plugin",
+                "no_sub",
+                "email",
+                "webapi_url",
+                "webapi_port",
+                "upload_strict"
+            ]
+        },
+        {
+            "name": "Performance Options",
+            "description": "Options to handle performance",
+            "id": "performance_options",
+            "members": [
+                "n_procs",
+                "mem_gb",
+                "testing",
+                "float32"
+            ]
+        },
+        {
+            "name": "Workflow Options",
+            "description": "Workflow options",
+            "id": "workflow_options",
+            "members": [
+                "ica",
+                "hmc_afni",
+                "hmc_fsl",
+                "fft_spikes_detector",
+                "fd_thres"
+            ]
+        },
+        {
+            "name": "ANTs specific settings",
+            "description": "ANTs specific settings",
+            "id": "ants_specific_settings",
+            "members": [
+                "ants_settings",
+                "ants_float",
+                "ants_nthreads"
+            ]
+        },
+        {
+            "name": "AFNI specific settings",
+            "description": "AFNI specific settings",
+            "id": "afni_specific_settings",
+            "members": [
+                "deoblique",
+                "despike",
+                "start_idx",
+                "stop_idx",
+                "correct_slice_timing"
+            ]
+        }
+    ],
+    "name": "MRIQC",
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 4,
+        "walltime-estimate": 172000
+    },
+    "tags": {
+        "application-type": [
+            "bids"
+        ],
+        "domain": [
+            "neuroinformatics",
+            "mri"
+        ]
+    },
+    "tool-version": "v0.14.2",
+    "url": "https://mriqc.readthedocs.io/en/0.14.2"
+}

--- a/app/static/pipelines/zenodo-3245387.json
+++ b/app/static/pipelines/zenodo-3245387.json
@@ -1,0 +1,116 @@
+{
+    "tool-version": "v1.1", 
+    "tests": [
+        {
+            "invocation": {
+                "input": "uniprotminier.fasta"
+            }, 
+            "name": "test1", 
+            "assertions": {
+                "output-files": [
+                    {
+                        "id": "outmafft_rascal", 
+                        "md5-reference": "4b003bebd3fb9722152f65ab5d17c434"
+                    }
+                ], 
+                "exit-code": 0
+            }
+        }
+    ], 
+    "description": "automatic quality improvment for multiple sequence alignment.", 
+    "command-line": "AQUA.tcl [INPUT] [OUTPUT_DIR]", 
+    "author": "Muller J, Creevey CJ, Thompson JD, Arendt D, Bork P.", 
+    "tags": {
+        "domain": [
+            "bioinformatics", 
+            "AQUA"
+        ]
+    }, 
+    "container-image": {
+        "index": "shub://", 
+        "image": "bioinformatics-group/aqua-singularity-recipe", 
+        "type": "singularity"
+    }, 
+    "inputs": [
+        {
+            "description": "A file containing the input sequence in fasta format", 
+            "value-key": "[INPUT]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "input", 
+            "name": "Input Sequence"
+        }, 
+        {
+            "description": "The directory where the results are stored. The default location is the same directory as the input sequence.", 
+            "default-value": ".", 
+            "value-key": "[OUTPUT_DIR]", 
+            "optional": false, 
+            "type": "File", 
+            "id": "output_dir", 
+            "name": "Output Directory"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].muscle", 
+            "optional": false, 
+            "id": "outmuscle", 
+            "name": "Output of muscle results"
+        }, 
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].mafft", 
+            "optional": false, 
+            "id": "outmafft", 
+            "name": "Output of mafft results"
+        }, 
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].muscle.rascal", 
+            "optional": false, 
+            "id": "outmuscle_rascal", 
+            "name": "Output of muscle and rascal results"
+        }, 
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].mafft.rascal", 
+            "optional": false, 
+            "id": "outmafft_rascal", 
+            "name": "Output of mafft and rascal results"
+        }, 
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].muscle.normd", 
+            "optional": false, 
+            "id": "outmuscle_normd", 
+            "name": "Output of muscle and normd results"
+        }, 
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].mafft.normd", 
+            "optional": false, 
+            "id": "outmafft_normd", 
+            "name": "Output of mafft and normd results"
+        }, 
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].muscle.rascal.normd", 
+            "optional": false, 
+            "id": "outmuscle_rascal_normd", 
+            "name": "Output of muscle, rascal and normd results"
+        }, 
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].mafft.rascal.normd", 
+            "optional": false, 
+            "id": "outmafft_rascal_normd", 
+            "name": "Output of mafft, rascal and normd results"
+        }, 
+        {
+            "path-template": "[OUTPUT_DIR]/[INPUT].best", 
+            "optional": false, 
+            "id": "outbest", 
+            "name": "Output of best results"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 60, 
+        "ram": 1, 
+        "cpu-cores": 1
+    }, 
+    "name": "AQUA"
+}

--- a/app/static/pipelines/zenodo-3257614.json
+++ b/app/static/pipelines/zenodo-3257614.json
@@ -1,0 +1,231 @@
+{
+    "name": "spark",
+    "schema-version": "0.5",
+    "tool-version": "v1.2.1",
+    "tags": {
+        "domain": "neuroinformatics"
+    },
+    "author": "Kangjoo Lee, Jean-Marc Lina, Jean Gotman, Christophe Grova",
+    "description": "SParsity-based Analysis of Reliable K-hubness (SPARK) for brain fMRI functional connectivity",
+    "container-image": {
+        "type": "singularity",
+        "image": "multifunkimlab/spark:1.2.1"
+    },
+    "command-line": "octave --no-gui --no-init-file -q $SPARK_ROOT/SPARK.m [FMRI_DATA] [MASK] [OUT_DIR] [NB_RESAMPLING] [NETWORK_SCALES] [NB_ITERATIONS] [P_VALUE] [RESAMPLING_METHOD] [BLOCK_WINDOW_LENGTH] [DICT_INIT_METHOD] [SPARSE_CODING_METHOD] [PRESERVE_DC_ATOM] [MAX_PARALLEL_JOBS]",
+
+    "groups": [
+        {
+            "id": "bootstrap_resampling",
+            "name": "Bootstrap resampling",
+            "members": [
+                "nb_resampling",
+                "resampling_method",
+                "block_window_length"
+            ]
+        },
+        {
+            "id": "sparse_dict_learning",
+            "name": "Sparse dictionary learning",
+            "members": [
+                "network_scales",
+                "nb_iterations",
+                "dict_init_method",
+                "sparse_coding_method",
+                "preserve_dc_atom"
+            ]
+        },
+        {
+            "id": "k_hubness_map_generation",
+            "name": "k-hubness map generation",
+            "members": [
+                "p_value"
+            ]
+        }
+    ],
+    "output-files": [
+        {
+            "id": "result",
+            "name": "Results directory",
+            "description": "Results directory containing:  k-hubness maps, atom maps and intermediate files. (file formats: MINC, NIfTI)",
+            "path-template": "[OUT_DIR]",
+            "optional": false
+        }
+    ],
+    "inputs": [
+        {
+            "id": "fmri_data",
+            "name": "fMRI data",
+            "description": "The fMRI data to analyze. (file formats: MINC, NIfTI)",
+            "type": "File",
+            "optional": false,
+            "command-line-flag": "--fmri-data",
+            "value-key": "[FMRI_DATA]"
+        },
+        {
+            "id": "mask",
+            "name": "Grey-matter mask",
+            "description": "Path to the grey-matter mask. (file formats: MINC, NIfTI)",
+            "type": "File",
+            "optional": false,
+            "command-line-flag": "--mask",
+            "value-key": "[MASK]"
+        },
+        {
+            "id": "out_dir",
+            "name": "Output name",
+            "description": "The name of the output directory.",
+            "type": "String",
+            "optional": false,
+            "command-line-flag": "--out-dir",
+            "value-key": "[OUT_DIR]"
+        },
+        {
+            "id": "nb_resampling",
+            "name": "Number of resampling",
+            "description": "Number of bootstrap resampling at the individual level. (recommended: 100)",
+            "type": "Number",
+            "optional": false,
+            "integer": true,
+            "minimum": 2,
+            "command-line-flag": "--nb-resampling",
+            "value-key": "[NB_RESAMPLING]"
+        },
+        {
+            "id": "network_scales",
+            "name": "Network scales",
+            "description": "Three numbers, respectively: [begin] [step] [end], used to create a regularly-spaced vector. In order to specify a single number, for instance '15', enter the same number for [begin] and [end], as: 15 1 15. This vector of numbers corresponds to the range of network scales to be tested. An optimal network scale is estimated from the specified set of numbers. (recommended: 10 2 30)",
+            "type": "Number",
+            "optional": false,
+            "list": true,
+            "integer": true,
+            "min-list-entries": 3,
+            "max-list-entries": 3,
+            "minimum": 1,
+            "command-line-flag": "--network-scales",
+            "value-key": "[NETWORK_SCALES]"
+        },
+        {
+            "id": "nb_iterations",
+            "name": "Number of iterations",
+            "description": "Number of iterations for the sparse dictionary learning.  (recommended: 20)",
+            "type": "Number",
+            "optional": false,
+            "integer": true,
+            "minimum": 2,
+            "command-line-flag": "--nb-iterations",
+            "value-key": "[NB_ITERATIONS]"
+        },
+        {
+            "id": "p_value",
+            "name": "P-Value",
+            "description": "Significance level, using a Z-test, for removing inconsistent elements in the average sparse coefficients (considered as the Gaussian noise) after spatial clustering (using a threshold).",
+            "type": "Number",
+            "optional": false,
+            "minimum": 0,
+            "maximum": 1,
+            "command-line-flag": "--p-value",
+            "value-key": "[P_VALUE]"
+        },
+        {
+            "id": "resampling_method",
+            "name": "Resampling method",
+            "description": "Method (from NIAK) used to resample the data under the null hypothesis. Note: If 'CBB' is selected, the option --block-window-length is used. [CBB]: Circular-block-bootstrap sample of multiple time series. [AR1B]: Bootstrap sample of multiple time series based on a semiparametric scheme mixing an auto-regressive temporal model and i.i.d. bootstrap of the 'innovations'. [AR1G]: (Bootstrap sample of multiple time series based on a parametric model of Gaussian data with arbitrary spatial correlations and first-order auto-regressive temporal correlations.",
+            "type": "String",
+            "optional": true,
+            "value-choices": [
+                "CBB",
+                "AR1B",
+                "AR1G"
+            ],
+            "value-disables": {
+                "CBB": [
+                ],
+                "AR1B": [
+                    "block_window_length"
+                ],
+                "AR1G": [
+                    "block_window_length"
+                ]
+            },
+            "value-requires": {
+                "CBB": [
+                    "block_window_length"
+                ],
+                "AR1B": [
+                ],
+                "AR1G": [
+                ]
+            },
+            "default-value": "CBB",
+            "command-line-flag": "--resampling-method",
+            "value-key": "[RESAMPLING_METHOD]"
+        },
+        {
+            "id": "block_window_length",
+            "name": "Block window length",
+            "description": "Three numbers, respectively: [begin] [step] [end], used to create a regularly-spaced vector. In order to specify a single number, for instance '15', enter the same number for [begin] and [end], as: 15 1 15. A number in this vector corresponds to a window length used in the circular block bootstrap. The unit of the window length is ‘time-point’ with each time-point indicating a 3D scan at each TR. If multiple numbers are specified, then a number is randomly selected from the list at each resampling. It is recommended to use a minimum of sqrt(T), where T is the total number of time points in the fMRI time-course. It is also recommended to randomize the window length to reduce a bias by window size.",
+            "type": "Number",
+            "optional": true,
+            "list": true,
+            "integer": true,
+            "min-list-entries": 3,
+            "max-list-entries": 3,
+            "minimum": 1,
+            "default-value": [10, 1, 30],
+            "command-line-flag": "--block-window-length",
+            "value-key": "[BLOCK_WINDOW_LENGTH]"
+        },
+        {
+            "id": "dict_init_method",
+            "name": "Dictionary initialization method",
+            "description": "If 'GivenMatrix' is selected, then the dictionary will be initialized by a random permutation of the raw data obtained in step 1. If 'DataElements' is selected, then the dictionary will be initialized by the first N (number of atoms) columns in the raw data obtained in step 1.",
+            "type": "String",
+            "optional": true,
+            "value-choices": [
+                "GivenMatrix",
+                "DataElements"
+            ],
+            "default-value": "GivenMatrix",
+            "command-line-flag": "--dict-init-method",
+            "value-key": "[DICT_INIT_METHOD]"
+        },
+        {
+            "id": "sparse_coding_method",
+            "name": "Sparse coding method",
+            "description": "Sparse coding method for the sparse dictionary learning.",
+            "type": "String",
+            "optional": true,
+            "value-choices": [
+                "OMP",
+                "Thresholding"
+            ],
+            "default-value": "Thresholding",
+            "command-line-flag": "--sparse-coding-method",
+            "value-key": "[SPARSE_CODING_METHOD]"
+        },
+        {
+            "id": "preserve_dc_atom",
+            "name": "Perserve first atom",
+            "description": "If set, then the first atom will be set to a constant and will never change, while all the other atoms will be trained and updated.",
+            "type": "Flag",
+            "optional": true,
+            "command-line-flag": "--preserve-dc-atom",
+            "value-key": "[PRESERVE_DC_ATOM]"
+        },
+        {
+            "id": "max_parallel_jobs",
+            "name": "Number of parallel jobs",
+            "description": "Maximum number of jobs to run in parallel.",
+            "type": "Number",
+            "optional": true,
+            "default-value": 12,
+            "command-line-flag": "--max-parallel-jobs",
+            "value-key": "[MAX_PARALLEL_JOBS]"
+        }
+    ],
+    "suggested-resources": {
+        "cpu-cores": 2,
+        "ram": 12,
+        "walltime-estimate": 100000
+    }
+}


### PR DESCRIPTION
@glatard @joeyzhou98 I need to change the path of these zenodo json files, momentarily. When I deploy the app on Heroku, it cannot find this `.cache` directory. So, I have commented out the `cache_dir` and updated it with a path inside `/static/pipelines/`. This is a hack to get the demo ready for Tuesday, this will no longer be necessary when we finish migrating to a production ubuntu server (it is currently in progress), where a `.cache` directory will be available. 