### PR TITLE
Change Dashboard to Home and add an analytics button

### DIFF
--- a/app/templates/fragments/sidebar.html
+++ b/app/templates/fragments/sidebar.html
@@ -29,13 +29,6 @@
       </p>
     </a>
     <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3  sidebar-tab"
-      href="{{ url_for('analytics.analytics') }}">
-      <h1><i class="fa fa-bar-chart"></i></h1>
-      <p class="text-center text-capitalize p-1">
-        Analytics
-      </p>
-    </a>
-    <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3  sidebar-tab"
       href="{{ url_for('main.faq') }}">
       <h1><i class="fa fa-info-circle"></i></h1>
       <p class="text-center text-capitalize p-1">

--- a/app/templates/fragments/sidebar.html
+++ b/app/templates/fragments/sidebar.html
@@ -4,7 +4,7 @@
       href="{{ url_for('main.index') }}">
       <h1><i class="fa fa-home"></i></h1>
       <p class="text-center text-capitalize p-1">
-        Home Page
+        Home
       </p>
     </a>
     <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3  sidebar-tab"

--- a/app/templates/fragments/sidebar.html
+++ b/app/templates/fragments/sidebar.html
@@ -2,9 +2,9 @@
   <div class="sticky-top sticky-offset">
     <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3  sidebar-tab"
       href="{{ url_for('main.index') }}">
-      <h1><i class="fa fa-bar-chart"></i></h1>
+      <h1><i class="fa fa-home"></i></h1>
       <p class="text-center text-capitalize p-1">
-        Dashboard
+        Home Page
       </p>
     </a>
     <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3  sidebar-tab"
@@ -26,6 +26,13 @@
       <h1><i class="fa fa-cloud-upload"></i></h1>
       <p class="text-center text-capitalize p-1">
         Share
+      </p>
+    </a>
+    <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3  sidebar-tab"
+      href="{{ url_for('analytics.analytics') }}">
+      <h1><i class="fa fa-bar-chart"></i></h1>
+      <p class="text-center text-capitalize p-1">
+        Analytics
       </p>
     </a>
     <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3  sidebar-tab"


### PR DESCRIPTION
This PR changes the sidebar chart logo for the home page to a home logo to make it clearer where one would want to click to go back to the home page of the portal and not accidentally clic on the CONP logo which redirects to the conp.ca website.

![Screen Shot 2021-04-15 at 1 00 14 PM](https://user-images.githubusercontent.com/1402456/114909087-c2245080-9dea-11eb-9062-5548c263d89d.png)
