### PR TITLE
Add GIfTI to the list of exceptions for file formats to handle in the drop down of the dataset search page

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -183,6 +183,8 @@ def dataset_search():
             formatted_string = re.sub(r'\.', '', m)
             if formatted_string.lower() in ['nifti', 'nii', 'niigz']:
                 formats.append('NIfTI')
+            elif formatted_string.lower() in ['gifti', 'gii']:
+                formats.append('GIfTI')
             elif formatted_string.lower() == 'bigwig':
                 formats.append('bigWig')
             elif formatted_string.lower() == 'rna-seq':


### PR DESCRIPTION
While recrawling the BigBrain dataset, we noticed that GIfTI should be added to the list of file format exceptions that do not follow the upper case convention.


