### PR TITLE
Dataset stats foreign key to dataset

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -140,12 +140,14 @@ def _seed_test_datasets_db(app):
             )
 
             db.session.add(dataset)
+        db.session.commit()
 
         dataset_stats_csvfile = os.path.join(
             app.root_path, "../test/datasets_stats.csv")
         with open(dataset_stats_csvfile, 'r') as datastat_csv:
             csv_reader = csv.DictReader(datastat_csv)
             for row in csv_reader:
+                dataset_id = Dataset.query.filter_by(dataset_id=row['dataset_id']).first().id
                 dataset_stat = DatasetStats(
                     dataset_id=row['dataset_id'],
                     size=row['size'],
@@ -155,7 +157,8 @@ def _seed_test_datasets_db(app):
                     num_downloads=row['num_downloads'],
                     num_likes=row['num_likes'],
                     num_views=row['num_views'],
-                    date_updated=datetime.utcnow()
+                    date_updated=datetime.utcnow(),
+                    fk_dataset_id=dataset_id
                 )
                 db.session.add(dataset_stat)
 

--- a/app/models.py
+++ b/app/models.py
@@ -238,7 +238,7 @@ class DatasetStats(db.Model):
     num_likes = db.Column(db.Integer, index=True)
     num_views = db.Column(db.Integer, index=True)
     date_updated = db.Column(db.DateTime, default=datetime.now())
-    fk_dataset_id = db.Column(db.Integer, db.ForeignKey('datasets.id'), nullable=False)
+    fk_dataset_id = db.Column(db.Integer, db.ForeignKey('datasets.id'), unique=True, nullable=False)
     dataset = db.relationship(Dataset, back_populates="stats")
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -238,7 +238,12 @@ class DatasetStats(db.Model):
     num_likes = db.Column(db.Integer, index=True)
     num_views = db.Column(db.Integer, index=True)
     date_updated = db.Column(db.DateTime, default=datetime.now())
-    fk_dataset_id = db.Column(db.Integer, db.ForeignKey('datasets.id'), unique=True, nullable=False)
+    fk_dataset_id = db.Column(
+        db.Integer,
+        db.ForeignKey('datasets.id'),
+        unique=True,
+        nullable=False
+    )
     dataset = db.relationship(Dataset, back_populates="stats")
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -216,6 +216,7 @@ class Dataset(db.Model):
     date_created = db.Column(db.DateTime, default=datetime.now())
     date_updated = db.Column(db.DateTime, default=datetime.now())
     is_private = db.Column(db.Boolean, index=True)
+    stats = db.relationship("DatasetStats", uselist=False, back_populates="dataset")
 
     def __repr__(self):
         return '<Dataset {}>'.format(self.name)
@@ -237,6 +238,8 @@ class DatasetStats(db.Model):
     num_likes = db.Column(db.Integer, index=True)
     num_views = db.Column(db.Integer, index=True)
     date_updated = db.Column(db.DateTime, default=datetime.now())
+    fk_dataset_id = db.Column(db.Integer, db.ForeignKey('datasets.id'), nullable=False)
+    dataset = db.relationship(Dataset, back_populates="stats")
 
 
 class Pipeline(db.Model):

