### PR TITLE
Remove pipeline-search side-effects

### DIFF
--- a/app/pipelines/routes.py
+++ b/app/pipelines/routes.py
@@ -61,28 +61,12 @@ def pipeline_search():
     all_desc_path = os.path.join(cache_dir, "all_descriptors.json")
     all_detailed_desc_path = os.path.join(cache_dir, "detailed_all_descriptors.json")
 
-    if not os.path.exists(all_desc_path) or \
-        not os.path.exists(all_detailed_desc_path):
-        print("--- no files need to update")
-        thr = UpdatePipelineData(path=cache_dir)
-        thr.start()
-        thr.join()
-
-
     # fetch data from cache
-
     with open(all_desc_path, "r") as f:
         all_descriptors = json.load(f)
 
     with open(all_detailed_desc_path, "r") as f:
         detailed_all_descriptors = json.load(f)
-
-    # if the cache data older than 5min or 300 seconds, update in background
-    delta = time.time() - os.path.getmtime(all_desc_path)
-    if delta > 300:
-        print("Pipeline database older than 5 minutes, updating...")
-        UpdatePipelineData(path=cache_dir).start()
-
 
     # search cache with search query else return everything
     if search_query not in ("", '', None):

--- a/tests/blueprint_specific_tests/pipelines_bp_tests/test_pipelines_endpoints.py
+++ b/tests/blueprint_specific_tests/pipelines_bp_tests/test_pipelines_endpoints.py
@@ -3,8 +3,10 @@
 Unit tests for endpoints in the pipelines blueprint
 """
 import pytest
+import app.cli as cli
 from urllib.parse import urlparse
 from flask import url_for
+
 
 
 def test_pipelines_route(test_client):
@@ -17,7 +19,7 @@ def test_pipelines_route(test_client):
     assert res.status_code == 200
 
 
-def test_pipeline_search_route(session, new_pipeline, test_client):
+def test_pipeline_search_route(session, new_pipeline, test_client, app, runner):
     """
     GIVEN calling the route "/pipeline-search"
     WHEN no user is logged in
@@ -27,6 +29,9 @@ def test_pipeline_search_route(session, new_pipeline, test_client):
 
     session.add(new_pipeline)
     session.commit()
+
+    cli.register(app)
+    result = runner.invoke(args=["update_pipeline_data"])
 
     headers = {'Content-Type': 'application/json'}
     res = test_client.get("/pipeline-search", headers = headers)


### PR DESCRIPTION
GitHub Issue #95 points out that pipeline cache updating
is currently done in odd places. In particular, it's done
by a background thread spawned by the pipeline-search endpoint
if either:

1. The cache directory doesn't exist
2. The cache directory is more than 5 minutes old

PR #103 fixes the bug which was preventing the
`flask update_pipeline_data` command from populating the cache,
which means the updating can be done on a periodic-basis from
cron now instead of spawning threads with side-effects when
searching for pipelines.