### PR TITLE
Add example SPARQL queries

### DIFF
--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -7,7 +7,7 @@ SELECT DISTINCT ?title ?license_name WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
   sdo:license ?license.
-  ?license sdo:name ?license_name.
+?license sdo:name ?license_name.
 FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
 }
 """
@@ -32,22 +32,22 @@ SELECT DISTINCT ?dataset ?title ?format WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
   sdo:distribution ?distribution.
-  ?distribution conp:formats ?format.
+?distribution conp:formats ?format.
 FILTER (regex(?format, "MINC", "i"))
-}"""
+}
+"""
 
 example_query_4 = """# The query searches for datasets that have an authorization type set to "Public".
 
 PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
-SELECT DISTINCT ?dataset_name ?value
-WHERE {
-    ?dataset a sdo:Dataset;
-        sdo:name ?dataset_name;
-        sdo:distribution ?distribution.
-  ?distribution sdo:accessMode ?access_mode.
-  ?access_mode conp:authorizations ?authorization.
-  ?authorization sdo:value ?value.
+SELECT DISTINCT ?dataset_name ?value WHERE {
+?dataset a sdo:Dataset;
+  sdo:name ?dataset_name;
+  sdo:distribution ?distribution.
+?distribution sdo:accessMode ?access_mode.
+?access_mode conp:authorizations ?authorization.
+?authorization sdo:value ?value.
 FILTER regex(lcase(str(?value)), "public", "i")
 }
 """
@@ -55,13 +55,15 @@ FILTER regex(lcase(str(?value)), "public", "i")
 example_query_5 = """# The query returns a list of cited papers (including their doi) with datasets that cited them.
 
 PREFIX sdo: <https://schema.org/>
-SELECT DISTINCT ?citation_name ?doi (GROUP_CONCAT(DISTINCT ?title; separator=" | ") as ?datasets) (COUNT(DISTINCT ?title) as ?citation_count) WHERE {
+SELECT DISTINCT ?citation_name ?doi
+(GROUP_CONCAT(DISTINCT ?title; separator=" | ") as ?datasets) 
+(COUNT(DISTINCT ?title) as ?citation_count) WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
   sdo:citation ?citation.
-  ?citation sdo:identifier ?value;
-            sdo:name ?citation_name.
-  ?value sdo:identifier ?doi
+?citation sdo:identifier ?value;
+          sdo:name ?citation_name.
+?value sdo:identifier ?doi.
 }
 GROUP BY ?citation_name ?doi
 """

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -12,7 +12,7 @@ FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
 }
 """
 
-example_query_2 = """# The query searches for all datasets that are about Alzheimer's.
+example_query_2 = """# The query searches for all datasets that are about Alzheimer's disease.
 
 PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
@@ -53,17 +53,16 @@ FILTER regex(lcase(str(?value)), "public", "i")
 }
 """
 
-example_query_5 = """# The query returns all datasets and their content size.
+example_query_5 = """# The query returns a list of cited papers (including their doi) with datasets that cited them.
 
 PREFIX sdo: <https://schema.org/>
-PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
-SELECT DISTINCT ?dataset_name ?content_size ?value
-WHERE {
-    ?dataset a sdo:Dataset;
-        sdo:name ?dataset_name;
-        sdo:distribution ?distribution.
-  ?distribution sdo:contentSize ?content_size;
-                conp:unit ?unit.
-  ?unit sdo:value ?value.
+SELECT DISTINCT ?citation_name ?doi (GROUP_CONCAT(DISTINCT ?title; separator=" | ") as ?datasets) (COUNT(DISTINCT ?title) as ?citation_count) WHERE {
+?dataset a sdo:Dataset;
+  sdo:name ?title;
+  sdo:citation ?citation.
+  ?citation sdo:identifier ?value;
+            sdo:name ?citation_name.
+  ?value sdo:identifier ?doi
 }
+GROUP BY ?citation_name ?doi
 """

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -1,39 +1,69 @@
 # The file contains example SPARQL queries that populate SPARQL query editor
 
