### PR TITLE
Skip invalid datasets

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -12,7 +12,10 @@ class DATSDataset(object):
         self.datasetpath = datasetpath
 
         with open(self.DatsFilepath, 'r') as f:
-            self.descriptor = json.load(f)
+            try:
+                self.descriptor = json.load(f)
+            except Exception as e:
+                raise 'Can`t parse {}'.format(self.DatsFilepath)
 
     @property
     def DatsFilepath(self):

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -106,7 +106,13 @@ def dataset_search():
 
     # Build dataset response
     for d in datasets:
-        datsdataset = DATSDataset(d.fspath)    
+        try:
+            datsdataset = DATSDataset(d.fspath)
+        except Exception as e:
+            # If the DATS file can't be laoded, skip this dataset.
+            # There should be an error message in the logs/update_datsets.log
+            continue
+
         dataset = {
             "authorized": authorized,
             "id": d.dataset_id,


### PR DESCRIPTION
This will skip datasets from which the DATS.json can't be parsed from showing in the /dataset_search endpoint response.

