### PR TITLE
DATS downloaded file name fix

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -622,8 +622,7 @@ def download_metadata():
         os.path.dirname(datspath),
         os.path.basename(datspath),
         as_attachment=True,
-        attachment_filename=os.path.join(
-            unidecode(dataset.name.replace(' ', '_')), '.dats.json'),
+        attachment_filename=unidecode(dataset.name.replace(' ', '_') + '.dats.json'),
         mimetype='application/json'
     )
 

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -441,7 +441,7 @@ datalad get &ltfilepath&gt</pre
         var file = window.URL.createObjectURL(blob, { type: 'application/json' });
         let link = document.createElement('a');
         link.href = file;
-        link.download = `${element.title.toLowerCase().replace(" ", "_")}.dats.json`;
+        link.download = `${element.title.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/[^a-zA-Z0-9]/g, "_")}.dats.json`;
         link.click();
 
         // For Firefox it is necessary to delay revoking the ObjectURL.

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,3 +120,4 @@ Whoosh==2.7.4
 wrapt==1.11.2
 WTForms==2.2.1
 zipp==0.6.0
+unidecode==1.3.8


### PR DESCRIPTION
Convert filename from
`consortium_pour l'identification précoce de la maladie d'alzheimer - québec (cima-q).dats.json`
to
`consortium_pour_l_identification_precoce_de_la_maladie_d_alzheimer___quebec__cima_q_.dats.json`

- Remove whitespace, accent and special characters from DATS downloaded file.
- Add missing `unidecode==1.3.8` requirements.