### PR TITLE
Missing pipelines fix

### DIFF
--- a/app/threads.py
+++ b/app/threads.py
@@ -31,7 +31,7 @@ class UpdatePipelineData(threading.Thread):
                 "production"
             )
             # first search for all descriptors
-            searcher = Searcher(query=None, max_results=100, no_trunc=True, verbose=True)
+            searcher = Searcher(query=None, max_results=9999, no_trunc=True, verbose=True)
             all_descriptors = searcher.search()
             # then pull every single descriptor
             all_descriptor_ids = list(map(lambda x: x["ID"], all_descriptors))


### PR DESCRIPTION
- Raise the item per page limit to temporarily fix an issue with missing pipelines from Zenodo.
- We will need a more permanent solution where the importer loops over all the returned pages.