### PR TITLE
[ADD] GitHub workflow to auto label/close stale issues and PRs.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open 5 months with no activity. Remove stale label or comment or this will be closed in 3 months."
+          stale-pr-message: "This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 20 days."
+          close-issue-message: "This issue was closed because it has been stalled for 3 months with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 20 days with no activity."
+          days-before-issue-stale: 150 # ~5 months
+          days-before-issue-close: 90 # ~3 months
+          days-before-pr-stale: 45
+          days-before-pr-close: 20


### PR DESCRIPTION
## Related issues
CONP-PCNO/conp-dataset#570.

## Purpose
<!--- A clear and concise description of what the PR does. -->
This PR propose to add a GitHub workflow to automatically label/close stale issues and PRs.

This was discussed in CONP-PCNO/conp-dataset#570.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Warns and then closes issues and PRs that have had no activity for a specified amount of time.
If the label is removed manually or new activity occurs on the issue or PR the stale status is reset.

- Issues:
  - label stale: 150 days (~5 months)
  - close after labeling: 90 days (~3 months)
- Pull requests:
  - label stale: 45 days
  - close after labeling: 20 days 
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No
