### PR TITLE
Make dataset search a little smarter

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 from functools import lru_cache
 import os
@@ -5,10 +7,20 @@ import json
 import re
 
 import fnmatch
+from collections.abc import Iterable
+from pathlib import Path
 from typing import Optional
 
 import dateutil
 import requests
+
+
+def _match_maybe_iterable(prop: str | Iterable, term: str):
+    if isinstance(prop, str):
+        if term.lower() in prop.lower():
+            return True
+    else:
+        return any(_match_maybe_iterable(subprop, term) for subprop in prop)
 
 
 @lru_cache(maxsize=1)
@@ -91,6 +103,57 @@ class DATSDataset(object):
                 self.descriptor = json.load(f)
             except Exception:
                 raise RuntimeError('Can`t parse {}'.format(self.DatsFilepath))
+
+
+    def search(self, term: str) -> bool:
+        if not term:
+            # Empty string, pointless to search for it
+            return True
+        props = [
+            prop
+            for prop in [
+                self.name,
+                self.creators,
+                [
+                    [pub['title'], pub['author'], pub['journal'], pub['doi']]
+                    for pub in (self.primaryPublications or [])
+                ],
+                self.origin,
+                self.contacts,
+                self.description,
+                self.licenses,
+                self.keywords,
+                self.sources,
+                self.dimensions,
+                self.isAbout,
+                self.spatialCoverage,
+                self.producedBy,
+                self.derivedFrom,
+                self.dates,
+            ]
+            if prop
+        ]
+        for prop in props:
+            if _match_maybe_iterable(prop, term):
+                return True
+
+        # Term wasn't in the metadata, but check the readme
+        try:
+            readme_path = self.ReadmeFilepath
+        except RuntimeError as err:
+            if str(err) == "No Readme found":
+                readme_path = None
+            else:
+                raise
+        if readme_path:
+            with Path(readme_path).open("r") as readme_file:
+                readme = readme_file.readlines()
+        else:
+            readme = ""
+        if term in readme:
+            return True
+        return False
+
 
     @property
     def name(self):
@@ -580,7 +643,7 @@ class DATSDataset(object):
         except Exception:
             return None
 
-    @ property
+    @property
     def status(self):
 
         test_results = get_latest_test_results()

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -158,14 +158,8 @@ def dataset_search():
         # If search term exists filter results here
         if request.args.get('search'):
             search_term = request.args.get('search')
-            with open(datsdataset.DatsFilepath, 'r') as dats:
-                match = False
-                for line in dats.readlines():
-                    if search_term.lower() in line.lower():
-                        match = True
-                        break
-                if not match:
-                    continue
+            if not datsdataset.search(search_term):
+                continue
 
         datasetTitle = d.name.replace("'", "")
         if datasetTitle in cbrain_dataset_ids.keys():


### PR DESCRIPTION
## Purpose
Makes dataset search a little more precise.

## Current behaviour
Dataset search looks (case-insensitively) for the exact search term anywhere in the DATS.json (including in its keys).

## New behaviour
Dataset search looks (case-insensitively) for the exact search term anywhere in a select group of parsed DATS.json values and the dataset README. Note: this is only a minor improvement, but was relatively easy to implement. Further improvements could include splitting search terms that aren't wrapped by quotation marks, adding boolean operators, potentially others? That will add a maintenance burden but this is an improvement at a low investment of dev time.