### PR TITLE
Remove space between "sponsors" and comma on main page

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -44,7 +44,7 @@
             rel="noopener noreferrer"
             href="https://conp.ca/discover/#Sponsors"
           >
-            sponsors </a
+            sponsors</a
           >,
           <a
             target="_blank"


### PR DESCRIPTION
## Purpose

Tiny change that removes a space between the word "sponsors" and a comma on the main page. Not a big deal but this is a typo that was easy to clean up.

## Current behaviour

The text looks like this:

> ![Screenshot from 2022-04-27 10-38-27](https://user-images.githubusercontent.com/6700252/165544206-8a73f069-1ea1-4f40-bd6d-f502dcfbc395.png)

## New behaviour

The text looks like this:

> ![Screenshot from 2022-04-27 10-38-35](https://user-images.githubusercontent.com/6700252/165544261-f021b631-eafd-438e-ac08-360277cf00e0.png)

#### Does this introduce a major change?
- [ ] Yes
- [x] No

