### PR TITLE
Adding content in template

### DIFF
--- a/app/templates/common/base_main.html
+++ b/app/templates/common/base_main.html
@@ -54,7 +54,66 @@ CONP Portal
         </button>
       </div>
       <div class="modal-body">
-        Terms go here
+Acceptance of Terms
+By using or visiting CONP website (the "Website", or the "Portal"), you agree to these terms and conditions (the "Terms"). CONP may, in its sole discretion, revise these Terms at any time without advance notice to you. You are bound by such revisions by continuing to use or visit the Website after they are posted online.
+<br>
+CONP portal
+These Terms apply to all users of the Portal, including users who contribute content to the Portal. The Website may contain interactive areas designed to allow you to post content on the Website and/or comment, including by commenting on our blogs. The use of these features is additionally governed by the Code of Conduct.
+<br>
+The Website may contain links to third party websites that are not owned or controlled by CONP. The links to the third party websites are provided for your convenience, and the inclusion of the links does not imply approval or endorsement of the third party websites by CONP. CONP has no control over, and assumes no responsibility for, the content, privacy policies, or practices of any third party websites.
+<br>
+User Accounts
+To access some features of the Website, you may have to register for a CONP user account. When registering for your user account, you must provide accurate and complete information. You are solely responsible for the activity that occurs on your user account, and you must keep your account password secure. You must notify CONP immediately of any breach of security or unauthorized use of your user account.
+<br>
+4.Ownership of Website Content
+<br>
+4.Ownership of Website Content
+As between you and CONP portal, CONP portal owns all intellectual property rights, including without limitation copyright and trade-mark rights, in all materials on or comprising the Website portal, including, without limitation, all written, audio visual or other materials and graphical elements on the Website. As between you and the portal content, all content should be use with their respective licenses, but excluding all content for which a licence or a term of used is found associated with the content including but not restricted data and pipelines. By agreeing with this term of use, you agree to abide by the licenses associated with the research objects accessible through the portal. In any case, you agree by using the CONP portal to not attempt to reidentify any human participant data accessible through the portal.
+<br>
+4.Ownership of Website Content
+User Content; Privacy
+You may be able to post or upload (in designated areas of the Website) written content or other content such as data, metadata, pipelines, etc (collectively "User Content") to the Website. You are solely responsible for your own User Content and the consequences of posting or publishing it. By uploading or posting User Content to the Website, you automatically grant CONP the right to make this content accessible for the purpose of sharing the User Content with users of the portal and to promote the portal. You represent and warrant that you have the rights to use and license this content in the manner contemplated by the portal and these Terms.
+<br>
+By accessing and/or using the portal, you may provide us with personal information as described in our Privacy Policy. You acknowledge that you have read and understood our Privacy Policy, which governs the collection, use, storage and disclosure of such personal information.
+<br>
+DISCLAIMER
+YOUR USE OF THIS WEBSITE IS ENTIRELY AT YOUR OWN RISK. THE WEBSITE AND CONTENT IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF MERCHANTABILITY, MERCHANTABLE QUALITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, OR NON-INFRINGEMENT. CONP DOES NOT WARRANT THAT THE WEBSITE OR CONTENT CONTAINED IN THIS WEBSITE WILL BE UNINTERRUPTED OR ERROR-FREE, THAT DEFECTS WILL BE CORRECTED, OR THAT THIS WEBSITE OR THE SERVER THAT MAKES IT AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS.
+<br>
+WITHOUT LIMITING THE FOREGOING, CONP DOES NOT WARRANT OR MAKE ANY REPRESENTATION REGARDING USE, THE ABILITY TO USE, OR THE RESULT OF USE OF THE CONTENT IN TERMS OF ACCURACY, RELIABILITY, OR OTHERWISE. THE CONTENT MAY INCLUDE TECHNICAL INACCURACIES OR TYPOGRAPHICAL ERRORS. CONP MAY MAKE CHANGES OR IMPROVEMENTS TO THE CONTENT OR THE WEBSITE AT ANY TIME. CONP MAKES NO WARRANTIES THAT YOUR USE OF THE CONTENT WILL NOT INFRINGE THE RIGHTS OF OTHERS AND ASSUMES NO LIABILITY OR RESPONSIBILITY FOR ERRORS OR OMISSIONS IN SUCH CONTENT.
+CONP, ITS EMPLOYEES, AGENTS, OFFICERS AND DIRECTORS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, PUNITIVE, CONSEQUENTIAL, SPECIAL, EXEMPLARY, OR OTHER DAMAGES, INCLUDING, WITHOUT LIMITATION, LOSS OF REVENUE OR INCOME, PAIN AND SUFFERING, EMOTIONAL DISTRESS, OR SIMILAR DAMAGES, OR DAMAGES RESULTING FROM ANY (I) ERRORS OR OMISSIONS IN CONTENT, (II) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (III) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM OUR WEBSITE, (IV) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE, WHICH MAY BE TRANSMITTED TO OR THROUGH OUR WEBSITE BY ANY THIRD PARTY, OR (V) FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF YOUR USE OF ANY CONTENT POSTED, EMAILED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE WEBSITE. THIS LIMITATION OF LIABILITY APPLIES REGARDLESS OF THE LEGAL THEORY GIVING RISE TO THE DAMAGES, AND EVEN IF CONP HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE FOREGOING LIMITATION OF LIABILITY SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW IN THE APPLICABLE JURISDICTION.
+<br>
+YOU SPECIFICALLY ACKNOWLEDGE THAT CONP, ITS EMPLOYEES, AGENTS, OFFICERS AND DIRECTORS SHALL NOT BE LIABLE FOR USER CONTENT OR THE DEFAMATORY, OFFENSIVE, OR ILLEGAL CONDUCT OF ANY THIRD PARTY AND THAT THE RISK OF HARM OR DAMAGE FROM THE FOREGOING RESTS ENTIRELY WITH YOU.
+<br>
+INDEMNITY
+YOU AGREE TO DEFEND, INDEMNIFY AND HOLD HARMLESS CONP, ITS EMPLOYEES, AGENTS, OFFICERS AND DIRECTORS FROM AND AGAINST ANY AND ALL CLAIMS, DAMAGES, OBLIGATIONS, JUDGMENTS, LOSSES, LIABILITIES, COSTS OR DEBT, ATTORNEY'S FEES AND OTHER EXPENSES ARISING FROM: (I) YOUR USE OF AND ACCESS TO THE WEBSITE; (II) YOUR VIOLATION OF ANY THIRD PARTY RIGHT, INCLUDING WITHOUT LIMITATION ANY COPYRIGHT, PROPERTY, OR PRIVACY RIGHT; OR (III) ANY CLAIM THAT YOU DID NOT HAVE THE RIGHT TO PROVIDE ANY USER CONTENT OR THAT YOUR USER CONTENT CAUSED DAMAGE TO A THIRD PARTY. THIS DEFENSE AND INDEMNIFICATION OBLIGATION WILL SURVIVE THESE TERMS AND YOUR USE OF THE WEBSITE. IN SUCH A CASE, CONP WILL PROVIDE YOU WITH WRITTEN NOTICE OF SUCH CLAIM, SUIT OR ACTION.
+<br>
+Miscellaneous
+You affirm that you are either more than 18 years of age, or possess parental or guardian consent to agree to these Terms and access and use the Website, and are otherwise fully able and competent to enter into the terms, conditions, obligations, affirmations, representations, and warranties set forth in these Terms, and to abide by and comply with these Terms.
+<br>
+These Terms will be governed by and construed in accordance with the laws of the Province of Ontario, Canada, without giving effect to its conflict of laws provisions. You agree to submit to the personal and exclusive jurisdiction of the courts located in the Province of Ontario, Canada. The Website is physically maintained and operated by CONP from the Province of Ontario.
+<br>
+You may not assign these Terms or assign any rights or delegate any obligations under these Terms, in whole or in part, whether voluntarily or by operation of law, without our prior written consent.
+<br>
+These Terms constitute the entire agreement between you and CONP with respect to the subject matter and supersede and replace all prior or contemporaneous understandings or agreements, written or oral, regarding such subject matter. If for any reason a court of competent jurisdiction finds any provision or portion of the Terms to be unenforceable, the remaining provisions of the Terms will continue in full force and effect.
+<br>
+In the event of any inconsistency between the English and French versions of these Terms, the English version shall govern.
+<br>
+Code of Conduct
+a. You may not use the CONP Website for any illegal or unauthorized purpose. In addition to the laws of the Province of Quebec, Canada, you also agree to comply with all local laws that apply to your use of the Website.
+<br>
+b. You may not use the Website in any manner which could disable, overburden, damage, or impair the Website, CONP’s servers or computer network, or interfere with any other party's use of the Website.
+<br>
+c. You agree that you are responsible for your own conduct and communications while using the Website and for any consequences of that use. By way of example, and not as a limitation, you agree that when using the Website, you will not:
+<br>
+post or upload any inappropriate, promotional, defamatory, destructive, obscene, or unlawful content;
+defame, abuse, harass, stalk, threaten or otherwise violate the legal rights (such as rights of privacy and publicity) of others;
+post or upload any User Content that infringes any patent, trademark, copyright, trade secret or other intellectual property right of any party;
+impersonate another person, or falsify or delete any author attributions, legal or other proper notices or proprietary designations or labels of the origin or source of any content;
+use the Website in connection with surveys, contests, junk email, spamming or any duplicative messages (commercial or otherwise);
+use any robot, spider, site search/retrieval application, or other device to retrieve or index any portion of the Website to collect information about other users or domain names;
+upload files that contain bugs, viruses, trojan horses, worms, or any other similar software or programs that may damage the operation of the computer or property of another; or
+submit User Content that falsely expresses or implies that such User Content is sponsored or endorsed by any party where it is not sponsored or endorsed by such party.
+d. CONP reserves the right to monitor use of this Website to determine compliance with these Terms. Although CONP does not read, review, vet or otherwise assess User Content in advance of its posting, CONP reserves the right to remove any User Content and/or terminate your CONP User Account without notice for breach or for any other reason.
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" id="btnAcceptTerms">Accept</button>


### PR DESCRIPTION
## Related issues
https://github.com/CONP-PCNO/conp-portal/issues/158


## Current behaviour
"term of use goes here" is displayed

## New behaviour
actual content is displayed
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
The template file contains the text. It might be desirable to have the content in a dedicated file.