--- a/app/static/lib/conp-react/src/DatasetElement/index.js
+++ b/app/static/lib/conp-react/src/DatasetElement/index.js
@@ -70,19 +70,19 @@ const DatasetElement = props => {
             </p>
             <p className="card-text text-muted">{element.format}</p>
           </li>
-          <li class="d-none d-md-flex">
+          <li className="d-none d-md-flex">
             <p className="card-text text-capitalize pr-1">
               <strong>Modalities: </strong>
             </p>
             <p className="card-text text-muted">{element.modalities}</p>
           </li>
-          <li class="d-none d-md-flex">
+          <li className="d-none d-md-flex">
             <p className="card-text text-capitalize pr-1">
               <strong>Date Added: </strong>
             </p>
             <p className="card-text text-muted">{element.dateAdded}</p>
           </li>{" "}
-          <li class="d-none d-md-flex">
+          <li className="d-none d-md-flex">
             <p className="card-text text-capitalize pr-1">
               <strong>Date Updated: </strong>
             </p>

--- a/app/threads.py
+++ b/app/threads.py
@@ -11,6 +11,7 @@ import os
 import logging
 import requests
 
+
 class UpdatePipelineData(threading.Thread):
     """
         Class that handles the threaded updating of the Pipeline
@@ -59,6 +60,7 @@ class UpdatePipelineData(threading.Thread):
         except Exception as e:
             logging.exception("An exception occurred in the thread.")
 
+
 class UpdateDatasets(threading.Thread):
     def __init__(self, path):
         super(UpdateDatasets, self).__init__()
@@ -78,10 +80,10 @@ class UpdateDatasets(threading.Thread):
             # first search for all descriptors
             datasets = json.loads(
                 requests.get('https://api.github.com/orgs/conpdatasets/repos')
-                    .content.decode('ascii')
-            );
+                .content.decode('ascii')
+            )
 
-            all_descriptors_filepath = os.path.join(self.cache_dir,"all_descriptors.json")
+            all_descriptors_filepath = os.path.join(self.cache_dir, "all_descriptors.json")
             print('here')
             with open(all_descriptors_filepath, "w") as f:
                 json.dump(datasets, f, indent=4)

--- a/app/threads.py
+++ b/app/threads.py
@@ -9,7 +9,7 @@ import threading
 import json
 import os
 import logging
-
+import requests
 
 class UpdatePipelineData(threading.Thread):
     """
@@ -55,6 +55,36 @@ class UpdatePipelineData(threading.Thread):
                                    "detailed_all_descriptors.json"),
                       "w") as f:
                 json.dump(detailed_all_descriptors, f, indent=4)
+
+        except Exception as e:
+            logging.exception("An exception occurred in the thread.")
+
+class UpdateDatasets(threading.Thread):
+    def __init__(self, path):
+        super(UpdateDatasets, self).__init__()
+        if not os.path.exists('logs'):
+            os.makedirs('logs')
+        logging.basicConfig(filename='logs/update_datasets_thread.log', level=logging.INFO)
+        self.cache_dir = path
+
+    def run(self):
+        try:
+            # if cache directory doesn't exist then create it
+            print(self.cache_dir)
+            if not os.path.exists(self.cache_dir):
+                print('yo')
+                os.makedirs(self.cache_dir)
+
+            # first search for all descriptors
+            datasets = json.loads(
+                requests.get('https://api.github.com/orgs/conpdatasets/repos')
+                    .content.decode('ascii')
+            );
+
+            all_descriptors_filepath = os.path.join(self.cache_dir,"all_descriptors.json")
+            print('here')
+            with open(all_descriptors_filepath, "w") as f:
+                json.dump(datasets, f, indent=4)
 
         except Exception as e:
             logging.exception("An exception occurred in the thread.")

