### PR TITLE
Filter out random numbers from the keywords search analytics graph

### DIFF
--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -238,6 +238,5 @@ def keywords():
     elements = list(filter(lambda e: len(e['label']) > 2, elements))
 
     elements.sort(key=lambda e: e["nb_hits"], reverse=True)
-    print(elements)
 
     return json.dumps(elements)

--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -206,7 +206,7 @@ def keywords():
         # skip searches with a sum_time_spent below 5 seconds as users are probably
         # still typing the words in the searches when the time spent on the result is
         # less than 5 seconds
-        if v.sum_time_spent < 5:
+        if v.sum_time_spent < 2:
             continue
 
         # skip if the keyword is a number and is not part of a dataset name

--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -203,12 +203,6 @@ def keywords():
         if v.label is None:
             continue
 
-        # skip searches with an exit rate below 30% considered "unsuccessful" searches
-        # otherwise, get a lot of 'b' 'bi' 'big' 'bigb' and so on
-        # exit_rate = int(re.match(r'(\d*)%', v.exit_rate).group(1))
-        # if exit_rate < 30:
-        #     continue
-
         # skip searches with a sum_time_spent below 5 seconds as users are probably
         # still typing the words in the searches when the time spent on the result is
         # less than 5 seconds


### PR DESCRIPTION
This PR fixes a number of issues with the keywords search graph:
- This will filter out the numbers currently being displayed on the keyword search graph. The only exception is when the number is actually part of the dataset ID (example: 1000 genomes).

- To avoid seeing a lot of "b", "bi", "big" etc since every keystroke is recorded, the dataset resulting from the query is filtered out based on the sum_time_spent value (if under 5 seconds, it is likely the user did not finish typing the word they are doing the search for).

- Fix the number keywords being displayed at the top of the graph even though their number of hits is very low. The sorting is now really based on the number of hits only.

Before:
![Screen Shot 2021-05-11 at 3 18 03 PM](https://user-images.githubusercontent.com/1402456/117871999-172d7800-b26c-11eb-940e-fa16c1086af8.png)


After:
![Screen Shot 2021-05-11 at 4 20 45 PM](https://user-images.githubusercontent.com/1402456/117879348-ddad3a80-b274-11eb-9de9-5c38418d714d.png)



Related to #452