### PR TITLE
Move matomo maps at the bottom of the analytics page

### DIFF
--- a/app/templates/analytics.html
+++ b/app/templates/analytics.html
@@ -18,32 +18,6 @@
 {% block appcontent %}
 
 <div class="d-flex flex-column">
-  <div class="d-flex flex-row">
-    <!-- Visitor Map -->
-    <div id="widgetIframe" class="w-100">
-      <iframe
-        width="100%"
-        height="400"
-        src="https://matomo-dev.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=UserCountryMap&actionToWidgetize=visitorMap&idSite=2&period=range&date=2021-01-22,today&disableLink=1&widget=1"
-        scrolling="no"
-        frameborder="0"
-        marginheight="0"
-        marginwidth="0"
-      ></iframe>
-    </div>
-    <!-- Real-time Visitor Map -->
-    <div id="widgetIframe" class="w-100">
-      <iframe
-        width="100%"
-        height="400"
-        src="https://matomo-dev.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=UserCountryMap&actionToWidgetize=realtimeMap&idSite=2&period=range&date=last30&disableLink=1&widget=1"
-        scrolling="no"
-        frameborder="0"
-        marginheight="0"
-        marginwidth="0"
-      ></iframe>
-    </div>
-  </div>
   <div class="card p-1 m-1">
     <div id="analytics-chart-1">
       <script type="text/javascript">
@@ -151,6 +125,33 @@
           document.querySelector("#analytics-chart-7")
         );
       </script>
+    </div>
+  </div>
+
+  <div class="d-flex flex-row">
+    <!-- Visitor Map -->
+    <div id="widgetIframe" class="w-100">
+      <iframe
+        width="100%"
+        height="400"
+        src="https://matomo-dev.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=UserCountryMap&actionToWidgetize=visitorMap&idSite=2&period=range&date=2021-01-22,today&disableLink=1&widget=1"
+        scrolling="no"
+        frameborder="0"
+        marginheight="0"
+        marginwidth="0"
+      ></iframe>
+    </div>
+    <!-- Real-time Visitor Map -->
+    <div id="widgetIframe" class="w-100">
+      <iframe
+        width="100%"
+        height="400"
+        src="https://matomo-dev.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=UserCountryMap&actionToWidgetize=realtimeMap&idSite=2&period=range&date=last30&disableLink=1&widget=1"
+        scrolling="no"
+        frameborder="0"
+        marginheight="0"
+        marginwidth="0"
+      ></iframe>
     </div>
   </div>
 


### PR DESCRIPTION
As discussed at the CONP dev this week, this PR moves the Matomo maps at the bottom of the analytics page so that when a user exceed the limit number of login, the Matomo error does not appear first in the page as the other graphics in the analytics page are still viewable.

Resolves #496 