### PR TITLE
Style rendered-markdown tables on documentation pages

### DIFF
--- a/app/templates/common/base_main.html
+++ b/app/templates/common/base_main.html
@@ -18,6 +18,13 @@
 {% block styles %}
 <link href="{{ url_for('static',filename='img/conp.ico')}}" rel="shortcut icon" type="image/png" />
 <link href="{{ url_for('static', filename='v1/css/bootstrap-multiselect.css') }}" rel="stylesheet" />
+<style>
+  /* Style tables rendered from markdown documentation pages (e.g. Data Governance, Download) */
+  .content-main table { border-collapse: collapse; width: 100%; margin: 1rem 0 1.5rem; }
+  .content-main th, .content-main td { border: 1px solid #ccd2d9; padding: .5rem .75rem; vertical-align: top; text-align: left; }
+  .content-main thead th { background: #f1f3f5; border-bottom: 2px solid #adb5bd; }
+  .content-main tbody tr:nth-child(even) { background: #f8f9fa; }
+</style>
 <link
   rel="stylesheet"
   href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"


### PR DESCRIPTION
Adds scoped CSS so tables in the rendered documentation pages actually look like tables.

The portal renders markdown from `conp-documentation` into `.content-main`, but had **no styling for tables** — so the tables on the Data Governance page rendered as borderless columns of text that blur into the surrounding paragraphs. This adds a small style block in `app/templates/common/base_main.html`:

- `border-collapse` + `1px` cell borders
- a shaded header row (`thead th`)
- cell padding and top-aligned text
- light zebra striping on body rows

Scoped to `.content-main table`, so it applies to **any** documentation page that uses tables (Data Governance today; Download or others in future) and touches nothing else.

To be followed by a 'declutter' PR for the data governance page.
