### PR TITLE
Change the site ID to 2 in config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -67,7 +67,7 @@ class Config(object):
 
     # Matomo
     MATOMO_SERVER_URL = os.environ.get("MATOMO_SERVER_URL")
-    MATOMO_SITE_ID = os.environ.get("MATOMO_SITE_ID", "1")
+    MATOMO_SITE_ID = os.environ.get("MATOMO_SITE_ID", "2")
 
 
 class DevelopmentConfig(Config):


### PR DESCRIPTION
This fixes the MATOMO site ID. It should be 2 for the portal

