### PR TITLE
Add a tutorial page to the portal

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -151,3 +151,34 @@ def about():
 
     return render_template('about.html', title='CONP | About', user=current_user,
                            countDatasets=countDatasets, countPipelines=countPipelines)
+
+@main_bp.route('/tutorial')
+def tutorial():
+    """ Tutorial Route
+
+        Route to lead to the tutorial page
+
+        Args:
+            None
+
+        Returns:
+            rendered template for tutorial.html
+    """
+
+    url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/CONP_portal_tutorial.md'
+    headers = {'Content-type': 'text/html; charset=UTF-8'}
+    response = requests.get(url, headers=headers)
+
+    tutorialRaw = response.text
+
+    url = 'https://api.github.com/markdown'
+    body = {
+        "text"   : tutorialRaw,
+        "mode"   : "gfm",
+        "context": "github/gollum"
+    }
+    response = requests.post(url, json=body)
+
+    content = response.text.replace('user-content-', '')
+
+    return render_template('tutorial.html', title='CONP | Tutorial', user=current_user, content=content)

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -54,6 +54,10 @@
     <a target="_blank", rel="noopener noreferrer" href="https://conp.ca/">
       here.
     </a>
+    A tutorial on how to use the CONP portal can be found
+    <a target="_blank", rel="noopener noreferrer" href="{{url_for('main.tutorial')}}">
+      here.
+    </a>
   </p>
 
 
@@ -92,7 +96,7 @@
     data modalities. Many of these datasets have been made accessible by neuroscience
     research institutes across Canada, while others link to publicly available
     resources that may be of interest to neuroscientists. A full list can be found
-    <a target="_blank", rel="noopener noreferrer" href="https://portal.conp.ca/search">
+    <a target="_blank", rel="noopener noreferrer" href="/search">
       here.
     </a>
   </p>
@@ -105,11 +109,11 @@
     additional data will be shared via a registered access for this PREVENT-AD cohort
     with clinical, cognitive and other biomarkers measures that were collected on this
     rich cohort. The original PREVENT-AD dataset is available
-    <a target="_blank", rel="noopener noreferrer" href="http://localhost:5000/dataset?id=projects/preventad-open">
+    <a target="_blank", rel="noopener noreferrer" href="/dataset?id=projects/preventad-open">
       here.
     </a>
     The same dataset organized according to the BIDS standard can be found
-    <a target="_blank", rel="noopener noreferrer" href="http://localhost:5000/dataset?id=projects/preventad-open-bids">
+    <a target="_blank", rel="noopener noreferrer" href="/dataset?id=projects/preventad-open-bids">
       here.
     </a>
   </p>
@@ -128,7 +132,7 @@
     The CONP portal was designed to parse existing datasets both externally and within
     the CONP context. As such, a variety of datasets are available for download within
     this portal. To access the data, the user will first go to the
-    <a target="_blank", rel="noopener noreferrer" href="https://portal.conp.ca/search">
+    <a target="_blank", rel="noopener noreferrer" href="/search">
       Data page
     </a>
     and filter for data of interest. Clicking on an individual dataset will provide
@@ -144,7 +148,7 @@
   <p>
     Once the user has downloaded a dataset, what can they do with it? We also provide
     a wide range of
-    <a target="_blank", rel="noopener noreferrer" href="https://portal.conp.ca/pipelines">
+    <a target="_blank", rel="noopener noreferrer" href="/pipelines">
       tools and pipelines.
     </a>
     Read the following sections to find out more.
@@ -157,7 +161,7 @@
     {{ countPipelines }} tools and pipelines.
     Many of these tools/pipelines are well-established and have been provided by
     neuroscience or genomics research institutes. A full list can be found
-    <a target="_blank", rel="noopener noreferrer" href="https://portal.conp.ca/pipelines">
+    <a target="_blank", rel="noopener noreferrer" href="/pipelines">
       here.
     </a>
   </p>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -43,6 +43,9 @@
           the obtained results including a link to the original dataset.
           <a href="{{url_for('main.about')}}">
             Read more
+          </a> |
+          <a target="_blank", rel="noopener noreferrer" href="{{url_for('main.tutorial')}}">
+            Portal tutorial
           </a>
         </p>
         <p>

--- a/app/templates/tutorial.html
+++ b/app/templates/tutorial.html
@@ -1,0 +1,13 @@
+{% extends 'common/base_main.html' %}
+
+<!-- Title Block -->
+
+{% block contenttitle %}
+<h2><span style="color:red;">CONP Portal </span> | Tutorial</h2>
+{% endblock %}
+
+<!-- Content Block -->
+
+{% block appcontent %}
+{{ content|safe }}
+{% endblock %}


### PR DESCRIPTION
This adds a tutorial page to the portal

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail

This was implemented the same way the Share and FAQ pages were implemented (link to the tutorial file in the conp-documentation repository.
