### PR TITLE
Refactor page-title accent into a CSS class (cosmetic polish)

### DIFF
--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -7,7 +7,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-    <h2><span style="color:red;">CONP Portal </span> | About</h2>
+    <h2><span class="brand-accent">CONP Portal </span> | About</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/analytics.html
+++ b/app/templates/analytics.html
@@ -12,7 +12,7 @@
 {% endblock %} {% block styles %} {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/highcharts.css') }}" />
 {% endblock %} {% block contenttitle %}
-<h2><span style="color: red">CONP</span> Portal | Analytics</h2>
+<h2><span class="brand-accent">CONP</span> Portal | Analytics</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/common/base_main.html
+++ b/app/templates/common/base_main.html
@@ -32,6 +32,12 @@
   .content-main th, .content-main td { border: 1px solid #ccd2d9; padding: .5rem .75rem; vertical-align: top; text-align: left; }
   .content-main thead th { background: #f1f3f5; border-bottom: 2px solid #adb5bd; }
   .content-main tbody tr:nth-child(even) { background: #f8f9fa; }
+  /* Brand accent for the "CONP Portal" part of page titles. Single tunable
+     token: set the colour below to the official CONP red if desired.
+     Centralizes what were previously ~22 inline red-coloured title spans. */
+  .brand-accent { color: #C8102E; font-weight: 600; }
+  /* Consistent spacing under the page-title row across pages. */
+  .page-title h2, .search-header h2 { margin-bottom: .75rem; }
 </style>
 <link
   rel="stylesheet"

--- a/app/templates/contact_us.html
+++ b/app/templates/contact_us.html
@@ -7,7 +7,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color:red;">CONP Portal </span> | Contact Us</h2>
+<h2><span class="brand-accent">CONP Portal </span> | Contact Us</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/data_governance.html
+++ b/app/templates/data_governance.html
@@ -8,7 +8,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color:red;">CONP Portal </span> | Data Governance</h2>
+<h2><span class="brand-accent">CONP Portal </span> | Data Governance</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/dataset.html
+++ b/app/templates/dataset.html
@@ -26,7 +26,7 @@
 </script>
 {% endblock %} {% block contenttitle %}
 <div class="search-header page-title">
-  <h2><span style="color: red">CONP Portal</span> | Dataset</h2>
+  <h2><span class="brand-accent">CONP Portal</span> | Dataset</h2>
 </div>
 {% endblock %} {% block appcontent %}
 <div id="mount-display" class="dataset"></div>

--- a/app/templates/dats-editor.html
+++ b/app/templates/dats-editor.html
@@ -18,7 +18,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | DATS Editor</h2>
+<h2><span class="brand-accent">CONP Portal</span> | DATS Editor</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/download.html
+++ b/app/templates/download.html
@@ -15,7 +15,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-    <h2><span style="color:red;">CONP Portal </span> | Download</h2>
+    <h2><span class="brand-accent">CONP Portal </span> | Download</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/execution-record-info.html
+++ b/app/templates/execution-record-info.html
@@ -15,7 +15,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | Pipeline Execution Record Information</h2>
+<h2><span class="brand-accent">CONP Portal</span> | Pipeline Execution Record Information</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/execution-records.html
+++ b/app/templates/execution-records.html
@@ -15,7 +15,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | Tool Executions</h2>
+<h2><span class="brand-accent">CONP Portal</span> | Tool Executions</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/experiments/experiment.html
+++ b/app/templates/experiments/experiment.html
@@ -8,7 +8,7 @@
 {% block og_description %}{% if experiment.description is defined and experiment.description %}{{ experiment.description | striptags | truncate(200) }}{% else %}An experiment on the Canadian Open Neuroscience Platform (CONP) Portal.{% endif %}{% endblock %}
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | {{ experiment.title }}</h2>
+<h2><span class="brand-accent">CONP Portal</span> | {{ experiment.title }}</h2>
 {% endblock %} {% block appcontent %}
 <div id="experiment-page"></div>
 <script id="experiment-data" type="application/json">

--- a/app/templates/experiments/search.html
+++ b/app/templates/experiments/search.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | Experiments Search</h2>
+<h2><span class="brand-accent">CONP Portal</span> | Experiments Search</h2>
 {% endblock %}
 
 {% block appcontent %}

--- a/app/templates/experiments/submit.html
+++ b/app/templates/experiments/submit.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | Experiments Form</h2>
+<h2><span class="brand-accent">CONP Portal</span> | Experiments Form</h2>
 {% endblock %} {% block scripts %} {{ super() }}
 <script>
   window.addEventListener("load", () => {

--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -7,7 +7,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color:red;">CONP Portal </span> | FAQ</h2>
+<h2><span class="brand-accent">CONP Portal </span> | FAQ</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/forums.html
+++ b/app/templates/forums.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block title %}
-  <h2><span style="color:red;">CONP Portal </span> | Forums</h2>
+  <h2><span class="brand-accent">CONP Portal </span> | Forums</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
 {% endblock %} {% block styles %} {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/highcharts.css') }}" />
 {% endblock %} {% block contenttitle %}
-<h2><span style="color: red">CONP</span> Portal</h2>
+<h2><span class="brand-accent">CONP</span> Portal</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/pipeline.html
+++ b/app/templates/pipeline.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css" />
 {% endblock %} {% block contenttitle %}
 <div class="search-header page-title">
-  <h2><span style="color: red">CONP Portal</span> | {{ pipeline.title }}</h2>
+  <h2><span class="brand-accent">CONP Portal</span> | {{ pipeline.title }}</h2>
 </div>
 {% endblock %} {% block appcontent %}
 <div id="mount-display" class="pipeline p-4"></div>

--- a/app/templates/pipelines.html
+++ b/app/templates/pipelines.html
@@ -15,7 +15,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | Tools & Pipelines Search</h2>
+<h2><span class="brand-accent">CONP Portal</span> | Tools & Pipelines Search</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -15,7 +15,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | Data Search</h2>
+<h2><span class="brand-accent">CONP Portal</span> | Data Search</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/share.html
+++ b/app/templates/share.html
@@ -14,7 +14,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal </span> | Share</h2>
+<h2><span class="brand-accent">CONP Portal </span> | Share</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/sparql.html
+++ b/app/templates/sparql.html
@@ -17,7 +17,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-<h2><span style="color: red">CONP Portal</span> | SPARQL</h2>
+<h2><span class="brand-accent">CONP Portal</span> | SPARQL</h2>
 <h5>Please note the SPARQL search is currently in experimental mode</h5>
 {% endblock %}
 

--- a/app/templates/team.html
+++ b/app/templates/team.html
@@ -7,7 +7,7 @@
 <!-- Title Block -->
 
 {% block contenttitle %}
-    <h2><span style="color:red;">CONP Portal </span> | Developer Team</h2>
+    <h2><span class="brand-accent">CONP Portal </span> | Developer Team</h2>
 {% endblock %}
 
 <!-- Content Block -->

--- a/app/templates/tutorial.html
+++ b/app/templates/tutorial.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block contenttitle %}
-<h2><span style="color:red;">CONP Portal </span> | Tutorial</h2>
+<h2><span class="brand-accent">CONP Portal </span> | Tutorial</h2>
 {% endblock %}
 
 <!-- Content Block -->


### PR DESCRIPTION
A small cosmetic fix: replaces the inline `style="color: red"` on the
"CONP Portal" part of every page title with a single reusable CSS class, and
adds a little consistent spacing under the page-title row.

- Adds `.brand-accent { color: #C8102E; font-weight: 600; }` to the site
  stylesheet block in `base_main.html`. This is now the **single place** the
  title accent colour is defined — set it to the official CONP red if you have a
  hex value; today the pages use a raw `red` (`#FF0000`).
- Swaps ~22 inline `style="color: red"` / `style="color:red;"` spans across the
  page templates for `class="brand-accent"`. No text changes, no layout changes
  beyond the accent colour/weight.
- Adds `.page-title h2, .search-header h2 { margin-bottom: .75rem; }` for
  consistent spacing under the title row.

The accent colour was hard-coded inline in ~22 templates with two slightly
different spellings and inconsistent trailing spaces. Centralizing it into one
class makes the brand colour a single tunable token and controlled shade, and
makes future title styling a one-line change instead of a find-and-replace.

## Files

`app/templates/common/base_main.html` (CSS) plus the page templates that carried
an inline red title span (about 22 files). Templates only; no routes, JS, or
dependencies.

## Testing

- All touched templates compile under Jinja2.
- Mechanical change; verify visually after deploy that page titles still show the
  red "CONP Portal" accent (now `#C8102E`) and nothing shifted.
