### PR TITLE
Add confirm dialogue before download

### DIFF
--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -244,10 +244,20 @@
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-body">
-        <h4 class="modal-title w-100 text-center" id="modalLongTitle">
-          You are about to download a {{ data.size }} file.
-        </h4>
-        <h4 class="modal-title w-100 text-center" id="modalLongTitle">Are you sure?</h4>
+        <table>
+          <tr>
+            <td style="width:150px">
+              <img src="../static/img/conp.png" class="text-center" style="width:100%">
+            </td>
+            <td style="width:25px"></td>
+            <td colspan="41">
+              <h4 class="modal-title w-100 text-center" id="modalLongTitle">
+                You are about to download a {{ data.size }} file.
+              </h4>
+              <h4 class="modal-title w-100 text-center" id="modalLongTitle">Are you sure?</h4>
+            </td>
+          </tr>
+        </table>
       </div>
       <div class="modal-footer">
         <div class="btn-group btn-group-lg" style="width:100%">

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -254,7 +254,7 @@
           <button type="button" class="btn btn-outline-secondary" data-dismiss="modal" id="cancelDownload">
             Cancel
           </button>
-          <a href="{{ zipLocation }}" class="btn btn-secondary" id="downloadButton">
+          <a href="{{ zipLocation }}" class="btn btn-secondary" id="confirmDownload">
             Download
           </a>
         </div>
@@ -446,6 +446,13 @@ datalad get &ltfilepath&gt</pre
 <script>
   $(function () {
       $("#cancelDownload").on("click", function (event) {
+          $("#confirmDownloadModal").modal("hide");
+      })
+  })
+</script>
+<script>
+  $(function () {
+      $("#confirmDownload").on("click", function (event) {
           $("#confirmDownloadModal").modal("hide");
       })
   })

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -233,7 +233,36 @@
     <div class="card-body">{{readme|safe}}</div>
   </div>
 </div>
-    
+
+<div
+  class="modal fade"
+  id="confirmDownloadModal"
+  role="dialog"
+  aria-labelledby="modalCenterTitle"
+  aria-hidden="true"
+>
+  <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <h4 class="modal-title w-100 text-center" id="modalLongTitle">
+          You are about to download a {{ data.size }} file.
+        </h4>
+        <h4 class="modal-title w-100 text-center" id="modalLongTitle">Are you sure?</h4>
+      </div>
+      <div class="modal-footer">
+        <div class="btn-group btn-group-lg" style="width:100%">
+          <button type="button" class="btn btn-outline-secondary" data-dismiss="modal" id="cancelDownload">
+            Cancel
+          </button>
+          <a href="{{ zipLocation }}" class="btn btn-secondary" id="downloadButton">
+            Download
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="d-flex flex-column p-2">
   <div class="d-flex flex-row align-items-center">
     <a name="downloadInstructions"></a>
@@ -244,14 +273,13 @@
   {% if showDownloadButton %}
     <div class="d-flex flex-row align-items-center">
     <div class="col-md-2">
-      <a
-        href="{{ zipLocation }}"
-        onclick="return confirm('You are about to download a {{ data.size }} file. Are you sure?')"
+      <button
+        onclick=$("#confirmDownloadModal").modal("show")
         class="btn btn-outline-secondary "
         id="downloadButton"
       >
         Download Current Version ({{ data.size }})
-      </a>
+      </button>
     </div>
   </div>
   {% else %}
@@ -413,6 +441,14 @@ datalad get &ltfilepath&gt</pre
   element.showDownload = true;
   const reactElement = React.createElement(CONPReact.DatasetElement, element);
   ReactDOM.render(reactElement, document.querySelector("#mount-display"));
+</script>
+
+<script>
+  $(function () {
+      $("#cancelDownload").on("click", function (event) {
+          $("#confirmDownloadModal").modal("hide");
+      })
+  })
 </script>
 <!--/span-->
 {% endblock %}

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -244,15 +244,20 @@
   {% if showDownloadButton %}
     <div class="d-flex flex-row align-items-center">
     <div class="col-md-2">
-      <a href="{{ zipLocation }}" class="btn btn-outline-secondary " id="downloadButton">
-        Download Current Version
+      <a
+        href="{{ zipLocation }}"
+        onclick="return confirm('You are about to download a {{ data.size }} file. Are you sure?')"
+        class="btn btn-outline-secondary "
+        id="downloadButton"
+      >
+        Download Current Version ({{ data.size }})
       </a>
     </div>
   </div>
   {% else %}
   <div class="d-flex flex-row align-items-center">
     <div class="col-md-2">
-      <a class="btn btn-outline-secondary disabled" id="UnvailableDownloadButton">
+      <a class="btn btn-outline-secondary disabled" id="UnavailableDownloadButton">
         Not Available
       </a>
     </div>


### PR DESCRIPTION
This modifies the download button behaviour so that a modal window appears asking the user to confirm they want to download XXGB of data.

![Screen Shot 2021-08-18 at 2 51 33 PM](https://user-images.githubusercontent.com/1402456/129955431-f91da75f-f215-438a-ad2a-fb2a1dd79f50.png)

Note: this can be tested on portal-dev.conp.ca