### PR TITLE
Add dates from the DATS file into the dataset page

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -465,6 +465,16 @@ class DATSDataset(object):
     def version(self):
         return self.descriptor.get('version', None)
 
+    @property
+    def dates(self):
+        dates = {}
+        for prop in self.descriptor.get('dates', {}):
+            date = prop.get('date', '')
+            date_type = prop.get('type', {}).get('value', '').title()
+            dates[date_type] = date
+
+        return dates if len(dates) > 0 else None
+
     @ property
     def schema_org_metadata(self):
         """ Returns json-ld metadata snippet for Google dataset search. """

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -544,6 +544,7 @@ def get_dataset_metadata_information(dataset):
         "isAbout": datsdataset.isAbout,
         "acknowledges": datsdataset.acknowledges,
         "spatialCoverage": datsdataset.spatialCoverage,
+        "dates": datsdataset.dates,
     }
 
 

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -210,7 +210,7 @@
               {{" -- " if not loop.last else "" }}
               {% endfor %}
             </td>
-          </tr>>
+          </tr>
           {% endif %}
         </tbody>
       </table>

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -157,7 +157,8 @@
   </div>
   {% endif %} {% endif %} {% if (metadata.dimensions is not none) or
   (metadata.producedBy is not none) or (metadata.isAbout is not none) or
-  (metadata.acknowledges is not none) or (metadata.spatialCoverage is not none)
+  (metadata.acknowledges is not none) or (metadata.spatialCoverage is not none) or
+  (metadata.dates is not none)
   %}
   <div class="py-1">
     <div class="d-inline-flex">
@@ -200,6 +201,16 @@
             <th scope="row">Spatial Coverage:</th>
             <td>{{metadata.spatialCoverage|join(", ")}}</td>
           </tr>
+          {% endif %} {% if metadata.dates is not none %}
+          <tr>
+            <th scope="row">Other Dates:</th>
+            <td>
+              {% for key, value in metadata.dates.items() %}
+              <i>{{ key }}:</i> {{ value }}
+              {{" -- " if not loop.last else "" }}
+              {% endfor %}
+            </td>
+          </tr>>
           {% endif %}
         </tbody>
       </table>


### PR DESCRIPTION
This adds the DATS `dates` field in the dataset page under the `more` section to display other dates that may have been stored in the DATS file.

This fixes #421 