### PR TITLE
Escape apostrophes in dataset titles

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -494,7 +494,7 @@ def dataset_info():
         "ark_id": 'https://n2t.net/' + ark_id_row.ark_id,
         "name": datsdataset.name,
         "id": d.dataset_id,
-        "title": d.name.replace("'", ""),
+        "title": d.name.replace("'", "\'"),
         "remoteUrl": d.remoteUrl,
         "isPrivate": d.is_private,
         "thumbnailURL": "/dataset_logo?id={}".format(d.dataset_id),


### PR DESCRIPTION
https://github.com/CONP-PCNO/conp-portal/pull/525 fixed the apostrophes not being escaped in the search dataset page but that bug fix was not included for the detailed dataset page. This resolves this so now, datasets with apostrophes will render properly.
