### PR TITLE
Remove CSS rule to not render first list marker

### DIFF
--- a/app/static/css/core.css
+++ b/app/static/css/core.css
@@ -335,10 +335,6 @@ Colour names courtesy of chir.ag/projects/name-that-color
   margin: 0;
 }
 
-.card .card-body li:first-child {
-  list-style: none;
-}
-
 .card .card-body li {
   padding-right: 1rem;
 }


### PR DESCRIPTION
This was causing problems for the CNeuroMod READMEs.