### PR TITLE
add json-ld descriptor to dataset page

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -441,9 +441,6 @@ def get_dataset_metadata_information(dataset):
     datasetAncestries=DatasetAncestry.query.all()
     for da in datasetAncestries:
         if da.parent_dataset_id == dataset.dataset_id:
-            print('dataset ' + da.parent_dataset_id +
-                  ' has child ' + da.child_dataset_id)
-
             name=da.child_dataset_id[9:]
             childDataset={
                 "child_dataset_id": da.child_dataset_id,
@@ -452,6 +449,7 @@ def get_dataset_metadata_information(dataset):
             childDatasets.append(childDataset)
 
     return {
+        "schema_org_metadata": datsdataset.schema_org_metadata,
         "authors": datsdataset.authors,
         "description": datsdataset.description,
         "contact": datsdataset.contacts,

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -6,6 +6,9 @@
 <script src=" {{ url_for('static',filename='js/react-dom.development-16.11.0.js') }}"></script>
 <script type="text/javascript" src="static/lib/conp-react/umd/conp-react.js"></script>
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css">
+
+<!-- ADD JSON-LD DESCRIPTOR -->
+<script type="application/ld+json">{{ metadata.schema_org_metadata | safe }}</script>
 {% endblock %}
 
 {% block contenttitle %}


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#301 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
This adds the JSON-LD descriptor to the head tag of the dataset.html page, containing the schema.org json-ld metadata for each dataset

## Current behaviour
<!--- Tell us what currently happens -->

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Example output from the BigBrain dataset (this will now be found inside the head tag on the page):

`<script type="application/ld+json">{'@context': 'https://schema.org/', '@type': 'Dataset', 'name': 'BigBrain dataset', 'description': 'The BigBrain dataset is the result of a collaborative effort between the teams of Dr. Katrin Amunts and Dr. Karl Zilles (Forschungszentrum Jülich) and Dr. Alan Evans (Montreal Neurological Institute). For more information please visit the BigBrain Project website [https://bigbrainproject.org]', 'version': '1.0', 'license': [{'@type': 'CreativeWork', 'name': 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License'}], 'keywords': ['Brain Histology', '3D Atlas', 'Microscopic', 'NeuroImaging', 'High Resolution', 'Human'], 'creator': [{'@type': 'Organization', 'name': 'BigBrain project'}]}</script>`
 
#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->

