### PR TITLE
Do not display current month in "Number of Unique Visitors" analytics graph

### DIFF
--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -7,7 +7,7 @@
 import json
 import re
 
-from datetime import datetime
+from datetime import date
 from flask import render_template, request
 from flask_login import current_user
 from app.analytics import analytics_bp
@@ -49,11 +49,12 @@ def visitors():
     daily_visits = MatomoDailyVisitsSummary.query.order_by(
         MatomoDailyVisitsSummary.id).all()
 
-    current_year_month = datetime.today().strftime("%Y%m")
+    current_date = date.today()
 
     for v in daily_visits:
-        visit_year_month = datetime.strptime(v.date, '%Y-%m-%d').strftime("%Y%m")
-        if visit_year_month == current_year_month:
+        visit_date = date.fromisoformat(v.date)
+        if (visit_date.year == current_date.year) \
+                and (visit_date.month == current_date.month):
             continue
         element = {
             "id": v.id,

--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -7,6 +7,7 @@
 import json
 import re
 
+from datetime import datetime
 from flask import render_template, request
 from flask_login import current_user
 from app.analytics import analytics_bp
@@ -48,7 +49,12 @@ def visitors():
     daily_visits = MatomoDailyVisitsSummary.query.order_by(
         MatomoDailyVisitsSummary.id).all()
 
+    current_year_month = datetime.today().strftime("%Y%m")
+
     for v in daily_visits:
+        visit_year_month = datetime.strptime(v.date, '%Y-%m-%d').strftime("%Y%m")
+        if visit_year_month == current_year_month:
+            continue
         element = {
             "id": v.id,
             "date": v.date,


### PR DESCRIPTION
As discussed during the CONP dev call of May 11th, 2022, the current month is removed from the "Number of Unique Visitors" graph since the month is not over and it gives a misrepresentation of the monthly visits.

Before:
![Screen Shot 2022-05-11 at 5 30 33 PM](https://user-images.githubusercontent.com/1402456/167951104-75a9ee90-7a3e-4095-b27f-4fee5525da05.png)


After:
![Screen Shot 2022-05-11 at 5 30 02 PM](https://user-images.githubusercontent.com/1402456/167951045-278e0f7e-18c5-4510-a900-5ffe65fe23c7.png)

