### PR TITLE
Updated canned queries for new nexus context

### DIFF
--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -41,8 +41,8 @@ SELECT DISTINCT ?dataset ?title ?format WHERE {
   sdo:name ?title;
   nexus:deprecated false;
   sdo:distribution ?distribution.
-?distribution conp:formats ?format.
-FILTER (regex(?format, "MINC", "i"))
+?distribution sdo:encodingFormat ?format.
+FILTER (regex(str(?format), "MINC", "i"))
 }
 """
 
@@ -58,7 +58,7 @@ SELECT DISTINCT ?dataset_name ?value WHERE {
   nexus:deprecated false;
   sdo:distribution ?distribution.
 ?distribution sdo:accessMode ?access_mode.
-?access_mode conp:authorizations ?authorization.
+?access_mode sdo:permissionType ?authorization.
 ?authorization sdo:value ?value.
 FILTER regex(lcase(str(?value)), "public", "i")
 }

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -11,8 +11,7 @@ SELECT DISTINCT ?title ?license_name ?data_portal WHERE {
   sdo:name ?title;
   nexus:deprecated false;
   conp:conp_portal_website ?data_portal;
-  sdo:license ?license.
-?license sdo:name ?license_name.
+  sdo:license/sdo:name ?license_name.
 FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
 }
 """
@@ -28,8 +27,7 @@ SELECT DISTINCT ?data_portal ?title ?about_name WHERE {
   sdo:name ?title;
   nexus:deprecated false;
   conp:conp_portal_website ?data_portal;
-  sdo:about ?about.
-?about sdo:name ?about_name.         
+  sdo:about/sdo:name ?about_name.         
 FILTER regex(lcase(str(?about_name)), "alzheimer", "i")
 }
 """
@@ -45,8 +43,7 @@ SELECT DISTINCT ?data_portal ?title ?format WHERE {
   sdo:name ?title;
   nexus:deprecated false;
   conp:conp_portal_website ?data_portal;
-  sdo:distribution ?distribution.
-?distribution sdo:encodingFormat ?format.
+  sdo:distribution/sdo:encodingFormat ?format.
 FILTER (regex(str(?format), "MINC", "i"))
 }
 """
@@ -62,10 +59,7 @@ SELECT DISTINCT ?data_portal ?dataset_name ?value WHERE {
   sdo:name ?dataset_name;
   nexus:deprecated false;
   conp:conp_portal_website ?data_portal;
-  sdo:distribution ?distribution.
-?distribution sdo:accessMode ?access_mode.
-?access_mode sdo:permissionType ?authorization.
-?authorization sdo:value ?value.
+  sdo:distribution/sdo:accessMode/sdo:permissionType/sdo:value ?value.
 FILTER regex(lcase(str(?value)), "public", "i")
 }
 """
@@ -82,9 +76,9 @@ SELECT DISTINCT ?citation_name ?doi
   sdo:name ?title;
   nexus:deprecated false;
   sdo:citation ?citation.
-?citation sdo:identifier ?value;
+?citation sdo:identifier/sdo:identifier ?doi;
           sdo:name ?citation_name.
-?value sdo:identifier ?doi.
+
 }
 GROUP BY ?citation_name ?doi
 """

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -3,9 +3,12 @@
 example_query_1 = """# The query searches for all datasets that are licensed under the CC BY-NC-SA license.
 
 PREFIX sdo: <https://schema.org/>
+PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
+
 SELECT DISTINCT ?title ?license_name WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
+  nexus:deprecated false;
   sdo:license ?license.
 ?license sdo:name ?license_name.
 FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
@@ -15,9 +18,12 @@ FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
 example_query_2 = """# The query searches for all datasets that are about Alzheimer's disease.
 
 PREFIX sdo: <https://schema.org/>
+PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
+
 SELECT DISTINCT ?dataset ?title ?about_name WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
+  nexus:deprecated false;
   sdo:about ?about.
 ?about sdo:name ?about_name.         
 FILTER regex(lcase(str(?about_name)), "alzheimer", "i")
