### PR TITLE
Escape apostrophies in the title of datasets

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -175,7 +175,7 @@ def dataset_search():
         dataset = {
             "authorized": authorized,
             "id": d.dataset_id,
-            "title": d.name.replace("'", ""),
+            "title": d.name.replace("'", "\'"),
             "remoteUrl": d.remoteUrl,
             "isPrivate": d.is_private,
             "thumbnailURL": "/dataset_logo?id={}".format(d.dataset_id),


### PR DESCRIPTION
For some reason, the `'` character was replaced by nothing in the name of datasets instead of being escaped when displayed on the portal. This fixes the issue so that dataset titles with apostrophes can be correctly displayed.

Before:
![Screen Shot 2022-03-04 at 10 06 17 AM](https://user-images.githubusercontent.com/1402456/156787676-56f637e7-8b51-4a9a-92f3-0fabf027916e.png)

After:
![Screen Shot 2022-03-04 at 10 06 49 AM](https://user-images.githubusercontent.com/1402456/156787781-4b4bd908-6fcc-4923-b788-8a97fc870da0.png)