--- a/migrations/versions/a756c32e9169_adding_one_to_one_relationship_for_.py
+++ b/migrations/versions/a756c32e9169_adding_one_to_one_relationship_for_.py
@@ -1,0 +1,61 @@
+"""adding one-to-one relationship for dataset stats
+
+Revision ID: a756c32e9169
+Revises: c4780889e90b
+Create Date: 2019-10-08 15:05:09.864185
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a756c32e9169'
+down_revision = 'c4780889e90b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+      "ALTER TABLE dataset_stats "
+      "ADD COLUMN fk_dataset_id INTEGER "
+      "REFERENCES datasets(id) " 
+    )
+    op.execute(
+      "UPDATE dataset_stats "
+      "SET fk_dataset_id = ("
+        "SELECT id FROM datasets "
+          "WHERE datasets.dataset_id = dataset_stats.dataset_id"
+      ")"
+    )
+
+
+def downgrade():
+    op.execute(
+      "CREATE TABLE tmp_dataset_stats AS "
+      "SELECT id, dataset_id, size, files, sources, "
+        "num_subjects, num_downloads, num_likes, "
+        "num_views, date_updated "
+      "FROM dataset_stats"
+    )
+    op.drop_index('ix_dataset_stats_dataset_id', table_name='dataset_stats')
+    op.drop_index('ix_dataset_stats_files', table_name='dataset_stats')
+    op.drop_index('ix_dataset_stats_num_downloads', table_name='dataset_stats')
+    op.drop_index('ix_dataset_stats_num_likes', table_name='dataset_stats')
+    op.drop_index('ix_dataset_stats_num_subjects', table_name='dataset_stats')
+    op.drop_index('ix_dataset_stats_num_views', table_name='dataset_stats')
+    op.drop_index('ix_dataset_stats_size', table_name='dataset_stats')
+    op.drop_index('ix_dataset_stats_sources', table_name='dataset_stats')
+    op.drop_table('dataset_stats')
+
+    op.execute("ALTER TABLE tmp_dataset_stats RENAME TO dataset_stats")
+    op.create_index('ix_dataset_stats_sources', 'dataset_stats', ['sources'], unique=False)
+    op.create_index('ix_dataset_stats_size', 'dataset_stats', ['size'], unique=False)
+    op.create_index('ix_dataset_stats_num_views', 'dataset_stats', ['num_views'], unique=False)
+    op.create_index('ix_dataset_stats_num_subjects', 'dataset_stats', ['num_subjects'], unique=False)
+    op.create_index('ix_dataset_stats_num_likes', 'dataset_stats', ['num_likes'], unique=False)
+    op.create_index('ix_dataset_stats_num_downloads', 'dataset_stats', ['num_downloads'], unique=False)
+    op.create_index('ix_dataset_stats_files', 'dataset_stats', ['files'], unique=False)
+    op.create_index('ix_dataset_stats_dataset_id', 'dataset_stats', ['dataset_id'], unique=1)
+    

--- a/migrations/versions/a756c32e9169_adding_one_to_one_relationship_for_.py
+++ b/migrations/versions/a756c32e9169_adding_one_to_one_relationship_for_.py
@@ -23,6 +23,10 @@ def upgrade():
       "REFERENCES datasets(id) " 
     )
     op.execute(
+      "CREATE UNIQUE INDEX ix_dataset_stats_fk_dataset_id "
+      "ON dataset_stats (fk_dataset_id) "
+    )
+    op.execute(
       "UPDATE dataset_stats "
       "SET fk_dataset_id = ("
         "SELECT id FROM datasets "
@@ -39,6 +43,7 @@ def downgrade():
         "num_views, date_updated "
       "FROM dataset_stats"
     )
+    op.drop_index('ix_dataset_stats_fk_dataset_id', table_name='dataset_stats')
     op.drop_index('ix_dataset_stats_dataset_id', table_name='dataset_stats')
     op.drop_index('ix_dataset_stats_files', table_name='dataset_stats')
     op.drop_index('ix_dataset_stats_num_downloads', table_name='dataset_stats')

--- a/test/insert_test_data_localhost.py
+++ b/test/insert_test_data_localhost.py
@@ -83,6 +83,8 @@ class InsertTestDataset(object):
             reader = csv.reader(dataset_stats_file)
             next(reader)
 
+            dataset = Dataset.query.filter_by(dataset_id=row[0]).first()
+
             for row in reader:
                 stat = DatasetStats(
                     dataset_id = row[0],
@@ -93,7 +95,8 @@ class InsertTestDataset(object):
                     num_downloads = row[5],
                     num_likes = row[6],
                     num_views = row[7],
-                    date_updated = datetime.now()
+                    date_updated = datetime.now(),
+                    fk_dataset_id = dataset.id
                 )
                 db.session.add(stat)
         db.session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,7 @@ def new_dataset_stats():
         num_downloads=0,
         num_likes=0,
         num_views=0,
-
+        fk_dataset_id=1,
     )
     return dataset_stats
 


### PR DESCRIPTION
This adds a constraint on the dataset_stats table to make sure it relates to a row in the dataset table.

## Implementation Detail
With sqlite limitations, adding a column to a table (`fk_dataset_id` in this case) requires to create a new table. The migration script is handling that.

_note_: This also fixes a react warning when html `class` attribute is used instead on `className` 