@@ -28,9 +34,12 @@ example_query_3 = """# The query searches for all datasets that have distributio
 
 PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
+PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
+
 SELECT DISTINCT ?dataset ?title ?format WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
+  nexus:deprecated false;
   sdo:distribution ?distribution.
 ?distribution conp:formats ?format.
 FILTER (regex(?format, "MINC", "i"))
@@ -41,9 +50,12 @@ example_query_4 = """# The query searches for datasets that have an authorizatio
 
 PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
+PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
+
 SELECT DISTINCT ?dataset_name ?value WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?dataset_name;
+  nexus:deprecated false;
   sdo:distribution ?distribution.
 ?distribution sdo:accessMode ?access_mode.
 ?access_mode conp:authorizations ?authorization.
@@ -55,11 +67,14 @@ FILTER regex(lcase(str(?value)), "public", "i")
 example_query_5 = """# The query returns a list of cited papers (including their doi) with datasets that cited them.
 
 PREFIX sdo: <https://schema.org/>
+PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
+
 SELECT DISTINCT ?citation_name ?doi
 (GROUP_CONCAT(DISTINCT ?title; separator=" | ") as ?datasets) 
 (COUNT(DISTINCT ?title) as ?citation_count) WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
+  nexus:deprecated false;
   sdo:citation ?citation.
 ?citation sdo:identifier ?value;
           sdo:name ?citation_name.

--- a/app/search/queries.py
+++ b/app/search/queries.py
@@ -3,12 +3,14 @@
 example_query_1 = """# The query searches for all datasets that are licensed under the CC BY-NC-SA license.
 
 PREFIX sdo: <https://schema.org/>
+PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
 PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
 
-SELECT DISTINCT ?title ?license_name WHERE {
+SELECT DISTINCT ?title ?license_name ?data_portal WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
   nexus:deprecated false;
+  conp:conp_portal_website ?data_portal;
   sdo:license ?license.
 ?license sdo:name ?license_name.
 FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
@@ -18,12 +20,14 @@ FILTER (?license_name = "CC BY-NC-SA"^^sdo:Text)
 example_query_2 = """# The query searches for all datasets that are about Alzheimer's disease.
 
 PREFIX sdo: <https://schema.org/>
+PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
 PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
 
-SELECT DISTINCT ?dataset ?title ?about_name WHERE {
+SELECT DISTINCT ?data_portal ?title ?about_name WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
   nexus:deprecated false;
+  conp:conp_portal_website ?data_portal;
   sdo:about ?about.
 ?about sdo:name ?about_name.         
 FILTER regex(lcase(str(?about_name)), "alzheimer", "i")
@@ -36,10 +40,11 @@ PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
 PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
 
-SELECT DISTINCT ?dataset ?title ?format WHERE {
+SELECT DISTINCT ?data_portal ?title ?format WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?title;
   nexus:deprecated false;
+  conp:conp_portal_website ?data_portal;
   sdo:distribution ?distribution.
 ?distribution sdo:encodingFormat ?format.
 FILTER (regex(str(?format), "MINC", "i"))
@@ -52,10 +57,11 @@ PREFIX sdo: <https://schema.org/>
 PREFIX conp: <https://reservoir.global/v1/vocabs/Public/CONP/>
 PREFIX nexus: <https://bluebrain.github.io/nexus/vocabulary/>
 
-SELECT DISTINCT ?dataset_name ?value WHERE {
+SELECT DISTINCT ?data_portal ?dataset_name ?value WHERE {
 ?dataset a sdo:Dataset;
   sdo:name ?dataset_name;
   nexus:deprecated false;
+  conp:conp_portal_website ?data_portal;
   sdo:distribution ?distribution.
 ?distribution sdo:accessMode ?access_mode.
 ?access_mode sdo:permissionType ?authorization.


### PR DESCRIPTION
## Related issues
Fixes #506 
#484 
https://github.com/CONP-PCNO/conp-dataset/issues/595

## Purpose
Nexus has rolled out the new schema.org contexts and also added a new attribute to each dataset to link to the corresponding conp portal website. The updated canned queries address these changes.

## Current behaviour
Queries are returning deprecated datasets and are not making use of the new conp portal links.

## New behaviour
canned queries
- will only return current datasets (undeprecated)
- show the link to the conp dataportal website for each result dataset
- make use of new schema.org terms that were previously custom conp/DATS terms
- have simplified syntax in some places
 
#### Does this introduce a major change?
- [ ] Yes
- [X] No

