### PR TITLE
use tojson to correctly encode json-ld descriptor

### DIFF
--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css">
 
 <!-- ADD JSON-LD DESCRIPTOR -->
-<script type="application/ld+json">{{ metadata.schema_org_metadata | safe }}</script>
+<script type="application/ld+json">{{ metadata.schema_org_metadata | tojson }}</script>
 {% endblock %}
 
 {% block contenttitle %}


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#301 #344 

## Checklist
<!--- Make sure to check the following items -->
- [x] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
This changes the jinja filter on the dataset page that handles the JSON-LD metadata. The encoding wasn't correct before.
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No