-example_query_1 = """# The query
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT * WHERE {
-    ?sub ?pred ?obj .
-} LIMIT 50
+example_query_1 = """# The query searches for all datasets that are licensed under the CC BY-NC-SA license.
+
+PREFIX sdo: <https://schema.org/>
+SELECT DISTINCT ?title ?license_name WHERE {
+?dataset a sdo:Dataset;
+  sdo:name ?title;
+  sdo:license ?license.
+  ?license sdo:name ?license_name.
+FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
+}
 """
 
-example_query_2 = """# The query looks for all datasets that annotated with a concept Homo sapiens
-PREFIX sdo: <https://schema.org/>
-SELECT DISTINCT ?datasetname ?conceptname ?uri
-WHERE {
-?dataset a sdo:Dataset;
-    sdo:name ?datasetname;
-    sdo:about ?about.  
-OPTIONAL {
-   ?about sdo:name ?conceptname.
-}
-OPTIONAL {
-    { 
-    ?concept sdo:identifier ?identifier_val;
-        sdo:Property ?uri.
-    } 
-    UNION 
-    { 
-    ?concept sdo:value ?annotation_val;
-        sdo:url ?uri.
-    }
+example_query_2 = """# The query searches for all datasets that are about Alzheimer's.
 
-    ?conceptroot (<>|!<>) ?concept;
-        sdo:name ?conceptname.
-    ?about (<>|!<>)* ?conceptroot.
+PREFIX sdo: <https://schema.org/>
+PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
+SELECT DISTINCT ?dataset ?title ?about_name WHERE {
+?dataset a sdo:Dataset;
+  sdo:name ?title;
+  sdo:about ?about.
+?about sdo:name ?about_name.         
+FILTER regex(lcase(str(?about_name)), "alzheimer", "i")
 }
-FILTER (?conceptname = "Homo sapiens"^^sdo:Text)
-FILTER NOT EXISTS { ?otherdata a sdo:Dataset; sdo:hasPart ?dataset }
+"""
+
+example_query_3 = """# The query searches for all datasets that have distribution in the MINC file format.
+
+PREFIX sdo: <https://schema.org/>
+PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
+SELECT DISTINCT ?dataset ?title ?format WHERE {
+?dataset a sdo:Dataset;
+  sdo:name ?title;
+  sdo:distribution ?distribution.
+  ?distribution conp:formats ?format.
+FILTER (regex(?format, "MINC", "i"))
+}"""
+
+example_query_4 = """# This query search for datasets that have an authorization type set to "Public".
+
+PREFIX sdo: <https://schema.org/>
+PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
+SELECT DISTINCT ?dataset_name ?value
+WHERE {
+    ?dataset a sdo:Dataset;
+        sdo:name ?dataset_name;
+        sdo:distribution ?distribution.
+  ?distribution sdo:accessMode ?access_mode.
+  ?access_mode conp:authorizations ?authorization.
+  ?authorization sdo:value ?value.
+FILTER regex(lcase(str(?value)), "public", "i")
+}
+"""
+
+example_query_5 = """# This query returns all datasets and their content size.
+
+PREFIX sdo: <https://schema.org/>
+PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
+SELECT DISTINCT ?dataset_name ?content_size ?value
+WHERE {
+    ?dataset a sdo:Dataset;
+        sdo:name ?dataset_name;
+        sdo:distribution ?distribution.
+  ?distribution sdo:contentSize ?content_size;
+                conp:unit ?unit.
+  ?unit sdo:value ?value.
 }
 """

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -37,7 +37,7 @@ SELECT DISTINCT ?dataset ?title ?format WHERE {
 FILTER (regex(?format, "MINC", "i"))
 }"""
 
-example_query_4 = """# This query searches for datasets that have an authorization type set to "Public".
+example_query_4 = """# The query searches for datasets that have an authorization type set to "Public".
 
 PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
@@ -53,7 +53,7 @@ FILTER regex(lcase(str(?value)), "public", "i")
 }
 """
 
-example_query_5 = """# This query returns all datasets and their content size.
+example_query_5 = """# The query returns all datasets and their content size.
 
 PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -1,0 +1,39 @@
+# The file contains example SPARQL queries that populate SPARQL query editor
+
+example_query_1 = """# The query
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT * WHERE {
+    ?sub ?pred ?obj .
+} LIMIT 50
+"""
+
+example_query_2 = """# The query looks for all datasets that annotated with a concept Homo sapiens
+PREFIX sdo: <https://schema.org/>
+SELECT DISTINCT ?datasetname ?conceptname ?uri
+WHERE {
+?dataset a sdo:Dataset;
+    sdo:name ?datasetname;
+    sdo:about ?about.  
+OPTIONAL {
+   ?about sdo:name ?conceptname.
+}
+OPTIONAL {
+    { 
+    ?concept sdo:identifier ?identifier_val;
+        sdo:Property ?uri.
+    } 
+    UNION 
+    { 
+    ?concept sdo:value ?annotation_val;
+        sdo:url ?uri.
+    }
+
+    ?conceptroot (<>|!<>) ?concept;
+        sdo:name ?conceptname.
+    ?about (<>|!<>)* ?conceptroot.
+}
+FILTER (?conceptname = "Homo sapiens"^^sdo:Text)
+FILTER NOT EXISTS { ?otherdata a sdo:Dataset; sdo:hasPart ?dataset }
+}
+"""

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -15,7 +15,6 @@ FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
 example_query_2 = """# The query searches for all datasets that are about Alzheimer's disease.
 
 PREFIX sdo: <https://schema.org/>
-PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
 SELECT DISTINCT ?dataset ?title ?about_name WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -37,7 +37,7 @@ SELECT DISTINCT ?dataset ?title ?format WHERE {
 FILTER (regex(?format, "MINC", "i"))
 }"""
 
-example_query_4 = """# This query search for datasets that have an authorization type set to "Public".
+example_query_4 = """# This query searches for datasets that have an authorization type set to "Public".
 
 PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -12,7 +12,9 @@ from flask_login import current_user
 from app.models import Dataset, DatasetAncestry
 from app.search import search_bp
 from app.search.models import DATSDataset, DatasetCache
-from app.search.queries import example_query_1, example_query_2
+from app.search.queries import (
+    example_query_1, example_query_2, example_query_3, example_query_4, example_query_5
+)
 from app.services import github
 from config import Config
 
@@ -532,7 +534,10 @@ def sparql():
     sparql_endpoint = Config.NEXUS_SPARQL_ENDPOINT
     queries = {
         "Example 1": example_query_1,
-        "Example 2": example_query_2
+        "Example 2": example_query_2,
+        "Example 3": example_query_3,
+        "Example 4": example_query_4,
+        "Example 5": example_query_5
     }
 
     return render_template('sparql.html', title='CONP | SPARQL', user=current_user,

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -12,6 +12,7 @@ from flask_login import current_user
 from app.models import Dataset, DatasetAncestry
 from app.search import search_bp
 from app.search.models import DATSDataset, DatasetCache
+from app.search.queries import example_query_1, example_query_2
 from app.services import github
 from config import Config
 
@@ -529,8 +530,13 @@ def sparql():
     """
 
     sparql_endpoint = Config.NEXUS_SPARQL_ENDPOINT
+    queries = {
+        "Example 1": example_query_1,
+        "Example 2": example_query_2
+    }
 
-    return render_template('sparql.html', title='CONP | SPARQL', user=current_user, sparql_endpoint=sparql_endpoint)
+    return render_template('sparql.html', title='CONP | SPARQL', user=current_user,
+                           sparql_endpoint=sparql_endpoint, queries=queries)
 
 
 def get_dataset_metadata_information(dataset):

--- a/app/templates/sparql.html
+++ b/app/templates/sparql.html
@@ -65,5 +65,13 @@ for (query in queries) {
   .yasr .yasr_results .CodeMirror {
     height: fit-content;
   }
+
+  #yasr_plugin_control > div > div:nth-child(1) > label > span {
+    padding: 0px 5px 0px 0px;
+  }
+
+  #yasr_plugin_control > div > div:nth-child(1) > label {
+    margin-bottom: 0;
+  }
 </style>
 {% endblock %}

--- a/app/templates/sparql.html
+++ b/app/templates/sparql.html
@@ -24,6 +24,8 @@
 {% block appcontent %}
 <div id="yasgui" style="padding:10px 0px;"></div>
 <script>
+// main yasgui block
+
   const yasgui = new Yasgui(document.getElementById("yasgui"),
   {
     requestConfig:
@@ -34,6 +36,24 @@
     copyEndpointOnNewTab: true
   }
   );
+
+// keep the default query tab active
+
+for (tab in yasgui.tabElements._tabs) {
+    yasgui.getTab(tab).close()
+}
+yasgui.addTab(true, { name: 'Query' });
+
+// read predefined queries
+
+const queries = {{queries | tojson | safe}};
+
+for (query in queries) {
+    value = queries[query];
+    yasgui.addTab(
+      false, { name: query, yasqe:{value:value} }
+    );
+}
 </script>
 <style>
   .yasgui .autocompleteWrapper {


### PR DESCRIPTION
## Purpose
This PR adds five predefined example SPARQL queries.
Each query prepopulates a separate tab in the SPARQL editor at `/sparql`.

## Related issues
#412

## Current behaviour
Only one tab with a generic query to query for 10 random triples.

## New behaviour
Overall six tabs in the query editor: one default active tab to start the query and five tabs with example queries that follow our schema.org context mappings.

#### Does this introduce a major change?
- [ ] Yes
- [x] No



![example_sparql_queries](https://user-images.githubusercontent.com/11253950/131199667-f254baf7-95c1-407e-b14c-7bf0cca00ebb.JPG)
