### PR TITLE
Rewording of download button and datalad download section header on detailed dataset page

### DIFF
--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -237,7 +237,7 @@
     <div class="d-flex flex-row align-items-center">
     <div class="col-md-2">
       <a href="{{ zipLocation }}" class="btn btn-outline-secondary " id="downloadButton">
-        Download This Version
+        Download Current Version
       </a>
     </div>
   </div>
@@ -262,7 +262,7 @@
     <a name="dataladInstructions"></a>
   </div>
   <div class="d-flex flex-row align-items-center">
-    <h2 class="px-2">DataLad Dataset Download Instructions</h2>
+    <h2 class="px-2">Download Using DataLad</h2>
     <a
       class="px-2"
       target="_blank"


### PR DESCRIPTION
This replaces the text of the download button and Datalad instruction sections:

 
- Replaced "Download This Version" download button text with "Download current version"
 
- Clarified the contrast between direct download and datalad sections by changing section title from "DataLad Dataset Download Instructions" to "Download using DataLad"

#462