### PR TITLE
Fixed the dashboard links to the three PREVENT-AD datasets

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -136,14 +136,14 @@
               </a>
             </div>
             <div>
-              <a href="/dataset?id=projects/preventad-open">
+              <a href="/dataset?id=projects/preventad-open-bids">
                 <button class="btn btn-outline-secondary" type="button">
                   Open Dataset (BIDS)
                 </button>
               </a>
             </div>
             <div>
-              <a href="/dataset?id=projects/preventad-open">
+              <a href="/dataset?id=projects/preventad-registered">
                 <button class="btn btn-outline-secondary" type="button">
                   Registered Dataset
                 </button>


### PR DESCRIPTION
This fixes the links in the dashboard to the preventad-open-bids and preventad-registered datasets that were pointing to the preventad-open instead.
