### PR TITLE
remove closing div tag from dataset.html

### DIFF
--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -209,6 +209,5 @@
   ReactDOM.render(reactElement, document.querySelector("#mount-display"));
 
 </script>
-</div>
 <!--/span-->
 {% endblock %}


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#368

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
Fixes an issue where a single closing div tag was changing the view hierarchy on the dataset page

