### PR TITLE
Update urllib3 and requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,7 @@ pytz==2018.9
 PyYAML==5.4
 rauth==0.7.3
 recommonmark==0.5.0
-requests==2.21.0
+requests==2.25.1
 requests-oauthlib==1.2.0
 SecretStorage==3.1.1
 simplejson==3.16.0
@@ -111,7 +111,7 @@ tabulate==0.8.3
 termcolor==1.1.0
 toml==0.10.1
 tqdm==4.38.0
-urllib3==1.24.3
+urllib3==1.26.5
 URLObject==2.4.3
 visitor==0.1.3
 wcwidth==0.1.7


### PR DESCRIPTION
Dependabot PR https://github.com/CONP-PCNO/conp-portal/pull/474 fails the tests because requests need to be updated in addition to urllib3 for the install to work.

This PR should fix the travis errors see in #474.