### PR TITLE
Origin new format

### DIFF
--- a/app/dats.py
+++ b/app/dats.py
@@ -191,14 +191,15 @@ class DATSObject:
 
     @property
     def origin(self):
-        origin = None
+        origin = []
         extraprops = self.descriptor.get('extraProperties', {})
         for prop in extraprops:
-            if prop.get('category') == 'origin':
-                origin = ", ".join([x['value']
-                                    for x in prop.get('values')])
-
-        return origin
+            if prop.get('category').startswith('origin_'):
+                key = prop.get('category').replace('origin_', '').capitalize()
+                origin.append(
+                    f"{key}: " + ", ".join([x['value'] for x in prop.get('values')])
+                )
+        return ", ".join(origin)
 
     @property
     def contacts(self):

--- a/app/search/models.py
+++ b/app/search/models.py
@@ -242,14 +242,15 @@ class DATSDataset(DATSObject):
 
     @property
     def origin(self):
-        origin = None
+        origin = []
         extraprops = self.descriptor.get('extraProperties', {})
         for prop in extraprops:
-            if prop.get('category') == 'origin':
-                origin = ", ".join([x['value']
-                                    for x in prop.get('values')])
-
-        return origin
+            if prop.get('category').startswith('origin_'):
+                key = prop.get('category').replace('origin_', '').capitalize()
+                origin.append(
+                    f"{key}: " + ", ".join([x['value'] for x in prop.get('values')])
+                )
+        return ", ".join(origin)
 
     @property
     def contacts(self):


### PR DESCRIPTION
Takes all extraProperties fields starting with origin_ and creates a string.
The parsed origin was previously empty since no strict origin extraProperties are ever present.

Example: 
Institution: Brock University, City: St. Catharines, Province: Ontario, Country: Canada, Consortium: EEGnet