### PR TITLE
Rename child and parent dataset to derived and input

### DIFF
--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -41,7 +41,7 @@
   <p><strong>Licenses: </strong> {{ metadata.licenses }}</p>
   {% endif %}
   {% if metadata.parentDatasets is defined and metadata.parentDatasets is not none %}
-  <p><strong>Parent Datasets: </strong>
+  <p><strong>Input Datasets: </strong>
     {% for d in metadata.parentDatasets %}
     {% if d is defined %}
     {% set href = "/dataset?id=projects/" ~ d %}
@@ -51,7 +51,7 @@
     {% endfor %}</p>
   {% endif %}
   {% if metadata.childDatasets is defined and metadata.childDatasets|length > 0 %}
-  <p><strong>Child Datasets: </strong>
+  <p><strong>Derived Datasets: </strong>
     {% for d in metadata.childDatasets %}
     {% set href = "/dataset?id=" ~ d.child_dataset_id %}
     <span class="mr-1"><a class="badge badge-primary"


### PR DESCRIPTION
The terms 'Child Datasets' and 'Parent Dataset' to specify the link between datasets might not be YODA-compatible.

This PR renames those terms as follows:
- 'Child Datasets' => 'Derived Datasets'
- 'Parent Dataset' => 'Input Dataset'

## Related issues

#342 

#### Does this introduce a major change?
- [ ] Yes
- [x] No


