### PR TITLE
page 1 as default instead of 0

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -133,7 +133,7 @@ def dataset_search():
         }
         elements.append(dataset)
 
-    delta = int(request.args.get('max_per_page', 10)) * (int(request.args.get('page', 0)) - 1 )
+    delta = int(request.args.get('max_per_page', 10)) * (int(request.args.get('page', 1)) - 1 )
     cursor = max(min(int(request.args.get('cursor') or 0), 0), 0) + delta
     limit = max(min(int(request.args.get('limit') or 10), 10), 0)
     sort_key = request.args.get('sortKey') or "conpStatus"


### PR DESCRIPTION
having 0 as default value for page number was causing the slice of the array to start at index -1.

This should fix the dashboard missing dataset bars
 