### PR TITLE
Display references in the dataset page

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -148,6 +148,47 @@ class DATSDataset(object):
 
         return ", ".join(principalInvestigators) if len(principalInvestigators) > 0 else None
 
+    @property
+    def primaryPublications(self):
+        primaryPublications = []
+        publications = self.descriptor.get('primaryPublications', {})
+        if type(publications) == list:
+            for publi in publications:
+                title = publi.get('title', '')
+                if not title.endswith('.'):
+                    title += '.'
+                journal = publi.get('publicationVenue', '')
+                if not journal.endswith('.'):
+                    journal += '.'
+                author  = publi.get('authors', [])[0].get('fullName', '') if 'authors' in publi else ''
+                if len(publi.get('authors', [])) > 1:
+                    author += ' et al.'
+                doi = publi.get('identifier', {}).get('identifier', '')
+                primaryPublications.append(
+                    {
+                        'title': title,
+                        'author': author,
+                        'journal': journal,
+                        'doi': doi
+                    }
+                )
+        elif 'title' in publications:
+            title = publications.get('title', '')
+            journal = publications.get('publicationVenue', '')
+            doi = publications.get('identifier', {}).get('identifier', '')
+            author = publications.get('authors', [])[0].get('fullName', '')  if 'authors' in publications else ''
+            if len(publications.get('authors', [])) > 1:
+                author += ' et al.'
+            primaryPublications.append(
+                {
+                    'title': title,
+                    'author': author,
+                    'journal': journal,
+                    'doi': doi
+                }
+            )
+
+        return primaryPublications if len(primaryPublications) > 0 else None
 
     @property
     def authorizations(self):

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -133,6 +133,7 @@ def dataset_search():
             "conpStatus": datsdataset.conpStatus,
             "authorizations": datsdataset.authorizations,
             "principalInvestigators": datsdataset.principalInvestigators,
+            "primaryPublications": datsdataset.primaryPublications,
             "logoFilepath": datsdataset.LogoFilepath,
             "status": datsdataset.status,
         }
@@ -361,6 +362,7 @@ def dataset_info():
         "conpStatus": datsdataset.conpStatus,
         "authorizations": datsdataset.authorizations,
         "principalInvestigators": datsdataset.principalInvestigators,
+        "primaryPublications": datsdataset.primaryPublications,
         "logoFilepath": datsdataset.LogoFilepath,
         "status": datsdataset.status,
     }
@@ -454,6 +456,7 @@ def get_dataset_metadata_information(dataset):
         "licenses": datsdataset.licenses,
         "sources": datsdataset.sources,
         "parentDatasets": datsdataset.parentDatasetId,
+        "primaryPublications": datsdataset.primaryPublications,
         "childDatasets": childDatasets
     }
 

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -58,7 +58,39 @@
         href="{{ href }}">{{ d.name }}</a></span>
     {% endfor %}</p>
   {% endif %}
+
+  {% if metadata.primaryPublications is defined and metadata.primaryPublications is not none %}
+  {% if metadata.primaryPublications|length > 1 %}
+    <p>
+      <strong>Primary Publications: </strong>
+      {% for p in metadata.primaryPublications %}
+        <ul>
+          <li>
+            {{p.title}} {{p.author}} <em>{{p.journal}}</em>
+            {% if p.doi is defined %}
+              <a target="_blank" rel="noopener noreferrer" href="{{ p.doi }}">{{ p.doi }}</a>
+            {% endif %}
+          </li>
+        </ul>
+      {% endfor %}
+    </p>
+  {% elif metadata.primaryPublications|length == 1 %}
+    <p>
+      <strong>Primary Publication: </strong>
+      {{metadata.primaryPublications[0].title}}
+      {{metadata.primaryPublications[0].author}}
+      <em>{{metadata.primaryPublications[0].journal}}</em>
+      {% if metadata.primaryPublications[0].doi is defined %}
+        <a target="_blank" rel="noopener noreferrer"
+           href="{{ metadata.primaryPublications[0].doi }}">
+          {{ metadata.primaryPublications[0].doi }}
+        </a>
+      {% endif %}
+    </p>
+  {% endif %}
+  {% endif %}
 </div>
+
 
 <div class="d-flex flex-column p-2">
   <h2>Dataset Download Instructions</h2>


### PR DESCRIPTION
This adds the primary publications to the detailed dataset page. 

![Screen Shot 2020-07-29 at 3 40 51 PM](https://user-images.githubusercontent.com/1402456/88845433-226a5800-d1b2-11ea-8d7b-6f17288d2277.png)



## Related issues
https://github.com/CONP-PCNO/conp-portal/issues/258

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
