### PR TITLE
Remove deprecated pipelines from the list of pipelines displayed

### DIFF
--- a/app/pipelines/routes.py
+++ b/app/pipelines/routes.py
@@ -93,6 +93,9 @@ def pipeline_search():
             for d_index, descriptor in enumerate(all_descriptors)
         ]
 
+    # filter our the deprecated pipelines
+    elements = list(filter(lambda e: (not e["DEPRECATED"]), elements))
+
     # filter by tags
     if len(tags) > 0:
         elements = list(filter(lambda e: ("tags" in e and "domain" in e["tags"]), elements))


### PR DESCRIPTION
## Related issues
#299

## Checklist
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
This removes the deprecated pipelines from the list of pipelines to be displayed in the portal.
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No


