### PR TITLE
IA cleanup: link Tutorial in nav, fix mobile nav gap, make Download download-specific

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -193,9 +193,7 @@ def dats_editor():
             rendered template for dats-editor.html
     """
 
-    content = github.get_tutorial_content()
-
-    return render_template('dats-editor.html', title='CONP | DATS Editor', user=current_user, content=content)
+    return render_template('dats-editor.html', title='CONP | DATS Editor', user=current_user)
 
 
 @main_bp.route('/ark:/<url_naan>/<url_ark_id>')

--- a/app/services/github.py
+++ b/app/services/github.py
@@ -44,7 +44,7 @@ def get_share_content():
 def get_download_content():
     content = None
     try:
-        url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/Documentation_displayed_on_the_portal/CONP_portal_tutorial.md'
+        url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/Documentation_displayed_on_the_portal/CONP_download.md'
         headers = {'Content-type': 'text/html; charset=UTF-8'}
         response = requests.get(url, headers=headers)
 

--- a/app/templates/fragments/navigation_bar.html
+++ b/app/templates/fragments/navigation_bar.html
@@ -23,6 +23,12 @@
         <a class="nav-link" href="{{ url_for('main.share') }}">Share</a>
       </li>
       <li class="d-lg-none d-xl-none nav-item px-3">
+        <a class="nav-link" href="{{ url_for('main.download') }}">Download</a>
+      </li>
+      <li class="d-lg-none d-xl-none nav-item px-3">
+        <a class="nav-link" href="{{ url_for('main.tutorial') }}">Tutorial</a>
+      </li>
+      <li class="d-lg-none d-xl-none nav-item px-3">
         <a class="nav-link" href="{{ url_for('main.faq') }}">FAQ</a>
       </li>
       <hr class="d-lg-none d-xl-none w-100" /> 

--- a/app/templates/fragments/sidebar.html
+++ b/app/templates/fragments/sidebar.html
@@ -54,6 +54,13 @@
       </p>
     </a>
     <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3 px-4 sidebar-tab"
+      href="{{ url_for('main.tutorial') }}">
+      <p class="text-center text-capitalize p-0 m-0">
+        <i class="fa fa-book"></i>
+        Tutorial
+      </p>
+    </a>
+    <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3 px-4 sidebar-tab"
       href="{{ url_for('main.faq') }}">
       <p class="text-center text-capitalize p-0 m-0">
         <i class="fa fa-info-circle"></i>


### PR DESCRIPTION
Information-architecture cleanup for the portal's documentation surfaces (low-risk first round).

- **De-orphan the Tutorial page.** Adds a "Tutorial" link (→ `/tutorial`) to the desktop sidebar and the mobile nav. The `/tutorial` route already existed but had no link anywhere in the UI.
- **Fix the mobile nav gap.** The collapsed mobile menu (the `d-lg-none` items in `navigation_bar.html`) was missing **Download**, which the desktop sidebar has — so on mobile users couldn't reach it. Added Download + Tutorial there so the mobile menu matches the desktop sidebar's primary sections.
- **Make Download download-specific.** Repoints `get_download_content()` from `CONP_portal_tutorial.md` to the new `CONP_download.md`, so the Download tab shows real download instructions instead of the entire tutorial. (Depends on the conp-documentation PR that adds that file.)
- **Drop an unused fetch.** The `/dats-editor` route fetched `get_tutorial_content()` but its template never used the result; removed it — one fewer GitHub API call per editor load.

Deferred to a later round (as planned): replacing the six hard-coded `?`-button help modals with a `?` that deep-links into `/tutorial`, and serving Terms of Use / Privacy Policy from canonical markdown (needs caching, since those modals render on every page).

**Merge order:** merge the conp-documentation PR (`CONP_download.md`) **first**, then this one.
