### PR TITLE
fix typo between licence and license

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -110,7 +110,7 @@ class DATSDataset(object):
         return formats
 
     @property
-    def licences(self):
+    def licenses(self):
         licenseString = self.descriptor.get('licenses', 'None')
         if type(licenseString) == list:
             licenses = ", ".join([x['name'] for x in licenseString])
@@ -122,7 +122,7 @@ class DATSDataset(object):
             elif 'dataUsesConditions' in licenseString:
                 licenses = licenseString['dataUsesConditions']
             else:
-                licences = licenseString
+                licenses = licenseString
 
         return licenses
 

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -296,6 +296,6 @@ def get_dataset_metadata_information(dataset):
         "description": datsdataset.description,
         "contact": datsdataset.contacts,
         "version": datsdataset.version,
-        "licenses": datsdataset.licences
+        "licenses": datsdataset.licenses
     }
 


### PR DESCRIPTION
fix a typo that was causing the portal to crash when asking for a dataset detail where the DATS.json do not contain a license property.