### PR TITLE
Automatically reindex search terms when importing new datasets

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -65,8 +65,10 @@ def register(app):
     def update_datasets():
         """
         Wrapper to call the updating to the datasets metadata
+        and search index
         """
         _update_datasets(app)
+        _update_index(app, DBDataset, False)
 
     @app.cli.command('update_index')
     @click.option(


### PR DESCRIPTION
Run the search index process as part of the dataset update routine.