### PR TITLE
Remove the year from the footer of HTML pages

### DIFF
--- a/app/templates/fragments/footer.html
+++ b/app/templates/fragments/footer.html
@@ -7,7 +7,7 @@
       class="col-sm-6 d-flex flex-column justify-content-center align-items-center text-center py-4 px-4"
     >
       <h5 class="py-2">
-        Canadian Open Neuroscience Platform (2019)
+        Canadian Open Neuroscience Platform 
       </h5>
 
       <a class="footer-link" href="https://github.com/CONP-PCNO/conp-portal"


### PR DESCRIPTION
Removes the year displayed in the footer of HTML pages.

## Related issues

#198 


## Checklist
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

#### Does this introduce a major change?
- [ ] Yes
- [x] No

