### PR TITLE
Fix indexation logic issue

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -68,7 +68,7 @@ def register(app):
         and search index
         """
         _update_datasets(app)
-        _update_index(app, DBDataset, False)
+        _update_index(app, DBDataset, True)
 
     @app.cli.command('update_index')
     @click.option(


### PR DESCRIPTION
Fix a problem with the indexer:
If used without the schema param set to True, each iteration adds a another copy of the documents already present instead of replacing them.