### PR TITLE
remove datalad dep in datsdataset

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -1,15 +1,12 @@
 import os
 import json
 import fnmatch
-from datalad.api import Dataset as DataladDataset
 
 class DATSDataset(object):
     def __init__(self, datasetpath):
         """
           store the datsetopath and tries to find a DATS.json file
         """
-
-        dataset = DataladDataset(path=datasetpath)
         if not os.path.isdir(datasetpath):
             raise 'No dataset found at {}'.format(datasetpath)
         self.datasetpath = datasetpath


### PR DESCRIPTION
Remove import datalad in datsdataset. I wasn't used and was causing weird error on the portal.

`FileNotFoundError: [Errno 2] No such file or directory: 'git': 'git'`

```
gunicorn[14063]:     from app.search.models import DATSDataset
gunicorn[14063]:   File "/home/conp-admin/conp-portal/app/search/__init__.py", line 4, in <module>
gunicorn[14063]:     from app.search import routes  # noqa: E402
gunicorn[14063]:   File "/home/conp-admin/conp-portal/app/search/routes.py", line 17, in <module>
gunicorn[14063]:     from app.search.models import DATSDataset
gunicorn[14063]:   File "/home/conp-admin/conp-portal/app/search/models.py", line 4, in <module>
gunicorn[14063]:     from datalad import api as DataladDataset
gunicorn[14063]:   File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/datalad/__init__.py", line 55, in <module>
gunicorn[14063]:     cfg = ConfigManager()
gunicorn[14063]:   File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/datalad/config.py", line 208, in __init__
gunicorn[14063]:     self.reload(force=True)
gunicorn[14063]:   File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/datalad/config.py", line 262, in reload
gunicorn[14063]:     stdout, stderr = self._run(run_args, log_stderr=True)
gunicorn[14063]:   File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/datalad/config.py", line 530, in _run
gunicorn[14063]:     out = self._runner.run(['git', 'config'] + args, **kwargs)
gunicorn[14063]:   File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/datalad/cmd.py", line 689, in run
gunicorn[14063]:     cmd, env=self.get_git_environ_adjusted(env), *args, **kwargs)
gunicorn[14063]:   File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/datalad/cmd.py", line 500, in run
gunicorn[14063]:     stdin=stdin)
gunicorn[14063]:   File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
gunicorn[14063]:     restore_signals, start_new_session)
gunicorn[14063]:   File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
gunicorn[14063]:     raise child_exception_type(errno_num, err_msg, err_filename)
gunicorn[14063]: FileNotFoundError: [Errno 2] No such file or directory: 'git': 'git'
```