### PR TITLE
Fix 500 error for the McGill EMC dataset page

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -417,8 +417,13 @@ class DATSDataset(object):
     @ property
     def producedBy(self):
         producedBy = []
-        for t in self.descriptor.get('producedBy', []):
-            prod = t.get('name', None)
+        field_data = self.descriptor.get('producedBy', None)
+        if not field_data:
+            return None
+        elif isinstance(field_data, str):
+            producedBy.append(field_data)
+        elif isinstance(field_data, dict):
+            prod = field_data.get('name', None)
             if prod is not None:
                 producedBy.append(prod)
 


### PR DESCRIPTION
this fixes the error reported in https://github.com/CONP-PCNO/conp-portal/issues/418.

The `producedBy` field of DATS could be a string, an array or an object. The fix handles the different possibilities when reading the DATS files.