### PR TITLE
Fix URL in pipeline search page

### DIFF
--- a/app/templates/pipelines.html
+++ b/app/templates/pipelines.html
@@ -33,7 +33,7 @@
 
     <script type="text/javascript">
       const reactElement = React.createElement(CONPReact.DataTableContainer, {
-        endpointURL: "/dataset-search",
+        endpointURL: "/pipeline-search",
         limit: 10,
         imagePath: "/static/img",
         renderElement: CONPReact.PipelineElement


### PR DESCRIPTION
The pipeline search page was pointing to the dataset-search URL.
Since both endpoints JSON have the same structure, this was resulting
in the page loading a list of datasets instead of a list of pipelines.

Fixing the URL is all that's required to fix the page since the JSON
of both endpoints is structured the same way.