### PR TITLE
Fix issue of search page not displaying when wrong value for conp_status in DATS file

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -174,8 +174,14 @@ def dataset_search():
         paginated = elements
 
         if(sort_key == "conpStatus"):
-            order = {'conp': 0, 'canadian': 1, 'external': 2}
-            paginated.sort(key=lambda o: order[o[sort_key].lower()])
+
+            def determine_order(element):
+                order = {'conp': 0, 'canadian': 1, 'external': 2}
+                if sort_key not in order:
+                    return 3
+                return order[element[sort_key].lower()]
+
+            paginated.sort(key=lambda o: determine_order(o))
 
         elif(sort_key == "title"):
             paginated.sort(key=lambda o: o[sort_key].lower())


### PR DESCRIPTION
This was noticed when testing the import of a new dataset. The conp_status field of the DATS.json model of the new dataset was invalid and this resulted in the data search page not loading. 

The code changes suggested in that PR fixes the issue in case we get another invalid DATS file by mistake. 

Note that separately, we will update the dats_validator to check if the DATS file has proper values in that field. See https://github.com/CONP-PCNO/conp-dataset/issues/345

