### PR TITLE
Add descriptive page titles and social link-preview (Open Graph) metadata

### DIFF
--- a/app/templates/common/base_main.html
+++ b/app/templates/common/base_main.html
@@ -2,17 +2,25 @@
 <meta charset="utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="description" content="CONP" />
+<meta name="description" content="{% block meta_description %}The Canadian Open Neuroscience Platform (CONP) Portal is a web interface for finding, sharing, and downloading open neuroscience datasets and analysis tools.{% endblock %}" />
 <meta name="author" content="CONP" />
-<!-- metadata for the Twitter Card -->
+<!--
+  Social link-preview metadata. Defaults describe the site as a whole; individual
+  pages override the og_title / og_description / og_image / og_url blocks below to
+  give each dataset, tool, or experiment its own preview. The Twitter Card tags
+  mirror the Open Graph values so both stay in sync.
+-->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="CONP Portal" />
+<meta property="og:title" content="{% block og_title %}CONP Portal{% endblock %}" />
+<meta property="og:description" content="{% block og_description %}The Canadian Open Neuroscience Platform (CONP) Portal is a web interface for finding, sharing, and downloading open neuroscience datasets and analysis tools.{% endblock %}" />
+<meta property="og:image" content="{% block og_image %}https://portal.conp.ca/static/img/conp_for_twitter_card.png{% endblock %}" />
+<meta property="og:url" content="{% block og_url %}https://portal.conp.ca{{ request.path }}{% endblock %}" />
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content="@NeuroLibre" />
-<meta name="twitter:title" content="CONP/PCNO" />
-<meta
-  name="twitter:description"
-  content="This portal is a web interface for the Canadian Open Neuroscience Platform (CONP) to facilitate open science in the neuroscience community. CONP simplifies global researcher access and sharing of datasets and tools. The portal internalizes the cycle of a typical research project: starting with data acquisition, followed by processing using already existing/published tools, and ultimately publication of the obtained results including a link to the original dataset."
-/>
-<meta name="twitter:image" content="https://portal.conp.ca/static/img/conp_for_twitter_card.png" />
+<meta name="twitter:site" content="@CONP_PCNO" />
+<meta name="twitter:title" content="{{ self.og_title() }}" />
+<meta name="twitter:description" content="{{ self.og_description() }}" />
+<meta name="twitter:image" content="{{ self.og_image() }}" />
 {% endblock %}
 
 {% block styles %}

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -1,8 +1,12 @@
 {% extends 'common/base_main.html' %}
 
 {% block head %} {{ super() }}
-<title>CONP Portal | Dataset</title>
+<title>CONP Portal | {{ data.title if data.title else 'Dataset' }}</title>
 {% endblock %}
+
+{% block og_title %}{{ data.title if data.title else 'Dataset' }} | CONP Portal{% endblock %}
+{% block og_description %}{% if metadata.description %}{{ metadata.description | striptags | truncate(200) }}{% else %}A dataset on the Canadian Open Neuroscience Platform (CONP) Portal.{% endif %}{% endblock %}
+{% block og_url %}https://portal.conp.ca/dataset?id={{ data.id }}{% endblock %}
 
 {% block scripts %} {{ super() }}
 <script src=" {{ url_for('static',filename='v1/js/react.development-16.11.0.js') }}"></script>

--- a/app/templates/experiments/experiment.html
+++ b/app/templates/experiments/experiment.html
@@ -4,6 +4,9 @@
 <title>CONP Portal | {{ experiment.title }}</title>
 {% endblock %}
 
+{% block og_title %}{{ experiment.title }} | CONP Portal{% endblock %}
+{% block og_description %}{% if experiment.description is defined and experiment.description %}{{ experiment.description | striptags | truncate(200) }}{% else %}An experiment on the Canadian Open Neuroscience Platform (CONP) Portal.{% endif %}{% endblock %}
+
 {% block contenttitle %}
 <h2><span style="color: red">CONP Portal</span> | {{ experiment.title }}</h2>
 {% endblock %} {% block appcontent %}

--- a/app/templates/pipeline.html
+++ b/app/templates/pipeline.html
@@ -4,6 +4,9 @@
 <title>CONP Portal | {{ pipeline.title }}</title>
 {% endblock %}
 
+{% block og_title %}{{ pipeline.title }} | CONP Portal{% endblock %}
+{% block og_description %}{% if pipeline.description is defined and pipeline.description|length %}{{ pipeline.description | striptags | truncate(200) }}{% else %}An analysis tool or pipeline on the Canadian Open Neuroscience Platform (CONP) Portal.{% endif %}{% endblock %}
+
 {% block scripts %} {{ super() }}
 <script src=" {{ url_for('static',filename='v1/js/react.development-16.11.0.js') }}"></script>
 <script src=" {{ url_for('static',filename='v1/js/react-dom.development-16.11.0.js') }}"></script>


### PR DESCRIPTION
## What

Gives dataset, tool/pipeline, and experiment pages their own browser title and
their own social link-preview, and replaces the site's placeholder meta
description with a real one.

- **Per-dataset browser titles.** The dataset page hard-coded
  `<title>CONP Portal | Dataset</title>` for *every* dataset. It now shows the
  dataset's own title (`CONP Portal | {{ data.title }}`), matching what the tool
  and experiment pages already do. Closes #754.
- **Open Graph tags for link previews.** `base_main.html` previously shipped only
  a Twitter Card with a single site-wide title. Added standard Open Graph tags
  (`og:type`, `og:site_name`, `og:title`, `og:description`, `og:image`,
  `og:url`) so that pasting a CONP link into Slack, Teams, Bluesky, LinkedIn,
  Mastodon, iMessage, or a document produces a real preview. Dataset, pipeline,
  and experiment pages override `og:title` / `og:description` (datasets also
  `og:url`) so each has its own card. The Twitter Card tags now mirror the Open
  Graph values so the two never drift.
- **Real meta description.** `<meta name="description" content="CONP">` is now a
  one-sentence description of the Portal (this is the text search engines show).
- **Social handle.** `twitter:site` is set to the CONP Bluesky handle
  **@CONP_PCNO** (was `@NeuroLibre`). Bluesky itself builds link cards from the
  Open Graph tags above; the handle tag is kept for X/Twitter attribution.

## How it works

The social values are overridable Jinja blocks in `base_main.html`
(`meta_description`, `og_title`, `og_description`, `og_image`, `og_url`). Pages
that know their subject override the relevant blocks; every other page falls back
to site-wide defaults. The Twitter tags render from the same blocks via
`self.og_title()` etc. All per-page values have fallbacks, and dataset/tool
descriptions are passed through `striptags | truncate(200)` for a clean card.

## Files

- `app/templates/common/base_main.html` — meta description; Open Graph + mirrored
  Twitter tags as overridable blocks; `twitter:site` set to `@CONP_PCNO`.
- `app/templates/dataset.html` — per-dataset `<title>`; og overrides.
- `app/templates/pipeline.html` — og overrides.
- `app/templates/experiments/experiment.html` — og overrides.

Templates only; no route, model, dependency, or build changes.

## Testing

- All four templates compile under Jinja2.
- A standalone render harness confirms child block overrides flow into both the
  Open Graph and mirrored Twitter tags, that HTML in descriptions is stripped and
  escaped, and that the missing-title / missing-description fallbacks fire.

## Possible follow-up

`og:image` is the site-wide CONP card on every page. Per-dataset images (via the
existing `/dataset_logo` endpoint) are a natural follow-up but were left out here
because dataset logos vary in size/availability and could produce broken cards.
