### PR TITLE
Update the terms of use to add latest text from Ethics and Governance Committee

### DIFF
--- a/app/templates/common/base_main.html
+++ b/app/templates/common/base_main.html
@@ -103,7 +103,7 @@
       </div>
       <div class="modal-body">
         <div class="terms-body">
-          <p class="text-center">(Last Updated on March 30th, 2020)</p>
+          <p class="text-center">(Last Updated on July 5th, 2021)</p>
           <h6>The user agrees:</h6>
           <ul>
             <li>
@@ -146,6 +146,10 @@
               that the CONP excludes all liability, to the greatest extent
               permitted by applicable law, with respect to the use or
               distribution of resources.
+            </li>
+            <li>
+              to contact the dataset creator immediately if it becomes apparent that data have
+              not been sufficiently de-identified.
             </li>
           </ul>
           <h6>The user agrees not to:</h6>


### PR DESCRIPTION
This adds the following sentence to the section "The user agrees:"
- to contact the dataset creator immediately if it becomes apparent that data have not been sufficiently de-identified.

The Terms of Use has also been updated to July 5th, 2021.

See below for a screenshot rendering:
![Screen Shot 2021-07-05 at 3 49 23 PM](https://user-images.githubusercontent.com/1402456/124513589-1e26c180-dda9-11eb-8fba-9b7a835edb54.png)

