### PR TITLE
Fix production bug to import ProductionConfig again when running on production server

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,10 +19,14 @@ mail = Mail()
 bootstrap = Bootstrap()
 
 
-def create_app(config_settings=DevelopmentConfig):
+def create_app():
 
     app = Flask(__name__, static_url_path='/static')
-    app.config.from_object(config_settings)
+    if os.environ.get('FLASK_ENV') == 'production':
+        from config import ProductionConfig
+        app.config.from_object(ProductionConfig)
+    else:
+        app.config.from_object(DevelopmentConfig)
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,14 +19,15 @@ mail = Mail()
 bootstrap = Bootstrap()
 
 
-def create_app():
+def create_app(config_settings=None):
 
     app = Flask(__name__, static_url_path='/static')
     if os.environ.get('FLASK_ENV') == 'production':
         from config import ProductionConfig
-        app.config.from_object(ProductionConfig)
-    else:
+        config_settings = ProductionConfig
+    elif not config_settings:
         app.config.from_object(DevelopmentConfig)
+    app.config.from_object(config_settings)
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,7 +26,7 @@ def create_app(config_settings=None):
         from config import ProductionConfig
         config_settings = ProductionConfig
     elif not config_settings:
-        app.config.from_object(DevelopmentConfig)
+        config_settings = DevelopmentConfig
     app.config.from_object(config_settings)
 
     db.init_app(app)

--- a/config.py
+++ b/config.py
@@ -16,6 +16,8 @@ class Config(object):
     the CONP Portal. Ideally, variables such as secret keys and such should
     be set by environment variable rather than explicitely here.
     """
+
+    FLASK_ENV = os.environ.get('FLASK_ENV')
     SECRET_KEY = os.environ.get('SECRET_KEY') or "conp-secret-key-for-here"
     DATA_PATH = os.environ.get('DATA_PATH') or os.path.join(
         basedir, "app/static/data")
@@ -30,8 +32,8 @@ class Config(object):
     MAIL_DEFAULT_SENDER = '"CONP-PCNO Portal" <shawntbrown@gmail.com>'
     ADMINS = [os.environ.get('ADMIN_EMAIL')] or ['conp-test@mailinator.com']
     LOG_TO_STDOUT = True
-    # Flask-User Settings
 
+    # Flask-User Settings
     USER_APP_NAME = "CONP-PCNO Data Portal"
     USER_ENABLE_CHANGE_PASSWORD = True
     USER_ENABLE_CHANGE_USERNAME = False


### PR DESCRIPTION
This fixes the issue on production where ProductionConfig was not imported anymore in `app/__init__.py` causing the production server to go into maintenance page because it could not find the ProductionConfig function.

