### PR TITLE
bugfix: no authors in primary publication cause the request to crash

### DIFF
--- a/app/search/models.py
+++ b/app/search/models.py
@@ -183,10 +183,12 @@ class DATSDataset(DATSObject):
                 journal = publi.get('publicationVenue', '')
                 if journal and not journal.endswith('.'):
                     journal += '.'
-                author = publi.get('authors', [])[0].get(
-                    'fullName', '') if 'authors' in publi else ''
-                if len(publi.get('authors', [])) > 1:
-                    author += ' et al.'
+                authors = publi.get('authors', [])
+                author = ''
+                if authors:
+                    author = publi.get('authors', [])[0].get('fullName', '')
+                    if len(authors) > 1:
+                        author += ' et al.'
                 doi = publi.get('identifier', {}).get('identifier', '')
                 primaryPublications.append(
                     {


### PR DESCRIPTION
---
name: No authors in primary publication cause the request to crash
about: Check if there is at least one author
title: Check if there is at least one author
labels: enhancement
assignees: ''

---

## Related issues
If a dataset had no authors in a primary publication, it was not caught, causing the request to crash and no dataset would be displayed.

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, create unit tests.

## Purpose
Verify if there is at least one author.

## Current behaviour
Request would crash if no author.

## New behaviour
Request won't crash if no author.
 
#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
Added a condition to check if there is at least one author.