### PR TITLE
add dataset readme, use GitHub markdown rendering

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -53,7 +53,18 @@ class DATSDataset(object):
 
         return logopath
 
+    @property
+    def ReadmeFilepath(self):
+        dirs = os.listdir(self.datasetpath)
+        for file in dirs:
+            if fnmatch.fnmatch(file.lower(), 'readme.md'):
+                readme = os.path.join(self.datasetpath, file)
+                break
 
+        if readme == None:
+            raise 'No Readme found'
+
+        return readme
 
     @property
     def authors(self):

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -86,6 +86,10 @@
     </a>.
   </h6>
 </div>
+<div class="d-flex flex-column p-4">
+  <h2>Dataset README information</h2>
+  <p>{{readme|safe}}</p>
+</div>
 
 <script type="text/javascript">
 

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -19,14 +19,15 @@
 
 <div class="d-flex flex-column p-4">
   <p><strong>Version: </strong> {{ metadata.version }} </p>
-  <p><strong>Source: </strong><a target="_blank" rel="noopener noreferrer" href="{{ metadata.sources }}">{{ metadata.sources }}</a></p>
+  <p><strong>Source: </strong><a target="_blank" rel="noopener noreferrer"
+      href="{{ metadata.sources }}">{{ metadata.sources }}</a></p>
   <p><strong>Authors: </strong>{{ metadata.authors }}</p>
   <p><strong>Contact: </strong> {{ metadata.contact }}</p>
   <p><strong>Description: </strong> {{ metadata.description|safe }}</p>
   <p><strong>Licenses: </strong> {{ metadata.licenses }}</p>
 </div>
 
-<div class="d-flex flex-column p-4">
+<div class="d-flex flex-column p-2">
   <h2>Dataset Download Instructions</h2>
   {% if data.authorizations == "private" %}
   <div class="alert alert-info" role="alert">
@@ -34,12 +35,13 @@
     account on the source page.</div>
   {% endif %}
   <p>
-    The following instructions require a basic understanding of UNIX/LINUX command lines. Future portal functionality may 
-    include downloads directly from the web browser. Dataset download is currently enabled through 
+    The following instructions require a basic understanding of UNIX/LINUX command lines. Future portal functionality
+    may
+    include downloads directly from the web browser. Dataset download is currently enabled through
     <a target="_blank" rel="noopener noreferrer" href="https://www.datalad.org/">DataLad</a>.
   </p>
   <p>
-    To install DataLad on your system, please refer to the 
+    To install DataLad on your system, please refer to the
     <a target="_blank" rel="noopener noreferrer"
       href="http://handbook.datalad.org/en/latest/intro/installation.html#install">
       install section of the DataLad Handbook
@@ -47,21 +49,26 @@
     (installation via miniconda is recommended in order to obtain the latest version of DataLad).
   </p>
   <h6>1) Initiate the CONP dataset</h6>
-  <p>To initiate the CONP dataset (<code>conp-dataset</code>), run the following command in the directory where you want CONP datasets to be installed:</p>
+  <p>To initiate the CONP dataset (<code>conp-dataset</code>), run the following command in the directory where you want
+    CONP datasets to be installed:</p>
   <div class="card">
     <div class="card-body">
-      <pre class="card-text" style="white-space: pre-wrap;">datalad install https://github.com/CONP-PCNO/conp-dataset.git</pre>
+      <pre class="card-text"
+        style="white-space: pre-wrap;">datalad install https://github.com/CONP-PCNO/conp-dataset.git</pre>
     </div>
   </div>
   <h6>2) Install the {{data.name}} dataset</h6>
-  <p>To install the dataset, go into the created conp-dataset directory and run <code>datalad install</code> on the dataset <code>{{data.name}}</code>:</p>
+  <p>To install the dataset, go into the created conp-dataset directory and run <code>datalad install</code> on the
+    dataset <code>{{data.name}}</code>:</p>
   <div class="card">
     <div class="card-body">
-      <pre class="card-text" style="white-space: pre-wrap;">cd conp-dataset<br>datalad install projects/{{data.name}}</pre>
+      <pre class="card-text"
+        style="white-space: pre-wrap;">cd conp-dataset<br>datalad install projects/{{data.name}}</pre>
     </div>
   </div>
   <h6>3) Download the {{data.name}} dataset</h6>
-  <p>Now that the DataLad dataset has been installed, go into the dataset directory under <code>projects/{{data.name}}</code>.</p>
+  <p>Now that the DataLad dataset has been installed, go into the dataset directory under
+    <code>projects/{{data.name}}</code>.</p>
   <div class="card">
     <div class="card-body">
       <pre class="card-text" style="white-space: pre-wrap;">cd projects/{{data.name}}</pre>
@@ -69,7 +76,8 @@
   </div>
   <p></p>
   <p>
-    Note that files visible in the dataset are symlinks and will need to be downloaded manually using the <code>datalad get</code> 
+    Note that files visible in the dataset are symlinks and will need to be downloaded manually using the
+    <code>datalad get</code>
     command in the dataset directory:
   </p>
   <div class="card">
@@ -78,17 +86,24 @@
     </div>
   </div>
   <p></p>
-  <p>Note, if you run <code>datalad get *</code> command, all the files present in the dataset directory will be downloaded.</p>
-  <h6>For more information on how DataLad works, please visit the 
-    <a target="_blank" rel="noopener noreferrer"
-      href="http://handbook.datalad.org/en/latest/">
+  <p>Note, if you run <code>datalad get *</code> command, all the files present in the dataset directory will be
+    downloaded.</p>
+  <h6>For more information on how DataLad works, please visit the
+    <a target="_blank" rel="noopener noreferrer" href="http://handbook.datalad.org/en/latest/">
       DataLad Handbook documentation
     </a>.
   </h6>
 </div>
-<div class="d-flex flex-column p-4">
+<div class="d-flex flex-column p-2">
   <h2>Dataset README information</h2>
-  <p>{{readme|safe}}</p>
+  <div class="card">
+    <div class="card-header">
+      README.md
+    </div>
+    <div class="card-body">
+      <p>{{readme|safe}}</p>
+    </div>
+  </div>
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#245 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
This PR displays the dataset readme at the bottom of the `dataset.html` page
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Again, it seems beneficial to use the Github markdown rendering API for this. Using generic markdown rendering left out important css attributes for some datasets, which led to images being rendered much too large for their containers, etc

