### PR TITLE
[analytics] Fix 'null' pipeline being shown in the most viewed pipeline

### DIFF
--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -160,15 +160,16 @@ def pipelines_views():
                     v.nb_uniq_visitors if v.nb_uniq_visitors is not None else 0)
 
         if not exists and v.label is not None and "/pipeline?id=" in v.label:
-            element = {
-                "url": v.url,
-                "label": v.label,
-                "title": pipelines.get_title_from_id(v.label.split('id=')[1]),
-                "nb_hits": v.nb_hits,
-                "nb_visits": v.nb_visits,
-                "nb_uniq_visitors": v.nb_uniq_visitors if v.nb_uniq_visitors is not None else 0,
-            }
-            elements.append(element)
+            if pipelines.get_title_from_id(v.label.split('id=')[1]):
+                element = {
+                    "url": v.url,
+                    "label": v.label,
+                    "title": pipelines.get_title_from_id(v.label.split('id=')[1]),
+                    "nb_hits": v.nb_hits,
+                    "nb_visits": v.nb_visits,
+                    "nb_uniq_visitors": v.nb_uniq_visitors if v.nb_uniq_visitors is not None else 0,
+                }
+                elements.append(element)
 
     elements.sort(key=lambda e: e["nb_hits"], reverse=True)
 


### PR DESCRIPTION
An old pipeline has been removed from the portal but showed up in the most viewed pipelines graphs with a label `null`. The change in this PR will ignore the stats for pipelines with no titles.

Before: 
![Screen Shot 2021-04-01 at 4 38 56 PM](https://user-images.githubusercontent.com/1402456/113351598-19192880-9309-11eb-9b62-ff4da2336261.png)


After: 
![Screen Shot 2021-04-01 at 4 41 46 PM](https://user-images.githubusercontent.com/1402456/113351729-41a12280-9309-11eb-9dac-f8a044ce6b68.png)

