### PR TITLE
Fix truncated dataset names

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -9,6 +9,7 @@ class DATSDataset(object):
         """
         if not os.path.isdir(datasetpath):
             raise 'No dataset found at {}'.format(datasetpath)
+
         self.datasetpath = datasetpath
 
         with open(self.DatsFilepath, 'r') as f:
@@ -16,6 +17,10 @@ class DATSDataset(object):
                 self.descriptor = json.load(f)
             except Exception as e:
                 raise 'Can`t parse {}'.format(self.DatsFilepath)
+
+    @property
+    def name(self):
+        return os.path.basename(self.datasetpath)
 
     @property
     def DatsFilepath(self):

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -2,6 +2,7 @@ import os
 import json
 import fnmatch
 
+
 class DATSDataset(object):
     def __init__(self, datasetpath):
         """
@@ -20,7 +21,7 @@ class DATSDataset(object):
 
     @property
     def name(self):
-        return os.path.basename(self.datasetpath)
+        return self.datasetpath.split('conp-dataset/projects/')[-1]
 
     @property
     def DatsFilepath(self):

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -223,10 +223,10 @@ def dataset_info():
         authorized = True
     else:
         authorized = False
-
+    print(str(d))
     dataset = {
         "authorized": authorized,
-
+        "name": datsdataset.name,
         "id": d.dataset_id,
         "title": d.name.replace("'", ""),
         "isPrivate": d.is_private,

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -53,18 +53,18 @@
   </div>
 </div>
 
+<h2 class="card-title">Download Options</h2>
+Download is enabled through <a style="color: blue;" href="http://handbook.datalad.org/en/latest/intro/installation.html#install">datalad</a>
+<br>
+Here are commands to download content from this dataset:
 <div class="card">
   <div class="card-body">
-    <h2 class="card-title">Download Options</h2>
     <pre class="card-text" style="white-space: pre-wrap;">
-# Download is enabled through <a style="color: blue;" href="http://handbook.datalad.org/en/latest/intro/installation.html#install">datalad</a>
-      
-# Here are commands to download content from this dataset:
-    ~$ datalad install https://github.com/CONP-PCNO/conp-dataset.git
-    ~$ cd conp-dataset
-    ~$ datalad install {{data.id}}
-    ~$ cd {{data.id}}
-    ~$ datalad get &ltfilepath&gt
+datalad install https://github.com/CONP-PCNO/conp-dataset.git
+cd conp-dataset
+datalad install projects/{{data.name}}
+cd projects/{{data.name}}
+datalad get &ltfilepath&gt
     </pre>
   </div>
 </div>


### PR DESCRIPTION
Fixes #181 

Also change the Download option presentation to make the commands copy-paste-able.

Before:
![before](https://user-images.githubusercontent.com/12155214/78265296-42bf2a00-74d2-11ea-9e31-4b9fcf67c9d8.png)


After:
![after](https://user-images.githubusercontent.com/12155214/78265264-363ad180-74d2-11ea-9fa4-689fb5be657a.png)
