### PR TITLE
Update Travis config to remove 3.5-dev old version of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 
 python:
-- 3.5-dev
 - 3.6
 - 3.6-dev
 - 3.7-dev
+- 3.7
 
 before_install:
   - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)


### PR DESCRIPTION
The portal is currently running on python 3.6.9 so no need to test for python 3.5-dev which is an unsupported version of Python anyways.


