### PR TITLE
Can load terms of use and privacy policy modal windows with URL

### DIFF
--- a/app/services/github.py
+++ b/app/services/github.py
@@ -44,7 +44,7 @@ def get_share_content():
 def get_faq_content():
     content = None
     try:
-        url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/Documentation_displayed_on_the_portal/CONP_FAQ.md'
+        url = 'https://raw.githubusercontent.com/cmadjar/conp-documentation/add_terms_of_use_to_FAQ/Documentation_displayed_on_the_portal/CONP_FAQ.md'
         headers = {'Content-type': 'text/html; charset=UTF-8'}
         response = requests.get(url, headers=headers)
 
@@ -60,7 +60,7 @@ def get_faq_content():
 def get_tutorial_content():
     content = None
     try:
-        url = 'https://raw.githubusercontent.com/cmadjar/conp-documentation/add_terms_of_use_to_FAQ/Documentation_displayed_on_the_portal/CONP_portal_tutorial.md'
+        url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/Documentation_displayed_on_the_portal/CONP_portal_tutorial.md'
         headers = {'Content-type': 'text/html; charset=UTF-8'}
         response = requests.get(url, headers=headers)
 

--- a/app/services/github.py
+++ b/app/services/github.py
@@ -44,7 +44,7 @@ def get_share_content():
 def get_faq_content():
     content = None
     try:
-        url = 'https://raw.githubusercontent.com/cmadjar/conp-documentation/add_terms_of_use_to_FAQ/Documentation_displayed_on_the_portal/CONP_FAQ.md'
+        url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/Documentation_displayed_on_the_portal/CONP_FAQ.md'
         headers = {'Content-type': 'text/html; charset=UTF-8'}
         response = requests.get(url, headers=headers)
 

--- a/app/services/github.py
+++ b/app/services/github.py
@@ -60,7 +60,7 @@ def get_faq_content():
 def get_tutorial_content():
     content = None
     try:
-        url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/Documentation_displayed_on_the_portal/CONP_portal_tutorial.md'
+        url = 'https://raw.githubusercontent.com/cmadjar/conp-documentation/add_terms_of_use_to_FAQ/Documentation_displayed_on_the_portal/CONP_portal_tutorial.md'
         headers = {'Content-type': 'text/html; charset=UTF-8'}
         response = requests.get(url, headers=headers)
 

--- a/app/templates/common/base_main.html
+++ b/app/templates/common/base_main.html
@@ -891,6 +891,19 @@
   });
 </script>
 
+<script>
+    $(document).ready(function () {
+        if (window.location.href.indexOf('#terms') != -1) {
+            $("#termsModal").modal("show");
+        }
+    });
+    $(document).ready(function () {
+        if (window.location.href.indexOf('#privacy') != -1) {
+            $("#privacyPolicyModal").modal("show");
+        }
+    });
+</script>
+
 <div id="page">
   {% block navigation_bar %} {% include "fragments/navigation_bar.html" %} {%
   endblock %}


### PR DESCRIPTION
This modifies the code so that the terms of use and privacy policy modal windows could be open when accessing them with the following URLs:

https://portal.conp.ca/#terms
https://portal.conp.ca/#privacy
