### PR TITLE
Add Data Governance page (route, template, nav link)

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -88,6 +88,24 @@ def faq():
     return render_template('faq.html', title='CONP | FAQ', user=current_user, content=content)
 
 
+@main_bp.route('/data-governance')
+def data_governance():
+    """ Data Governance Route
+
+        Route to lead to the data governance page
+
+        Args:
+            None
+
+        Returns:
+            rendered template for data_governance.html
+    """
+
+    content = github.get_data_governance_content()
+
+    return render_template('data_governance.html', title='CONP | Data Governance', user=current_user, content=content)
+
+
 @main_bp.route('/contact_us')
 def contact_us():
     """ Contact Us Route

--- a/app/services/github.py
+++ b/app/services/github.py
@@ -87,3 +87,20 @@ def get_tutorial_content():
         print("ERROR: Something went wrong retrieving the Github markdown", err)
 
     return content
+
+
+
+def get_data_governance_content():
+    content = None
+    try:
+        url = 'https://raw.githubusercontent.com/CONP-PCNO/conp-documentation/master/Documentation_displayed_on_the_portal/CONP_data_governance.md'
+        headers = {'Content-type': 'text/html; charset=UTF-8'}
+        response = requests.get(url, headers=headers)
+
+        raw = response.text
+
+        content = render_content(raw)
+    except requests.exceptions.HTTPError as err:
+        print("ERROR: Something went wrong retrieving the Github markdown", err)
+
+    return content

--- a/app/templates/data_governance.html
+++ b/app/templates/data_governance.html
@@ -1,0 +1,18 @@
+{% extends 'common/base_main.html' %}
+
+<!-- Head Block -->
+{% block head %} {{ super() }}
+<title>CONP Portal | Data Governance</title>
+{% endblock %}
+
+<!-- Title Block -->
+
+{% block contenttitle %}
+<h2><span style="color:red;">CONP Portal </span> | Data Governance</h2>
+{% endblock %}
+
+<!-- Content Block -->
+
+{% block appcontent %}
+{{ content|safe }}
+{% endblock %}

--- a/app/templates/fragments/navigation_bar.html
+++ b/app/templates/fragments/navigation_bar.html
@@ -26,6 +26,9 @@
         <a class="nav-link" href="{{ url_for('main.download') }}">Download</a>
       </li>
       <li class="d-lg-none d-xl-none nav-item px-3">
+        <a class="nav-link" href="{{ url_for('main.data_governance') }}">Data Governance</a>
+      </li>
+      <li class="d-lg-none d-xl-none nav-item px-3">
         <a class="nav-link" href="{{ url_for('main.tutorial') }}">Tutorial</a>
       </li>
       <li class="d-lg-none d-xl-none nav-item px-3">

--- a/app/templates/fragments/sidebar.html
+++ b/app/templates/fragments/sidebar.html
@@ -54,6 +54,13 @@
       </p>
     </a>
     <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3 px-4 sidebar-tab"
+      href="{{ url_for('main.data_governance') }}">
+      <p class="text-center text-capitalize p-0 m-0">
+        <i class="fa fa-balance-scale"></i>
+        Data Governance
+      </p>
+    </a>
+    <a class="col-12 d-flex flex-column justify-content-center align-items-center text-white p-3 px-4 sidebar-tab"
       href="{{ url_for('main.tutorial') }}">
       <p class="text-center text-capitalize p-0 m-0">
         <i class="fa fa-book"></i>


### PR DESCRIPTION
Adds a **Data Governance** page to the Portal, following the same pattern as the other documentation pages:

- `app/services/github.py` — new `get_data_governance_content()` that fetches `Documentation_displayed_on_the_portal/CONP_data_governance.md` from conp-documentation.
- `app/main/routes.py` — new `/data-governance` route.
- `app/templates/data_governance.html` — thin template that renders the fetched markdown.
- Sidebar + mobile nav — a "Data Governance" link (placed after Share).

**Dependencies / merge order (important):**
1. This PR **stacks on the IA nav PR** (`fix/portal-ia-nav-download`). Its nav edits assume that PR's sidebar/mobile-menu changes, so **open/merge this only after the IA PR is merged** — otherwise the patch won't apply to `master`.
2. It renders `CONP_data_governance.md`, added by the conp-documentation PR — merge that (after content approval) before this goes live, or the page will fail to load.

