### PR TITLE
Move DATS editor in its own page

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -141,3 +141,19 @@ def tutorial():
     content = github.get_tutorial_content()
 
     return render_template('tutorial.html', title='CONP | Tutorial', user=current_user, content=content)
+
+@main_bp.route('/dats-editor')
+def dats_editor():
+    """ DATS Editor Route
+
+        Route to lead to the DATS Editor page
+
+        Args:
+            None
+        Returns:
+            rendered template for dats-editor.html
+    """
+
+    content = github.get_tutorial_content()
+
+    return render_template('dats-editor.html', title='CONP | DATS Editor', user=current_user, content=content)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -142,6 +142,7 @@ def tutorial():
 
     return render_template('tutorial.html', title='CONP | Tutorial', user=current_user, content=content)
 
+
 @main_bp.route('/dats-editor')
 def dats_editor():
     """ DATS Editor Route

--- a/app/templates/dats-editor.html
+++ b/app/templates/dats-editor.html
@@ -1,0 +1,29 @@
+{% extends 'common/base_main.html' %}
+
+<!-- Head Block -->
+
+{% block scripts %}
+{{ super() }}
+<script src=" {{ url_for('static',filename='js/react.development-16.11.0.js') }}"></script>
+<script src=" {{ url_for('static',filename='js/react-dom.development-16.11.0.js') }}"></script>
+<script type="text/javascript" src="static/lib/conp-react/umd/conp-react.js"></script>
+{% endblock %}
+
+<!-- Title Block -->
+
+{% block contenttitle %}
+<h2><span style="color: red">CONP Portal</span> | DATS Editor</h2>
+{% endblock %}
+
+<!-- Content Block -->
+
+{% block appcontent %}
+<div>
+  <div id="dats-editor-container"></div>
+
+  <script type="text/javascript">
+          const datsEditor = React.createElement(CONPReact.DatsEditorForm);
+          ReactDOM.render(datsEditor, document.querySelector("#dats-editor-container"));
+  </script>
+</div>
+{% endblock %}

--- a/app/templates/share.html
+++ b/app/templates/share.html
@@ -11,39 +11,11 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color:red;">CONP Portal </span> | Share</h2>
+    <h2><span style="color:red;">CONP Portal </span> | Share</h2>
 {% endblock %}
 
 <!-- Content Block -->
 
 {% block appcontent %}
-<ul class="nav nav-tabs nav-fill my-4" id="myTab" role="tablist">
-  <li class="nav-item">
-    <a class="nav-link active" id="howto-tab" data-toggle="tab" href="#howto" role="tab" aria-controls="howto"
-      aria-selected="true"><h5>How to Share Datasets and Pipelines</h5></a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" id="dats-editor-tab" data-toggle="tab" href="#dats-editor" role="tab"
-      aria-controls="dats-editor" aria-selected="false"><h5>Create or Edit a DATS.json file</h5></a>
-  </li>
-</ul>
-<div class="tab-content" id="myTabContent">
-  <div class="tab-pane fade show active" id="howto" role="tabpanel" aria-labelledby="howto-tab">
-    <div class="p-2 flex-fill">
-      {{ content|safe }}
-    </div>
-  </div>
-  <div class="tab-pane fade" id="dats-editor" role="tabpanel" aria-labelledby="dats-editor-tab">
-    <div class="p-2 flex-fill">
-      <div id="dats-editor-container">
-
-        <script type="text/javascript">
-          const datsEditor = React.createElement(CONPReact.DatsEditorForm);
-          ReactDOM.render(datsEditor, document.querySelector("#dats-editor-container"));
-        </script>
-
-      </div>
-    </div>
-  </div>
-</div>
+{{ content|safe }}
 {% endblock %}

--- a/app/templates/share.html
+++ b/app/templates/share.html
@@ -17,5 +17,5 @@
 <!-- Content Block -->
 
 {% block appcontent %}
-{{ content|safe }}
+    {{ content|safe }}
 {% endblock %}


### PR DESCRIPTION
This PR moves the DATS editor into its own page instead of being a tab in the Share page.

Note: the documentation displayed on the portal for the Share page is being updated in the following PR to add the link to the DATS editor: https://github.com/CONP-PCNO/conp-documentation/pull/71