### PR TITLE
Fix os.path.expanduser call

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -166,7 +166,7 @@ def _update_pipeline_data(app):
     """
     Updates from Zenodo the available pipelines
     """
-    thr = UpdatePipelineData(path=os.path.join(os.path.expanduser('-'),
+    thr = UpdatePipelineData(path=os.path.join(os.path.expanduser('~'),
                                                ".cache", "boutiques"))
     thr.start()
     thr.join()


### PR DESCRIPTION
The update_pipeline_data cli command was calling expanduser with
an argument of '-' instead of '~' to represent the user's home
directory.

Fix the call to use the correct tilde expansion.
