### PR TITLE
Update `update_datasets` script

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -210,8 +210,8 @@ def _update_datasets(app):
                 print("\033[0m")
                 continue
 
-        # The folowing relates to the DATS.json files of the projects. Skip directories that aren't projects or investigators.
-        patterns = [app.config['DATA_PATH'] + '/conp-dataset/projects/*', app.config['DATA_PATH'] + '/conp-dataset/investigators/*']
+        # The folowing relates to the DATS.json files of the projects. Skip directories that aren't projects.
+        patterns = [app.config['DATA_PATH'] + '/conp-dataset/projects/*']
         if not any(fnmatch.fnmatch(ds['path'], pattern) for pattern in patterns):
             continue
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -216,7 +216,6 @@ def _update_datasets(app):
             continue
 
         dirs = os.listdir(ds['path'])
-        print(ds['path'])
         descriptor = ''
         for file in dirs:
             if fnmatch.fnmatch(file.lower(), 'dats.json'):

--- a/app/cli.py
+++ b/app/cli.py
@@ -210,7 +210,8 @@ def _update_datasets(app):
                 print("\033[0m")
                 continue
 
-        # The folowing relates to the DATS.json files of the projects. Skip directories that aren't projects.
+        # The folowing relates to the DATS.json files of the projects.
+        # Skip directories that aren't projects.
         patterns = [app.config['DATA_PATH'] + '/conp-dataset/projects/*']
         if not any(fnmatch.fnmatch(ds['path'], pattern) for pattern in patterns):
             continue

--- a/app/cli.py
+++ b/app/cli.py
@@ -210,7 +210,7 @@ def _update_datasets(app):
                 print("\033[0m")
                 continue
 
-        # The folowing relates to the DATS.json files of the projects.
+        # The following relates to the DATS.json files of the projects directory in the conp-dataset repo.
         # Skip directories that aren't projects.
         patterns = [app.config['DATA_PATH'] + '/conp-dataset/projects/*']
         if not any(fnmatch.fnmatch(ds['path'], pattern) for pattern in patterns):

--- a/app/cli.py
+++ b/app/cli.py
@@ -210,8 +210,9 @@ def _update_datasets(app):
                 print("\033[0m")
                 continue
 
-        # The folowing relates to the DATS.json files of the projects. Skip directories that aren't projects. 
-        if not fnmatch.fnmatch(ds['path'], app.config['DATA_PATH'] + '/conp-dataset/projects/*'):
+        # The folowing relates to the DATS.json files of the projects. Skip directories that aren't projects or investigators.
+        patterns = [app.config['DATA_PATH'] + '/conp-dataset/projects/*', app.config['DATA_PATH'] + '/conp-dataset/investigators/*']
+        if not any(fnmatch.fnmatch(ds['path'], pattern) for pattern in patterns):
             continue
 
         dirs = os.listdir(ds['path'])

--- a/app/cli.py
+++ b/app/cli.py
@@ -210,7 +210,8 @@ def _update_datasets(app):
                 print("\033[0m")
                 continue
 
-        # The following relates to the DATS.json files of the projects directory in the conp-dataset repo.
+        # The following relates to the DATS.json files
+        # of the projects directory in the conp-dataset repo.
         # Skip directories that aren't projects.
         patterns = [app.config['DATA_PATH'] + '/conp-dataset/projects/*']
         if not any(fnmatch.fnmatch(ds['path'], pattern) for pattern in patterns):

--- a/app/cli.py
+++ b/app/cli.py
@@ -8,6 +8,7 @@ import os
 import click
 import csv
 import uuid
+import fnmatch
 from datetime import datetime, timedelta
 from pytz import timezone
 from app.threads import UpdatePipelineData
@@ -209,7 +210,12 @@ def _update_datasets(app):
                 print("\033[0m")
                 continue
 
+        # The folowing relates to the DATS.json files of the projects. Skip directories that aren't projects. 
+        if not fnmatch.fnmatch(ds['path'], app.config['DATA_PATH'] + '/conp-dataset/projects/*'):
+            continue
+
         dirs = os.listdir(ds['path'])
+        print(ds['path'])
         descriptor = ''
         for file in dirs:
             if fnmatch.fnmatch(file.lower(), 'dats.json'):


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#155 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
This PR ensure the `update_datasets` script skips directories that are not in either the `/projects` or `/investigator` directories. An ERROR message was being thrown every time this script ran because of searching for DATS files where they don't exist.

## Current behaviour
<!--- Tell us what currently happens -->
All subdirectories are searched for a DATS.json file including those where none are expected

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Only the `/projects` and `/investigators` directories are searched 
 
#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->

