### PR TITLE
remove ability to dismiss terms dialog

### DIFF
--- a/app/templates/common/base_main.html
+++ b/app/templates/common/base_main.html
@@ -43,15 +43,12 @@ CONP Portal
 {{ super() }}
 
 <!-- Modal -->
-<div class="modal fade" id="termsModal" tabindex="-1" role="dialog" aria-labelledby="modalCenterTitle"
+<div class="modal fade" id="termsModal" tabindex="-1" role="dialog" data-backdrop="static" data-keyboard="false" aria-labelledby="modalCenterTitle"
   aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title w-100 text-center" id="modalLongTitle">Terms of Use</h4>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
       </div>
       <div class="modal-body">
         <div class="terms-body">


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#221 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
Don't allow the user to dismiss the terms of use dialog without accepting
 
#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
The modal which shows the terms of use has been modified to remove the dismiss 'X' at the top right. Also, dismissing by keyboard or by clicking outside the modal has been disabled

