### PR TITLE
don't use TEXT column as index

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -202,7 +202,7 @@ class Dataset(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     dataset_id = db.Column(db.String(256), index=True, unique=True)
-    description = db.Column(db.Text, index=True)
+    description = db.Column(db.Text)
     name = db.Column(db.String(256), index=True)
     fspath = db.Column(db.Text)
     version = db.Column(db.String(6), index=True)


### PR DESCRIPTION
---
name: Remove index from TEXT column in Dataset db model
about: This removes the index from the dataset description column
labels: bug

---

## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#270 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->

Recently, our database migrations using Flask-Migrate were updated to include schema changes such as column types and indexes, etc. The production database cannot synchronize because a schema change made in the past cannot be applied. See below:

`(venv) conp-admin@portal:~/conp-portal$ flask db upgrade
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 98fcda19748e -> a8f98d953599, empty message
Traceback (most recent call last):
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1244, in _execute_context
    cursor, statement, parameters, context
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 552, in do_execute
    cursor.execute(statement, parameters)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet    packet.check_error()
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1170, "BLOB/TEXT column 'description' used in key specification without a key length")`

The dataset description is a TEXT column, because we can't be sure of it's length. This means it cannot be an indexed column. This code change removes indexing of the description column.

## Current behaviour
<!--- Tell us what currently happens -->

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
 
#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Indexing of the description column in the Dataset model is removed.

