### PR TITLE
Fixing spacing between download instructions

### DIFF
--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -57,6 +57,7 @@
         style="white-space: pre-wrap;">datalad install https://github.com/CONP-PCNO/conp-dataset.git</pre>
     </div>
   </div>
+  <p></p>
   <h6>2) Install the {{data.name}} dataset</h6>
   <p>To install the dataset, go into the created conp-dataset directory and run <code>datalad install</code> on the
     dataset <code>{{data.name}}</code>:</p>
@@ -66,6 +67,7 @@
         style="white-space: pre-wrap;">cd conp-dataset<br>datalad install projects/{{data.name}}</pre>
     </div>
   </div>
+  <p></p>
   <h6>3) Download the {{data.name}} dataset</h6>
   <p>Now that the DataLad dataset has been installed, go into the dataset directory under
     <code>projects/{{data.name}}</code>.</p>


### PR DESCRIPTION
This fixes some spacing issues I noticed on the dataset download instructions section during the demo today.



## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

#### Does this introduce a major change?
- [ ] Yes
- [x] No

