### PR TITLE
Modify links to matomo for production

### DIFF
--- a/app/templates/analytics.html
+++ b/app/templates/analytics.html
@@ -134,7 +134,7 @@
       <iframe
         width="100%"
         height="400"
-        src="https://matomo-dev.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=UserCountryMap&actionToWidgetize=visitorMap&idSite=2&period=range&date=2021-01-22,today&disableLink=1&widget=1"
+        src="https://matomo.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=UserCountryMap&actionToWidgetize=visitorMap&idSite=2&period=range&date=2021-01-22,today&disableLink=1&widget=1"
         scrolling="no"
         frameborder="0"
         marginheight="0"
@@ -146,7 +146,7 @@
       <iframe
         width="100%"
         height="400"
-        src="https://matomo-dev.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=UserCountryMap&actionToWidgetize=realtimeMap&idSite=2&period=range&date=last30&disableLink=1&widget=1"
+        src="https://matomo.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=UserCountryMap&actionToWidgetize=realtimeMap&idSite=2&period=range&date=last30&disableLink=1&widget=1"
         scrolling="no"
         frameborder="0"
         marginheight="0"
@@ -160,7 +160,7 @@
     <iframe
       width="100%"
       height="800"
-      src="https://matomo-dev.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=Transitions&actionToWidgetize=getTransitions&idSite=2&period=range&date=last30&disableLink=1&widget=1"
+      src="https://matomo.acelab.ca/index.php?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=Transitions&actionToWidgetize=getTransitions&idSite=2&period=range&date=last30&disableLink=1&widget=1"
       scrolling="no"
       frameborder="0"
       marginheight="0"


### PR DESCRIPTION
This updates the URL used to call the widgets of Matomo in the analytics page to use the production URL instead of dev. This will need to be merged once Andy is done migrating Matomo to production.

