### PR TITLE
add notice to dataset page for private datasets

### DIFF
--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -28,6 +28,11 @@
 
 <div class="d-flex flex-column p-4">
   <h2>Download Options</h2>
+  {% if data.authorizations == "private" %}
+  <div class="alert alert-info" role="alert">
+    <strong>Note: </strong>an account is required to access this dataset. Please follow the Source URL and request an
+    account on the source page.</div>
+  {% endif %}
   <p>Download is enabled through <a
       href="http://handbook.datalad.org/en/latest/intro/installation.html#install">datalad</a></p>
   <p>Here are commands to download content from this dataset:</p>


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#217 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
A notice is added to dataset.html for private datasets directing the user on how to access
 
#### Does this introduce a major change?
- [ ] Yes
- [ ] No

