### PR TITLE
Search and submodule updates fixes

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -209,7 +209,7 @@ def _update_datalad_objects(
     # Update to latest commit
     origin = repo.remotes.origin
     origin.pull('master')
-    repo.submodule_update(recursive=True, force_reset=True, force_remove=True, keep_going=True)
+    repo.submodule_update(recursive=True, force_reset=True, force_remove=True, to_latest_revision=True, keep_going=True)
 
     d = DataladDataset(path=datasetsdir)
     if not d.is_installed():

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -377,7 +377,7 @@ class DATSDataset(DATSObject):
             dist = dists[0]
 
         size = float(dist.get('size', 0))
-        unit = dist.get('unit', {}).get('value', '')
+        unit = dist.get('unit', {}).get('value', '').upper()
 
         # Some data values from the DATS are not user friendly so
         # If size > 1000, divide n times until it is < 1000 and increment the units from the array


### PR DESCRIPTION
Fix an error with the search indexer:
```
(venv) conp-admin@portal:~/conp-portal$ flask update_index --schema
[INFO   ] Generating search schema
Traceback (most recent call last):
  File "/home/conp-admin/conp-portal/venv/bin/flask", line 11, in <module>
    sys.exit(main())
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/flask/cli.py", line 894, in main
    cli.main(args=args, prog_name=name)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/flask/cli.py", line 557, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/flask/cli.py", line 412, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/home/conp-admin/conp-portal/venv/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/conp-admin/conp-portal/app/cli.py", line 84, in update_index
    _update_index(app, DBDataset, schema)
  File "/home/conp-admin/conp-portal/app/cli.py", line 486, in _update_index
    size=_format_index_value(datsdataset.size),
  File "/home/conp-admin/conp-portal/app/search/models.py", line 392, in size
    unit = units[units.index(unit) + count]
ValueError: 'kB' is not in list
```
and an issue with the git submodules (datasets) not fetching the latest changes.