### PR TITLE
add faq page, fetch content from github

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -31,7 +31,6 @@ def share():
     """ Share Route
 
         Route to lead to the share page
-        CURRENTLY NOT WORKING
 
         Args:
             None
@@ -57,3 +56,34 @@ def share():
     content = response.text
 
     return render_template('share.html', title='CONP | Share a Dataset', user=current_user, content=content)
+
+@main_bp.route('/faq')
+def faq():
+    """ FAQ Route
+
+        Route to lead to the faq page
+
+        Args:
+            None
+
+        Returns:
+            rendered template for faq.html
+    """
+
+    url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/CONP_FAQ.md'
+    headers = {'Content-type': 'text/html; charset=UTF-8'}
+    response = requests.get(url, headers=headers)
+
+    faqRaw = response.text
+
+    url = 'https://api.github.com/markdown'
+    body = {
+        "text": faqRaw,
+        "mode": "gfm",
+        "context": "github/gollum"
+    }
+    response = requests.post(url, json=body)
+
+    content = response.text
+
+    return render_template('faq.html', title='CONP | FAQ', user=current_user, content=content)

--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -1,0 +1,13 @@
+{% extends 'base_public.html' %}
+
+<!-- Title Block -->
+
+{% block title %}
+<h2><span style="color:red;">CONP Portal </span> | FAQ</h2>
+{% endblock %}
+
+<!-- Content Block -->
+
+{% block content %}
+{{ content|safe }}
+{% endblock %}

--- a/app/templates/fragments/sidebar.html
+++ b/app/templates/fragments/sidebar.html
@@ -28,8 +28,7 @@
     </p>
   </a>
   <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3  sidebar-tab"
-    target="_blank" rel="noopener noreferrer"
-    href="https://github.com/CONP-PCNO/conp-documentation/blob/master/CONP_FAQ.md">
+    href="{{ url_for('main.faq') }}">
     <h1><i class="fa fa-info-circle"></i></h1>
     <p class="text-center text-capitalize p-1">
       FAQ


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#220 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
This adds an faq.html page, rather than linking externally
 
#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Content is pulled from the FAQ in conp-documentation on Github. It's then rendered in the same way the share page currently works.

