### PR TITLE
Fix typo in pipeline documentation

### DIFF
--- a/app/templates/pipeline.html
+++ b/app/templates/pipeline.html
@@ -153,7 +153,7 @@
             </div>
             <p>Note: this command will list only the required options to run the pipeline. To view the complete list of
                 options, use</p>
-            <p><code>bosh --complete {{ pipeline.id }}</code></p>
+            <p><code>bosh example --complete {{ pipeline.id }}</code></p>
             <p class="font-italic ml-4">2. Create an invocation JSON file based on the output of the
                 <code>bosh example</code></p>
             <p class="font-italic ml-4">3. Run the pipeline with the invocation JSON file created in 2.</p>


### PR DESCRIPTION
---
name: Fix typo in pipeline documentation
about: Propose modifications in the code
title: 'Feature implementation | Bug fix for issue #<000>'
labels: enhancement
assignees: ''

---

## Checklist
<!--- Make sure to check the following items -->
- [x ] **DO** Unit tests pass.

## Purpose
<!--- A clear and concise description of what the PR does. -->
Fix a typo in the documentation for using Boutiques that appears on every pipeline page.

## Current behaviour
<!--- Tell us what currently happens -->
Under the "How to run the tool locally" section on each pipeline's page, the documentation suggests that users run `bosh --complete {{ pipeline.id }}`. Actually running this snippet as suggested yields something like:

```bosh: error: argument function: invalid choice: 'zenodo.1482743' (choose from 'create', 'data', 'deprecate', 'evaluate', 'example', 'exec', 'export', 'import', 'invocation', 'pprint', 'publish', 'pull', 'search', 'test', 'validate', 'version')```

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
The documentation adds the proper bash function argument, instead suggesting that users run `bosh example --complete {{ pipeline.id }}`, which yields the complete list of options as expected.
 
#### Does this introduce a major change?
- [ ] Yes
- [x ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
 Minor change to one of the website templates.
