### PR TITLE
Adding more CONP datasets to dataset-cbrain-ids.json with CBRAIN IDs

### DIFF
--- a/app/static/datasets/dataset-cbrain-ids.json
+++ b/app/static/datasets/dataset-cbrain-ids.json
@@ -15,5 +15,12 @@
 	"OpenPain subacute_longitudinal_study":"https://portal.cbrain.mcgill.ca/groups/switch?id=9243",
 	"OpenPain thermal":"https://portal.cbrain.mcgill.ca/groups/switch?id=9246",
 	"SIMON":"https://portal.cbrain.mcgill.ca/groups/switch?id=7332",
-	"Visual working memory: Study of Task fMRI and Behavioural response":"https://portal.cbrain.mcgill.ca/groups/switch?id=6537"
+	"Visual working memory: Study of Task fMRI and Behavioural response":"https://portal.cbrain.mcgill.ca/groups/switch?id=6537",
+	"MICA-MICs: a dataset for Microstructure-Informed Connectomics":"https://portal.cbrain.mcgill.ca/groups/switch?id=9818",
+	"Learning Naturalistic Structure: Processed fMRI dataset":"https://portal.cbrain.mcgill.ca/groups/switch?id=9827",
+	"Multimodal data with wide-field GCaMP imaging":"https://portal.cbrain.mcgill.ca/groups/switch?id=9830",
+	"HCPUR100: Healthy Adult human Brain Diffusion Template":"https://portal.cbrain.mcgill.ca/groups/switch?id=9836",
+	"Calgary Preschool MRI Dataset":"https://portal.cbrain.mcgill.ca/groups/switch?id=9839",
+	"Hippocampal morphology and cytoarchitecture in the 3D BigBrain":"https://portal.cbrain.mcgill.ca/groups/switch?id=9842",
+	"BrainSpan: Atlas of the Developing Human Brain":"https://portal.cbrain.mcgill.ca/groups/switch?id=9845"
 }


### PR DESCRIPTION
This adds 7 news CONP datasets available on CBRAIN to the dataset-cbrain-ids.json.