### PR TITLE
add metadata for twitter card to base_main.html

### DIFF
--- a/app/templates/common/base_main.html
+++ b/app/templates/common/base_main.html
@@ -4,6 +4,21 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="description" content="CONP" />
 <meta name="author" content="CONP" />
+
+<!-- metadata for the Twitter Card -->
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@NeuroLibre" />
+
+<meta name="twitter:title" content="CONP/PCNO" />
+<meta
+  name="twitter:description"
+  content="This portal is a web interface for the Canadian Open Neuroscience Platform (CONP) to facilitate open science in the neuroscience community. CONP simplifies global researcher access and sharing of datasets and tools. The portal internalizes the cycle of a typical research project: starting with data acquisition, followed by processing using already existing/published tools, and ultimately publication of the obtained results including a link to the original dataset."
+/>
+<meta
+  name="twitter:image"
+  content="https://portal.conp.ca/static/img/conp.png"
+/>
+
 {% endblock %} {% block styles %}
 <link
   href="{{ url_for('static', filename='css/font-awesome.css') }}"


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#389 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.

## Purpose
<!--- A clear and concise description of what the PR does. -->
This adds twitter summary card metadata to base_main.html, meaning all pages that implement base_main will contain the metadata. Any URL on the portal linked via a tweet should result in the summary card showing within the twtt.

## Current behaviour
<!--- Tell us what currently happens -->

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
 
#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->

