### PR TITLE
Add https:// in front of matomo URL for the update_analytics function of flask

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -323,7 +323,7 @@ def _update_analytics(app):
     matomo_site_id = app.config['MATOMO_SITE_ID']
     matomo_token_auth = app.config['MATOMO_TOKEN_AUTH']
 
-    matomo_api_baseurl = f"{matomo_server_url}/?module=API" \
+    matomo_api_baseurl = f"https://{matomo_server_url}/?module=API" \
                          f"&idSite={matomo_site_id}" \
                          f"&token_auth={matomo_token_auth}" \
                          f"&format=json" \

--- a/flaskenv.template
+++ b/flaskenv.template
@@ -21,7 +21,7 @@ ORCID_OAUTH_CLIENT_SECRET=<ORCID SECRET ID>
 ORCID_TOKEN_URL=https://orcid.org/oauth/token
 ADMIN_EMAIL = <Your gmail>
 WEBHOOKS_SECRET=<github webhook secret>
-MATOMO_SERVER_URL=<Your Matomo URL>
+MATOMO_SERVER_URL=<Your Matomo base URL> ## no http:// or https://
 MATOMO_SITE_ID=1
 
 # GITHUB CREDENTIALS FOR MARKDOWN RENDERER (OPTIONAL)


### PR DESCRIPTION
When the analytics got pulled to the portal, the config was changed from `base_url` to `https://base_url` causing the JS tracker to fail. 

In this PR, we modify the `update_analytics` cli function to add `https://` in front of the Matomo URL and add a note next to the config on the `flaskenv.template` to avoid any confusion in the future.

There are probably more elegant ways to deal with this but we need a short term fix so that the updates to the analytics can run and the tracking code can work correctly.