### PR TITLE
Read URL of CBRAIN from JSON file instead of hardcoding it to login URL

### DIFF
--- a/app/pipelines/routes.py
+++ b/app/pipelines/routes.py
@@ -152,7 +152,7 @@ def pipeline_search():
                 if "cbrain" in url:
                     element["platforms"][0]["img"] = url_for(
                         'static', filename="img/run_on_cbrain_green.png")
-                    element["platforms"][0]["uri"] = "https://portal.cbrain.mcgill.ca"
+                    element["platforms"][0]["uri"] = url
                 else:
                     platform_dict = {"img": url_for('static', filename="img/globe-solid-green.png"),
                                      "uri": url}
@@ -260,7 +260,7 @@ def pipeline_info():
             if "cbrain" in url:
                 element["platforms"][0]["img"] = url_for(
                     'static', filename="img/run_on_cbrain_green.png")
-                element["platforms"][0]["uri"] = "https://portal.cbrain.mcgill.ca"
+                element["platforms"][0]["uri"] = url
             else:
                 platform_dict = {"img": url_for('static', filename="img/globe-solid-green.png"),
                                  "uri": url}

--- a/app/pipelines/routes.py
+++ b/app/pipelines/routes.py
@@ -149,7 +149,7 @@ def pipeline_search():
         if "onlineplatformurls" in element:
             # Check CBRAIN
             for url in element["onlineplatformurls"]:
-                if "cbrain" in url:
+                if url.startswith('https://portal.cbrain.mcgill.ca'):
                     element["platforms"][0]["img"] = url_for(
                         'static', filename="img/run_on_cbrain_green.png")
                     element["platforms"][0]["uri"] = url

--- a/app/pipelines/routes.py
+++ b/app/pipelines/routes.py
@@ -257,7 +257,7 @@ def pipeline_info():
     if "online-platform-urls" in element:
         # Check CBRAIN
         for url in element["online-platform-urls"]:
-            if "cbrain" in url:
+            if url.startswith('https://portal.cbrain.mcgill.ca'):
                 element["platforms"][0]["img"] = url_for(
                     'static', filename="img/run_on_cbrain_green.png")
                 element["platforms"][0]["uri"] = url


### PR DESCRIPTION
Instead of hardcoding the CBRAIN URL to the login page when clicking on the CBRAIN buttons, this will read the URL from the Boutiques descriptor of the tool instead in case the URL contains the pipeline ID so that users can be redirected directly to the tool page on CBRAIN.

