### PR TITLE
Search datasets by title in the DB

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -130,10 +130,11 @@ def dataset_search():
         # Query datasets
         datasets = Dataset.query.filter_by(
             dataset_id=request.args.get('id')).all()
-
+    elif request.args.get('search'):
+        datasets = Dataset.query.filter(Dataset.name.contains(request.args.get('search', ''))).all()
     else:
         # Query datasets
-        datasets = Dataset.query.order_by(Dataset.id).all()
+        datasets = Dataset.query.all()
 
     # Element input for payload
     elements = []
@@ -154,18 +155,6 @@ def dataset_search():
             # If the DATS file can't be laoded, skip this dataset.
             # There should be an error message in the logs/update_datsets.log
             continue
-
-        # If search term exists filter results here
-        if request.args.get('search'):
-            search_term = request.args.get('search')
-            with open(datsdataset.DatsFilepath, 'r') as dats:
-                match = False
-                for line in dats.readlines():
-                    if search_term.lower() in line.lower():
-                        match = True
-                        break
-                if not match:
-                    continue
 
         datasetTitle = d.name.replace("'", "")
         if datasetTitle in cbrain_dataset_ids.keys():


### PR DESCRIPTION
This PR changes search behaviour to query the DB by dataset title before parsing any of the DATS.json files, and removes the filtering by DATS.json content. I'm not sure this will really improve speeds, but it's possible and seems worth a shot given the issues @GHPBZ has been seeing.